### PR TITLE
fix go vet error on mutex

### DIFF
--- a/cloud-resource-manager/crmutil/controller-client.go
+++ b/cloud-resource-manager/crmutil/controller-client.go
@@ -16,8 +16,8 @@ func CloudletClient(api edgeproto.CloudletApiClient, srv *CloudResourceManagerSe
 	err := prepCloudletData(srv)
 	ctx := context.TODO()
 
-	srv.CloudResourceData.mux.Lock()
-	defer srv.CloudResourceData.mux.Unlock()
+	srv.mux.Lock()
+	defer srv.mux.Unlock()
 
 	q.Q("call cloudlet api", len(srv.CloudResourceData.CloudResources))
 
@@ -35,8 +35,8 @@ func CloudletClient(api edgeproto.CloudletApiClient, srv *CloudResourceManagerSe
 }
 
 func prepCloudletData(srv *CloudResourceManagerServer) error {
-	srv.CloudResourceData.mux.Lock()
-	defer srv.CloudResourceData.mux.Unlock()
+	srv.mux.Lock()
+	defer srv.mux.Unlock()
 
 	if len(CloudletData) < len(srv.CloudResourceData.CloudResources) {
 		return fmt.Errorf("insufficient cloudlet test data")

--- a/cloud-resource-manager/crmutil/crm-svc-api.go
+++ b/cloud-resource-manager/crmutil/crm-svc-api.go
@@ -12,7 +12,6 @@ import (
 
 type CloudResourceData struct {
 	CloudResources []*edgeproto.CloudResource
-	mux            sync.Mutex
 }
 
 var crdb = CloudResourceData{
@@ -44,6 +43,7 @@ var resourceID int32 = 0
 
 // CloudResourceManagerServer describes Cloud Resource Manager Server instance container
 type CloudResourceManagerServer struct {
+	mux               sync.Mutex
 	CloudResourceData CloudResourceData
 }
 
@@ -57,8 +57,8 @@ func (server *CloudResourceManagerServer) ListCloudResource(cr *edgeproto.CloudR
 	var err error
 	q.Q("ListCloudResource", *cr)
 
-	server.CloudResourceData.mux.Lock()
-	defer server.CloudResourceData.mux.Unlock()
+	server.mux.Lock()
+	defer server.mux.Unlock()
 
 	for _, obj := range server.CloudResourceData.CloudResources {
 		q.Q(obj)
@@ -81,8 +81,8 @@ func (server *CloudResourceManagerServer) ListCloudResource(cr *edgeproto.CloudR
 // Add Cloud Resource
 func (server *CloudResourceManagerServer) AddCloudResource(ctx context.Context, cr *edgeproto.CloudResource) (*edgeproto.Result, error) {
 	q.Q("AddCloudResource", *cr)
-	server.CloudResourceData.mux.Lock()
-	defer server.CloudResourceData.mux.Unlock()
+	server.mux.Lock()
+	defer server.mux.Unlock()
 
 	cr.Id = resourceID
 	resourceID = resourceID + 1
@@ -95,8 +95,8 @@ func (server *CloudResourceManagerServer) AddCloudResource(ctx context.Context, 
 func (server *CloudResourceManagerServer) DeleteCloudResource(ctx context.Context, cr *edgeproto.CloudResource) (*edgeproto.Result, error) {
 	q.Q("DeleteCloudResource", *cr)
 
-	server.CloudResourceData.mux.Lock()
-	defer server.CloudResourceData.mux.Unlock()
+	server.mux.Lock()
+	defer server.mux.Unlock()
 
 	found := false
 	foundIndex := -1


### PR DESCRIPTION
Move mutex out of copied data area. The mux should go away, but temporarily fixed so go vet will not fail.
