### PR TITLE
push data from controller to crm via notify; cli support for crm

### DIFF
--- a/cloud-resource-manager/cmd/crmctl/main.go
+++ b/cloud-resource-manager/cmd/crmctl/main.go
@@ -101,13 +101,12 @@ func doAddCloudResource() {
 
 	ctx := context.TODO()
 
-	cloudlet := edgeproto.Cloudlet{}
 	okey := edgeproto.OperatorKey{Name: *opkey}
-	cloudlet.Key = edgeproto.CloudletKey{OperatorKey: okey, Name: *opkeyname}
-	cloudlet.AccessIp = net.ParseIP(*address)
+	cloudletKey := edgeproto.CloudletKey{OperatorKey: okey, Name: *opkeyname}
 
-	cr := edgeproto.CloudResource{Cloudlet: &cloudlet}
+	cr := edgeproto.CloudResource{CloudletKey: &cloudletKey}
 	cr.Name = *name
+	cr.AccessIp = net.ParseIP(*address)
 
 	res, err := api.AddCloudResource(ctx, &cr)
 
@@ -148,8 +147,8 @@ func doListCloudResource() {
 	}
 
 	ctx := context.TODO()
-	cloudlet := edgeproto.Cloudlet{}
-	cr := edgeproto.CloudResource{Cloudlet: &cloudlet}
+	cloudletKey := edgeproto.CloudletKey{}
+	cr := edgeproto.CloudResource{CloudletKey: &cloudletKey}
 	cr.Category = edgeproto.CloudResourceCategory(*category)
 
 	q.Q("calling ListCloudResource")
@@ -208,14 +207,12 @@ func doDeleteCloudResource() {
 
 	ctx := context.TODO()
 
-	cloudlet := edgeproto.Cloudlet{}
-
 	okey := edgeproto.OperatorKey{Name: *opkey}
-	cloudlet.Key = edgeproto.CloudletKey{OperatorKey: okey, Name: *opkeyname}
-	cloudlet.AccessIp = net.ParseIP(*address)
+	cloudletKey := edgeproto.CloudletKey{OperatorKey: okey, Name: *opkeyname}
 
-	cr := edgeproto.CloudResource{Cloudlet: &cloudlet}
+	cr := edgeproto.CloudResource{CloudletKey: &cloudletKey}
 	cr.Name = *name
+	cr.AccessIp = net.ParseIP(*address)
 
 	res, err := api.DeleteCloudResource(ctx, &cr)
 
@@ -264,9 +261,9 @@ func doDeployApplication() {
 	edgeapp.Replicas = int32(*replicas)
 	edgeapp.Exposure = *exposure
 
-	app := edgeproto.App{}
+	appInstKey := edgeproto.AppInstKey{}
 
-	edgeapp.App = &app
+	edgeapp.AppInstKey = &appInstKey
 	edgeapplication.Apps = []*edgeproto.EdgeCloudApp{&edgeapp}
 
 	res, err := api.DeployApplication(ctx, &edgeapplication)
@@ -310,9 +307,9 @@ func doDeleteApplication() {
 	edgeapp.Name = *name
 	edgeapp.Namespace = *namespace
 
-	app := edgeproto.App{}
+	appInstKey := edgeproto.AppInstKey{}
 
-	edgeapp.App = &app
+	edgeapp.AppInstKey = &appInstKey
 	edgeapplication.Apps = []*edgeproto.EdgeCloudApp{&edgeapp}
 
 	res, err := api.DeleteApplication(ctx, &edgeapplication)

--- a/cloud-resource-manager/crmutil/controller-client.go
+++ b/cloud-resource-manager/crmutil/controller-client.go
@@ -21,14 +21,14 @@ func CloudletClient(api edgeproto.CloudletApiClient, srv *CloudResourceManagerSe
 
 	q.Q("call cloudlet api", len(srv.CloudResourceData.CloudResources))
 
-	for _, cr := range srv.CloudResourceData.CloudResources {
+	for i, cr := range srv.CloudResourceData.CloudResources {
 		q.Q(cr)
-		_, err = api.CreateCloudlet(ctx, cr.Cloudlet)
+		_, err = api.CreateCloudlet(ctx, &CloudletData[i])
 		if err != nil {
 			q.Q(err)
 			break
 		}
-		q.Q("CreateCloudlet", cr.Cloudlet)
+		q.Q("CreateCloudlet", CloudletData[i])
 	}
 
 	return err
@@ -43,7 +43,7 @@ func prepCloudletData(srv *CloudResourceManagerServer) error {
 	}
 
 	for i, cr := range srv.CloudResourceData.CloudResources {
-		cr.Cloudlet = &CloudletData[i]
+		cr.CloudletKey = &CloudletData[i].Key
 	}
 
 	return nil

--- a/controller/main.go
+++ b/controller/main.go
@@ -27,7 +27,7 @@ var apiIP = flag.String("apiIP", "127.0.0.1", "API listener IP")
 var apiPort = flag.Uint("apiPort", 55001, "API listener port")
 var httpPort = flag.Uint("httpPort", 8091, "HTTP listener port")
 var matcherAddrs = flag.String("matcherAddrs", "", "comma separated list of distributed matching engine addresses")
-var cloudletMgrAddrs = flag.String("cloudletMgrAddrs", "", "comma separated list of cloudlet manager addresses")
+var crmAddrs = flag.String("crmAddrs", "", "comma separated list of cloudlet resource manager addresses")
 var debugLevels = flag.String("d", "", "comma separated list of debug levels")
 
 func GetRootDir() string {
@@ -92,7 +92,7 @@ func main() {
 	}
 	notify.InitNotifySenders(NewControllerNotifier(appInstApi, cloudletApi))
 	notify.RegisterMatcherAddrs(*matcherAddrs)
-	notify.RegisterCloudletAddrs(*cloudletMgrAddrs)
+	notify.RegisterCloudletAddrs(*crmAddrs)
 
 	server := grpc.NewServer()
 	edgeproto.RegisterDeveloperApiServer(server, developerApi)

--- a/edgectl/main.go
+++ b/edgectl/main.go
@@ -23,8 +23,8 @@ var controllerCmd = &cobra.Command{
 var dmeCmd = &cobra.Command{
 	Use: "dme",
 }
-var cloudletCmd = &cobra.Command{
-	Use: "cloudlet",
+var crmCmd = &cobra.Command{
+	Use: "crm",
 }
 
 func connect(cmd *cobra.Command, args []string) {
@@ -39,6 +39,7 @@ func connect(cmd *cobra.Command, args []string) {
 	gencmd.CloudletApiCmd = edgeproto.NewCloudletApiClient(conn)
 	gencmd.AppInstApiCmd = edgeproto.NewAppInstApiClient(conn)
 	gencmd.Match_Engine_ApiCmd = dme.NewMatch_Engine_ApiClient(conn)
+	gencmd.CloudResourceManagerCmd = edgeproto.NewCloudResourceManagerClient(conn)
 }
 
 func close(cmd *cobra.Command, args []string) {
@@ -48,7 +49,7 @@ func close(cmd *cobra.Command, args []string) {
 func main() {
 	rootCmd.AddCommand(controllerCmd)
 	rootCmd.AddCommand(dmeCmd)
-	rootCmd.AddCommand(cloudletCmd)
+	rootCmd.AddCommand(crmCmd)
 	rootCmd.PersistentFlags().StringVar(&addr, "addr", "127.0.0.1:55001", "address to connect to")
 
 	controllerCmd.AddCommand(gencmd.CreateDeveloperCmd)
@@ -78,6 +79,12 @@ func main() {
 
 	dmeCmd.AddCommand(gencmd.FindCloudletCmd)
 	dmeCmd.AddCommand(gencmd.VerifyLocationCmd)
+
+	crmCmd.AddCommand(gencmd.ListCloudResourceCmd)
+	crmCmd.AddCommand(gencmd.AddCloudResourceCmd)
+	crmCmd.AddCommand(gencmd.DeleteCloudResourceCmd)
+	crmCmd.AddCommand(gencmd.DeployApplicationCmd)
+	crmCmd.AddCommand(gencmd.DeleteApplicationCmd)
 
 	rootCmd.Execute()
 }

--- a/edgeproto/cloud-resource-manager.proto
+++ b/edgeproto/cloud-resource-manager.proto
@@ -4,7 +4,7 @@ package edgeproto;
 
 import "cloudlet.proto";
 import "result.proto";
-import "app.proto";
+import "app_inst.proto";
 
 service CloudResourceManager {
   rpc ListCloudResource(CloudResource) returns (stream CloudResource) {}
@@ -35,9 +35,12 @@ enum CloudResourceCategory {
 message CloudResource {
   string name = 1;
   CloudResourceCategory category = 2;
-  Cloudlet cloudlet = 3;
+  CloudletKey cloudletKey = 3;
   bool active = 4;
   int32 id = 5;
+  // AccessIp should come from the cloudlet, but for testing it
+  // is configurable here. This will need to be removed later.
+  bytes access_ip = 100;
 }
 
 message EdgeCloudApp {
@@ -51,7 +54,7 @@ message EdgeCloudApp {
   int32 replicas = 9;
   string context = 10;
   string namespace = 11;
-  App app = 12;
+  AppInstKey appInstKey = 12;
 }
 
 message EdgeCloudApplication {

--- a/gencmd/app-client.cmd.go
+++ b/gencmd/app-client.cmd.go
@@ -42,7 +42,7 @@ var Match_Engine_RequestInIdType string
 func Match_Engine_RequestSlicer(in *distributed_match_engine.Match_Engine_Request) []string {
 	s := make([]string, 0, 9)
 	s = append(s, string(in.Ver))
-	s = append(s, string(in.IdType))
+	s = append(s, distributed_match_engine.Match_Engine_Request_IDType_name[int32(in.IdType)])
 	s = append(s, in.Id)
 	s = append(s, string(in.Carrier))
 	s = append(s, string(in.Tower))
@@ -59,8 +59,8 @@ func Match_Engine_RequestSlicer(in *distributed_match_engine.Match_Engine_Reques
 	if in.GpsLocation.Timestamp == nil {
 		in.GpsLocation.Timestamp = &google_protobuf.Timestamp{}
 	}
-	timestampTime := time.Unix(in.GpsLocation.Timestamp.Seconds, int64(in.GpsLocation.Timestamp.Nanos))
-	s = append(s, timestampTime.String())
+	_GpsLocation_TimestampTime := time.Unix(in.GpsLocation.Timestamp.Seconds, int64(in.GpsLocation.Timestamp.Nanos))
+	s = append(s, _GpsLocation_TimestampTime.String())
 	s = append(s, string(in.AppId))
 	return s
 }
@@ -102,8 +102,8 @@ func Match_Engine_ReplySlicer(in *distributed_match_engine.Match_Engine_Reply) [
 	if in.CloudletLocation.Timestamp == nil {
 		in.CloudletLocation.Timestamp = &google_protobuf.Timestamp{}
 	}
-	timestampTime := time.Unix(in.CloudletLocation.Timestamp.Seconds, int64(in.CloudletLocation.Timestamp.Nanos))
-	s = append(s, timestampTime.String())
+	_CloudletLocation_TimestampTime := time.Unix(in.CloudletLocation.Timestamp.Seconds, int64(in.CloudletLocation.Timestamp.Nanos))
+	s = append(s, _CloudletLocation_TimestampTime.String())
 	return s
 }
 
@@ -126,8 +126,8 @@ func Match_Engine_ReplyHeaderSlicer() []string {
 func Match_Engine_Loc_VerifySlicer(in *distributed_match_engine.Match_Engine_Loc_Verify) []string {
 	s := make([]string, 0, 3)
 	s = append(s, string(in.Ver))
-	s = append(s, string(in.TowerStatus))
-	s = append(s, string(in.GpsLocationStatus))
+	s = append(s, distributed_match_engine.Match_Engine_Loc_Verify_Tower_Status_name[int32(in.TowerStatus)])
+	s = append(s, distributed_match_engine.Match_Engine_Loc_Verify_GPS_Location_Status_name[int32(in.GpsLocationStatus)])
 	return s
 }
 

--- a/gencmd/app_inst.cmd.go
+++ b/gencmd/app_inst.cmd.go
@@ -73,10 +73,10 @@ func AppInstSlicer(in *edgeproto.AppInst) []string {
 	if in.CloudletLoc.Timestamp == nil {
 		in.CloudletLoc.Timestamp = &google_protobuf.Timestamp{}
 	}
-	timestampTime := time.Unix(in.CloudletLoc.Timestamp.Seconds, int64(in.CloudletLoc.Timestamp.Nanos))
-	s = append(s, timestampTime.String())
+	_CloudletLoc_TimestampTime := time.Unix(in.CloudletLoc.Timestamp.Seconds, int64(in.CloudletLoc.Timestamp.Nanos))
+	s = append(s, _CloudletLoc_TimestampTime.String())
 	s = append(s, string(in.Port))
-	s = append(s, string(in.Liveness))
+	s = append(s, edgeproto.AppInst_Liveness_name[int32(in.Liveness)])
 	return s
 }
 

--- a/gencmd/cloudlet.cmd.go
+++ b/gencmd/cloudlet.cmd.go
@@ -59,8 +59,8 @@ func CloudletSlicer(in *edgeproto.Cloudlet) []string {
 	if in.Location.Timestamp == nil {
 		in.Location.Timestamp = &google_protobuf.Timestamp{}
 	}
-	timestampTime := time.Unix(in.Location.Timestamp.Seconds, int64(in.Location.Timestamp.Nanos))
-	s = append(s, timestampTime.String())
+	_Location_TimestampTime := time.Unix(in.Location.Timestamp.Seconds, int64(in.Location.Timestamp.Nanos))
+	s = append(s, _Location_TimestampTime.String())
 	return s
 }
 

--- a/gencmd/loc.cmd.go
+++ b/gencmd/loc.cmd.go
@@ -31,8 +31,8 @@ func LocSlicer(in *edgeproto.Loc) []string {
 	if in.Timestamp == nil {
 		in.Timestamp = &google_protobuf.Timestamp{}
 	}
-	timestampTime := time.Unix(in.Timestamp.Seconds, int64(in.Timestamp.Nanos))
-	s = append(s, timestampTime.String())
+	_TimestampTime := time.Unix(in.Timestamp.Seconds, int64(in.Timestamp.Nanos))
+	s = append(s, _TimestampTime.String())
 	return s
 }
 

--- a/gencmd/notice.cmd.go
+++ b/gencmd/notice.cmd.go
@@ -21,7 +21,7 @@ var NotifyApiCmd edgeproto.NotifyApiClient
 
 func NoticeSlicer(in *edgeproto.Notice) []string {
 	s := make([]string, 0, 5)
-	s = append(s, string(in.Action))
+	s = append(s, edgeproto.NoticeAction_name[int32(in.Action)])
 	s = append(s, string(in.ConnectionId))
 	s = append(s, string(in.Version))
 	return s
@@ -37,7 +37,7 @@ func NoticeHeaderSlicer() []string {
 
 func NoticeReplySlicer(in *edgeproto.NoticeReply) []string {
 	s := make([]string, 0, 2)
-	s = append(s, string(in.Action))
+	s = append(s, edgeproto.NoticeAction_name[int32(in.Action)])
 	s = append(s, string(in.Version))
 	return s
 }

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -345,8 +345,8 @@ func (s *NotifySender) Stop() {
 }
 
 type NotifySendAllMaps struct {
-	appInsts  map[edgeproto.AppInstKey]bool
-	cloudlets map[edgeproto.CloudletKey]bool
+	AppInsts  map[edgeproto.AppInstKey]bool
+	Cloudlets map[edgeproto.CloudletKey]bool
 }
 
 type NotifyRecvHandler interface {
@@ -476,8 +476,8 @@ func (s *NotifyReceiver) StreamNotice(stream edgeproto.NotifyApi_StreamNoticeSer
 		return err
 	}
 	sendAllMaps := &NotifySendAllMaps{}
-	sendAllMaps.appInsts = make(map[edgeproto.AppInstKey]bool)
-	sendAllMaps.cloudlets = make(map[edgeproto.CloudletKey]bool)
+	sendAllMaps.AppInsts = make(map[edgeproto.AppInstKey]bool)
+	sendAllMaps.Cloudlets = make(map[edgeproto.CloudletKey]bool)
 	util.DebugLog(util.DebugLevelNotify, "NotifyReceiver connected", "version", s.version, "supported-version", NotifyVersion)
 
 	for !s.done {
@@ -494,11 +494,11 @@ func (s *NotifyReceiver) StreamNotice(stream edgeproto.NotifyApi_StreamNoticeSer
 		if sendAllMaps != nil && notice.Action == edgeproto.NoticeAction_UPDATE {
 			appInst := notice.GetAppInst()
 			if appInst != nil {
-				sendAllMaps.appInsts[appInst.Key] = true
+				sendAllMaps.AppInsts[appInst.Key] = true
 			}
 			cloudlet := notice.GetCloudlet()
 			if cloudlet != nil {
-				sendAllMaps.cloudlets[cloudlet.Key] = true
+				sendAllMaps.Cloudlets[cloudlet.Key] = true
 			}
 		}
 		if notice.Action == edgeproto.NoticeAction_SENDALL_END {

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -88,12 +88,12 @@ func NewDummyRecvHandler() *DummyRecvHandler {
 
 func (s *DummyRecvHandler) HandleSendAllDone(maps *NotifySendAllMaps) {
 	for key, _ := range s.appInsts {
-		if _, ok := maps.appInsts[key]; !ok {
+		if _, ok := maps.AppInsts[key]; !ok {
 			delete(s.appInsts, key)
 		}
 	}
 	for key, _ := range s.cloudlets {
-		if _, ok := maps.cloudlets[key]; !ok {
+		if _, ok := maps.Cloudlets[key]; !ok {
 			delete(s.cloudlets, key)
 		}
 	}

--- a/procfiles/Procfile
+++ b/procfiles/Procfile
@@ -2,5 +2,6 @@
 etcd1: etcd --name etcd1 --data-dir /var/tmp/edge-cloud-local-cluster/etcd1 --listen-client-urls http://127.0.0.1:30001 --advertise-client-urls http://127.0.0.1:30001 --listen-peer-urls http://127.0.0.1:30011
 etcd2: etcd --name etcd2 --data-dir /var/tmp/edge-cloud-local-cluster/etcd2 --listen-client-urls http://127.0.0.1:30002 --advertise-client-urls http://127.0.0.1:30002 --listen-peer-urls http://127.0.0.1:30012
 etcd3: etcd --name etcd3 --data-dir /var/tmp/edge-cloud-local-cluster/etcd3 --listen-client-urls http://127.0.0.1:30003 --advertise-client-urls http://127.0.0.1:30003 --listen-peer-urls http://127.0.0.1:30013
-ctrl1: controller -r /var/tmp/edge-cloud-local-cluster/controller1 --etcdUrls "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003" --apiPort 40101 --httpPort 50101 --matcherAddrs "127.0.0.1:30021" -d api,notify,etcd
+ctrl1: controller -r /var/tmp/edge-cloud-local-cluster/controller1 --etcdUrls "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003" --apiPort 40101 --httpPort 50101 --matcherAddrs "127.0.0.1:30021" --crmAddrs "127.0.0.1:30101" -d api,notify,etcd
 dme1: dme-server --notifyAddr "127.0.0.1:30021"
+crm1: crmserver --controller "127.0.0.1:40101" --notifyAddr "127.0.0.1:30101"

--- a/protogen/Makefile
+++ b/protogen/Makefile
@@ -4,5 +4,4 @@ PROTOCGRPC	= ../../../grpc-ecosystem/grpc-gateway/third_party/googleapis
 GOGOPROTO	= 
 
 build:
-	go install github.com/gogo/protobuf/protoc-gen-gogo
 	protoc -I. -I${PROTOCGRPC} --gogofast_out=Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor:. *.proto


### PR DESCRIPTION
I've added the notify scheme to the cloudlet resource manager. So whenever a Cloudlet or AppInst is added to the Controller, it will push the object to any registered Cloudlet Resource Managers. The way to do this is to specify a cloudlet resource manager when running the controller:
```
controller -crmAddrs "127.0.0.1:51001"
```
In the cloud-resource-manage.proto, I've changed the instantiated Cloudlet and App to CloudletKey and AppInstKey. The CRM should look up the data sent by the controller if it needs any of the data from those objects. I put some dummy code in there Bob. Hopefully I didn't break anything Bob, I tried not to touch too much :)

Also I've added support for repeated fields in the edgectl cli (I only support one object, which is what Bob's CLI is doing). I've added the CRM methods to edgectl as well, but you can see below when the nesting gets deep the auto-generated cli args become quite ugly. The cli is only for testing anyway.

```
edge-cloud$ edgectl crm --addr "127.0.0.1:55099" ListCloudResource
Name       Category   CloudletKey-OperatorKey-Name CloudletKey-Name   Active Id
Cloudlet-1 Kubernetes AT&T Inc.                    San Jose Site      false  
Cloudlet-2 Kubernetes AT&T Inc.                    New York Site      false  
Cloudlet-3 Kubernetes T-Mobile                     San Francisco Site false  
```
```
edge-cloud$ edgectl crm --addr "127.0.0.1:55099" DeployApplication -h
Usage:
  edgectl crm DeployApplication [flags]

Flags:
      --apps-appinstkey-appkey-developerkey-name string       Apps[0].AppInstKey.AppKey.DeveloperKey.Name
      --apps-appinstkey-appkey-name string                    Apps[0].AppInstKey.AppKey.Name
      --apps-appinstkey-appkey-version string                 Apps[0].AppInstKey.AppKey.Version
      --apps-appinstkey-cloudletkey-name string               Apps[0].AppInstKey.CloudletKey.Name
      --apps-appinstkey-cloudletkey-operatorkey-name string   Apps[0].AppInstKey.CloudletKey.OperatorKey.Name
      --apps-appinstkey-id uint                               Apps[0].AppInstKey.Id
      --apps-context string                                   Apps[0].Context
      --apps-cpu string                                       Apps[0].Cpu
      --apps-exposure string                                  Apps[0].Exposure
      --apps-image string                                     Apps[0].Image
      --apps-limitfactor int32                                Apps[0].Limitfactor
      --apps-memory string                                    Apps[0].Memory
      --apps-name string                                      Apps[0].Name
      --apps-namespace string                                 Apps[0].Namespace
      --apps-replicas int32                                   Apps[0].Replicas
      --apps-repository string                                Apps[0].Repository
  -h, --help                                                  help for DeployApplication
      --kind string                                           Kind
      --manifest string                                       Manifest

Global Flags:
      --addr string   address to connect to (default "127.0.0.1:55001")
```