### PR TITLE
Added gogofast

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -71,6 +71,7 @@
     "protoc-gen-gogo/generator",
     "protoc-gen-gogo/grpc",
     "protoc-gen-gogo/plugin",
+    "protoc-gen-gogofast",
     "sortkeys",
     "types",
     "vanity",
@@ -503,6 +504,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c07536f2529dfa0885f0a7e546157693ad7026a71d8e82f2e9d32716582f2369"
+  inputs-digest = "4dcefe1bfea9b2580748011c677ca44478651fd56b18c4b4e220145756e4f8da"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,6 +27,7 @@
 required = [
   "github.com/golang/protobuf/protoc-gen-go",
   "github.com/gogo/protobuf/protoc-gen-gogo",
+  "github.com/gogo/protobuf/protoc-gen-gogofast",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,5 @@ install:
 tools:
 	go install ./vendor/github.com/golang/protobuf/protoc-gen-go
 	go install ./vendor/github.com/gogo/protobuf/protoc-gen-gogo
+	go install ./vendor/github.com/gogo/protobuf/protoc-gen-gogofast
 	go install ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway


### PR DESCRIPTION
The `dep` toml file does not ensure gogofast is vendored and built.  

If you have macbook set up already with all the protoc-xyz-abc type programs you will not notice this. It is a problem for fresh environment, and definitely when trying to build in a containerized docker environment targetting Linux.

