### PR TITLE
integration test framework

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,6 +27,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/daviddengcn/go-colortext"
+  packages = ["."]
+  revision = "17e75f6184bc9e727756cd0d82e0af58b1fc7191"
+  version = "1.0.0"
+
+[[projects]]
   name = "github.com/ghodss/yaml"
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
@@ -130,6 +136,25 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/gophercloud/gophercloud"
+  packages = [
+    ".",
+    "internal",
+    "openstack",
+    "openstack/compute/v2/flavors",
+    "openstack/compute/v2/images",
+    "openstack/compute/v2/servers",
+    "openstack/identity/v2/tenants",
+    "openstack/identity/v2/tokens",
+    "openstack/identity/v3/tokens",
+    "openstack/imageservice/v2/images",
+    "openstack/utils",
+    "pagination"
+  ]
+  revision = "7112fcd50da4ea27e8d4d499b30f04eea143bec2"
+
+[[projects]]
+  branch = "master"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
@@ -227,7 +252,10 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
@@ -504,6 +532,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4dcefe1bfea9b2580748011c677ca44478651fd56b18c4b4e220145756e4f8da"
+  inputs-digest = "f647bf3671a56bdc749a52341ec48fa3a8b1dbc80e8dbd2050ec9ab185aa343a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -1,0 +1,88 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/integration/process"
+	"github.com/mobiledgex/edge-cloud/integration/setups"
+	"github.com/mobiledgex/edge-cloud/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// This tests the synchronization of the database between
+// controller processes via etcd watch calls.
+func testControllerSync(t *testing.T, setup *process.ProcessSetup) {
+	numproc := 3
+	process.RequireEtcdCount(t, setup, numproc)
+	process.RequireControllerCount(t, setup, numproc)
+	process.ResetEtcds(t, setup, numproc)
+	process.StartEtcds(t, setup, numproc)
+	process.StartControllers(t, setup, numproc, process.WithDebug("etcd,api,notify"))
+	connectTimeout := 4 * time.Second
+	ctrlApis := process.ConnectControllerAPIs(t, setup, numproc, connectTimeout)
+
+	devApis := make([]edgeproto.DeveloperApiClient, numproc)
+	for ii := 0; ii < numproc; ii++ {
+		devApis[ii] = edgeproto.NewDeveloperApiClient(ctrlApis[ii])
+	}
+
+	var err error
+	retries := 10
+	interval := 10 * time.Millisecond
+
+	// create developers and see that they show up on the other controllers
+	for _, dev := range testutil.DevData {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		_, err = devApis[0].CreateDeveloper(ctx, &dev)
+		cancel()
+		assert.Nil(t, err, "create dev "+dev.Key.GetKeyString())
+		for ii := 0; ii < numproc; ii++ {
+			testutil.WaitAssertFoundDeveloper(t, devApis[ii], &dev, retries, interval)
+		}
+	}
+
+	// restart a controller and make sure it resyncs
+	ctrlApis[0].Close()
+	setup.Controllers[0].Stop()
+	setup.Controllers[0].Start(process.WithDebug("etcd,api,notify"))
+	ctrlApis[0], err = setup.Controllers[0].ConnectAPI(connectTimeout)
+	assert.Nil(t, err, "reconnect to controller 0")
+	devApis[0] = edgeproto.NewDeveloperApiClient(ctrlApis[0])
+	for _, dev := range testutil.DevData {
+		testutil.WaitAssertFoundDeveloper(t, devApis[0], &dev, retries, interval)
+	}
+
+	// update a developer and make sure it syncs
+	testutil.DevData[0].Email = "updated email"
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	_, err = devApis[0].UpdateDeveloper(ctx, &testutil.DevData[0])
+	cancel()
+	for ii := 0; ii < numproc; ii++ {
+		testutil.WaitAssertFoundDeveloper(t, devApis[ii], &testutil.DevData[0], retries, interval)
+	}
+
+	// delete a developer and make sure it propagates
+	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+	_, err = devApis[0].DeleteDeveloper(ctx, &testutil.DevData[0])
+	cancel()
+	for ii := 0; ii < numproc; ii++ {
+		testutil.WaitAssertNotFoundDeveloper(t, devApis[ii], &testutil.DevData[0], retries, interval)
+	}
+
+	process.StopControllers(setup, numproc)
+	process.StopEtcds(setup, numproc)
+}
+
+func TestControllerSyncLocal(t *testing.T) {
+	// The LocalCtrlSync setup has controllers connecting to
+	// separate etcd instances, so that synchronization must
+	// happen via controllerA -> etcdA -> etcdB -> controllerB
+	testControllerSync(t, &setups.LocalCtrlSync)
+}
+
+func TestControllerSyncBasic(t *testing.T) {
+	testControllerSync(t, &setups.LocalBasic)
+}

--- a/integration/doc.go
+++ b/integration/doc.go
@@ -1,0 +1,1 @@
+package integration

--- a/integration/process/process.go
+++ b/integration/process/process.go
@@ -1,0 +1,136 @@
+package process
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// ProcessSetup defines a collection of various processes.
+// Processes are all the processes that make up our edge cloud, such as
+// the etcd db, controller, DME, CRM, plus possibly external
+// processes for application clients and servers.
+//
+// The goal of this abstraction layer is to allow the same integration
+// tests to be run against different implementations of the processes.
+// I.e. for unit testing, processes may be run locally on a laptop
+// in the global namespace. For CI/CD testing, the same tests may be
+// run against processes in docker images that will be the same images
+// used in deployment. Alternatively tests could run against pre-existing
+// processes (deployments) already running in the cloud.
+type ProcessSetup struct {
+	Etcds       []EtcdProcess
+	Controllers []ControllerProcess
+	Dmes        []DmeProcess
+	Crms        []CrmProcess
+}
+
+type EtcdProcess interface {
+	Start() error
+	Stop()
+	ResetData() error
+}
+
+type ControllerProcess interface {
+	Start(opts ...StartOp) error
+	Stop()
+	ConnectAPI(timeout time.Duration) (*grpc.ClientConn, error)
+}
+
+type DmeProcess interface {
+	Start() error
+	Stop()
+	ConnectAPI() (*grpc.ClientConn, error)
+}
+
+type CrmProcess interface {
+	Start() error
+	Stop()
+	ConnectAPI() (*grpc.ClientConn, error)
+}
+
+// options
+
+type StartOptions struct {
+	Debug string
+}
+
+type StartOp func(op *StartOptions)
+
+func WithDebug(debug string) StartOp {
+	return func(op *StartOptions) { op.Debug = debug }
+}
+
+func (s *StartOptions) ApplyStartOptions(opts ...StartOp) {
+	for _, fn := range opts {
+		fn(s)
+	}
+}
+
+// Support functions
+
+func RequireEtcdCount(t *testing.T, setup *ProcessSetup, min int) {
+	count := len(setup.Etcds)
+	require.True(t, count >= min, "check minimum number of Etcds")
+}
+
+func RequireControllerCount(t *testing.T, setup *ProcessSetup, min int) {
+	count := len(setup.Controllers)
+	require.True(t, count >= min, "check minimum number of Controllers")
+}
+
+func RequireDmeCount(t *testing.T, setup *ProcessSetup, min int) {
+	count := len(setup.Dmes)
+	require.True(t, count >= min, "check minimum number of Dmes")
+}
+
+func RequireCrmCount(t *testing.T, setup *ProcessSetup, min int) {
+	count := len(setup.Crms)
+	require.True(t, count >= min, "check minimum number of Crms")
+}
+
+func ResetEtcds(t *testing.T, setup *ProcessSetup, count int) {
+	for ii := 0; ii < count; ii++ {
+		err := setup.Etcds[ii].ResetData()
+		assert.Nil(t, err, "reset etcd ", ii)
+	}
+}
+
+func StartEtcds(t *testing.T, setup *ProcessSetup, count int) {
+	for ii := 0; ii < count; ii++ {
+		err := setup.Etcds[ii].Start()
+		require.Nil(t, err, "start etcd ", ii)
+	}
+}
+
+func StopEtcds(setup *ProcessSetup, count int) {
+	for ii := 0; ii < count; ii++ {
+		setup.Etcds[ii].Stop()
+	}
+}
+
+func StartControllers(t *testing.T, setup *ProcessSetup, count int, opts ...StartOp) {
+	for ii := 0; ii < count; ii++ {
+		err := setup.Controllers[ii].Start(opts...)
+		require.Nil(t, err, "start controller ", ii)
+	}
+}
+
+func StopControllers(setup *ProcessSetup, count int) {
+	for ii := 0; ii < count; ii++ {
+		setup.Controllers[ii].Stop()
+	}
+}
+
+func ConnectControllerAPIs(t *testing.T, setup *ProcessSetup, count int, timeout time.Duration) []*grpc.ClientConn {
+	conns := make([]*grpc.ClientConn, 0)
+	for ii := 0; ii < count; ii++ {
+		conn, err := setup.Controllers[ii].ConnectAPI(timeout)
+		require.Nil(t, err, "connect controller API ", ii)
+		conns = append(conns, conn)
+	}
+	return conns
+}

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -1,0 +1,222 @@
+package process
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	ct "github.com/daviddengcn/go-colortext"
+	"google.golang.org/grpc"
+)
+
+// Local processes all run in the same global namespace, using different
+// tcp ports to communicate with each other.
+
+// EtcdLocal
+
+type EtcdLocal struct {
+	Name           string
+	DataDir        string
+	PeerAddrs      string
+	ClientAddrs    string
+	InitialCluster string
+	cmd            *exec.Cmd
+}
+
+func (p *EtcdLocal) Start() error {
+	args := []string{"--name", p.Name, "--data-dir", p.DataDir, "--listen-peer-urls", p.PeerAddrs, "--listen-client-urls", p.ClientAddrs, "--advertise-client-urls", p.ClientAddrs, "--initial-advertise-peer-urls", p.PeerAddrs, "--initial-cluster", p.InitialCluster}
+	var err error
+	p.cmd, err = StartLocal(p.Name, "etcd", args)
+	return err
+}
+
+func (p *EtcdLocal) Stop() {
+	StopLocal(p.cmd)
+}
+
+func (p *EtcdLocal) ResetData() error {
+	return os.RemoveAll(p.DataDir)
+}
+
+// ControllerLocal
+
+type ControllerLocal struct {
+	Name         string
+	EtcdAddrs    string
+	ApiAddr      string
+	HttpAddr     string
+	MatcherAddrs string
+	CRMAddrs     string
+	cmd          *exec.Cmd
+}
+
+func (p *ControllerLocal) Start(opts ...StartOp) error {
+	args := []string{"--etcdUrls", p.EtcdAddrs, "--matcherAddrs", p.MatcherAddrs, "--crmAddrs", p.CRMAddrs}
+	if p.ApiAddr != "" {
+		args = append(args, "--apiAddr")
+		args = append(args, p.ApiAddr)
+	}
+	if p.HttpAddr != "" {
+		args = append(args, "--httpAddr")
+		args = append(args, p.HttpAddr)
+	}
+	options := StartOptions{}
+	options.ApplyStartOptions(opts...)
+	if options.Debug != "" {
+		args = append(args, "-d")
+		args = append(args, options.Debug)
+	}
+
+	var err error
+	p.cmd, err = StartLocal(p.Name, "controller", args)
+	return err
+}
+
+func (p *ControllerLocal) Stop() {
+	StopLocal(p.cmd)
+}
+
+func (p *ControllerLocal) ConnectAPI(timeout time.Duration) (*grpc.ClientConn, error) {
+	// Wait for controller to be ready to connect.
+	// Note: using grpc WithBlock() takes about a second longer
+	// than doing the retry connect below so requires a larger timeout.
+	wait := 20 * time.Millisecond
+	for {
+		_, err := net.Dial("tcp", p.ApiAddr)
+		if err == nil || timeout < wait {
+			break
+		}
+		timeout -= wait
+		time.Sleep(wait)
+	}
+	conn, err := grpc.Dial(p.ApiAddr, grpc.WithInsecure())
+	return conn, err
+}
+
+// DmeLocal
+
+type DmeLocal struct {
+	Name       string
+	NotifyAddr string
+	cmd        *exec.Cmd
+}
+
+func (p *DmeLocal) Start() error {
+	args := []string{"--notifyAddr", p.NotifyAddr}
+	var err error
+	p.cmd, err = StartLocal(p.Name, "dme-server", args)
+	return err
+}
+
+func (p *DmeLocal) Stop() {
+	StopLocal(p.cmd)
+}
+
+func (p *DmeLocal) ConnectAPI() (*grpc.ClientConn, error) {
+	// TODO
+	return nil, errors.New("TODO")
+}
+
+// CrmLocal
+
+type CrmLocal struct {
+	Name       string
+	NotifyAddr string
+	cmd        *exec.Cmd
+}
+
+func (p *CrmLocal) Start() error {
+	args := []string{"--notifyAddr", p.NotifyAddr}
+	var err error
+	p.cmd, err = StartLocal(p.Name, "crmserver", args)
+	return err
+}
+
+func (p *CrmLocal) Stop() {
+	StopLocal(p.cmd)
+}
+
+func (p *CrmLocal) ConnectAPI() (*grpc.ClientConn, error) {
+	// TODO
+	return nil, errors.New("TODO")
+}
+
+// Support funcs
+
+func StartLocal(name, bin string, args []string) (*exec.Cmd, error) {
+	cmd := exec.Command(bin, args...)
+	writer := NewColorWriter(name)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	err := cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func StopLocal(cmd *exec.Cmd) {
+	if cmd != nil {
+		cmd.Process.Kill()
+	}
+}
+
+type ColorWriter struct {
+	Name  string
+	Color ct.Color
+}
+
+func (c *ColorWriter) Write(p []byte) (int, error) {
+	buf := bytes.NewBuffer(p)
+	printed := 0
+	for {
+		line, err := buf.ReadBytes('\n')
+		if len(line) > 0 {
+			ct.ChangeColor(c.Color, false, ct.None, false)
+			fmt.Printf("%s : %s", c.Name, string(line))
+			ct.ResetColor()
+			printed += len(line)
+		}
+		if err != nil {
+			if err != io.EOF {
+				return printed, err
+			}
+			break
+		}
+	}
+	return printed, nil
+}
+
+var nextColorIdx = 0
+var nextColorMux sync.Mutex
+
+var colors = []ct.Color{
+	ct.Green,
+	ct.Cyan,
+	ct.Magenta,
+	ct.Blue,
+	ct.Red,
+	ct.Yellow,
+}
+
+func NewColorWriter(name string) *ColorWriter {
+	nextColorMux.Lock()
+	color := colors[nextColorIdx]
+	nextColorIdx++
+	if nextColorIdx >= len(colors) {
+		nextColorIdx = 0
+	}
+	nextColorMux.Unlock()
+
+	writer := ColorWriter{
+		Name:  name,
+		Color: color,
+	}
+	return &writer
+}

--- a/integration/setups/local_basic.go
+++ b/integration/setups/local_basic.go
@@ -1,0 +1,72 @@
+package setups
+
+import "github.com/mobiledgex/edge-cloud/integration/process"
+
+var localBasicEtcdCluster = "etcd1=http://127.0.0.1:30011,etcd2=http://127.0.0.1:30012,etcd3=http://127.0.0.1:30013"
+var localBasicEtcdAddrs = "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
+
+var LocalBasic = process.ProcessSetup{
+	Etcds: []process.EtcdProcess{
+		&process.EtcdLocal{
+			Name:           "etcd1",
+			DataDir:        "/var/tmp/edge-cloud-local-etcd/etcd1",
+			PeerAddrs:      "http://127.0.0.1:30011",
+			ClientAddrs:    "http://127.0.0.1:30001",
+			InitialCluster: localBasicEtcdCluster,
+		},
+		&process.EtcdLocal{
+			Name:           "etcd2",
+			DataDir:        "/var/tmp/edge-cloud-local-etcd/etcd2",
+			PeerAddrs:      "http://127.0.0.1:30012",
+			ClientAddrs:    "http://127.0.0.1:30002",
+			InitialCluster: localBasicEtcdCluster,
+		},
+		&process.EtcdLocal{
+			Name:           "etcd3",
+			DataDir:        "/var/tmp/edge-cloud-local-etcd/etcd3",
+			PeerAddrs:      "http://127.0.0.1:30013",
+			ClientAddrs:    "http://127.0.0.1:30003",
+			InitialCluster: localBasicEtcdCluster,
+		},
+	},
+	Controllers: []process.ControllerProcess{
+		&process.ControllerLocal{
+			Name:      "ctrl1",
+			EtcdAddrs: localBasicEtcdAddrs,
+			ApiAddr:   "127.0.0.1:35001",
+			HttpAddr:  "127.0.0.1:36001",
+		},
+		&process.ControllerLocal{
+			Name:      "ctrl2",
+			EtcdAddrs: localBasicEtcdAddrs,
+			ApiAddr:   "127.0.0.1:35002",
+			HttpAddr:  "127.0.0.1:36002",
+		},
+		&process.ControllerLocal{
+			Name:      "ctrl3",
+			EtcdAddrs: localBasicEtcdAddrs,
+			ApiAddr:   "127.0.0.1:35003",
+			HttpAddr:  "127.0.0.1:36003",
+		},
+	},
+	Dmes: []process.DmeProcess{
+		&process.DmeLocal{
+			Name:       "dme1",
+			NotifyAddr: "127.0.0.1:31001",
+		},
+		&process.DmeLocal{
+			Name:       "dme2",
+			NotifyAddr: "127.0.0.1:31002",
+		},
+	},
+	Crms: []process.CrmProcess{
+		&process.CrmLocal{
+			Name:       "crm1",
+			NotifyAddr: "127.0.0.1:33001",
+		},
+		&process.CrmLocal{
+			Name:       "crm2",
+			NotifyAddr: "127.0.0.1:33002",
+		},
+	},
+}

--- a/integration/setups/local_ctrlsync.go
+++ b/integration/setups/local_ctrlsync.go
@@ -1,0 +1,56 @@
+package setups
+
+import "github.com/mobiledgex/edge-cloud/integration/process"
+
+// This setup directs each controller to a single separate etcd instance so
+// that any update to one controller must flow to etcd, to another etcd,
+// and then back to another controller. This allows us to test the
+// synchronization between controllers via etcd watch.
+
+var localCtrlSyncEtcdCluster = "etcd1=http://127.0.0.1:30011,etcd2=http://127.0.0.1:30012,etcd3=http://127.0.0.1:30013"
+
+var LocalCtrlSync = process.ProcessSetup{
+	Etcds: []process.EtcdProcess{
+		&process.EtcdLocal{
+			Name:           "etcd1",
+			DataDir:        "/var/tmp/edge-cloud-local-etcd/etcd1",
+			PeerAddrs:      "http://127.0.0.1:30011",
+			ClientAddrs:    "http://127.0.0.1:30001",
+			InitialCluster: localCtrlSyncEtcdCluster,
+		},
+		&process.EtcdLocal{
+			Name:           "etcd2",
+			DataDir:        "/var/tmp/edge-cloud-local-etcd/etcd2",
+			PeerAddrs:      "http://127.0.0.1:30012",
+			ClientAddrs:    "http://127.0.0.1:30002",
+			InitialCluster: localCtrlSyncEtcdCluster,
+		},
+		&process.EtcdLocal{
+			Name:           "etcd3",
+			DataDir:        "/var/tmp/edge-cloud-local-etcd/etcd3",
+			PeerAddrs:      "http://127.0.0.1:30013",
+			ClientAddrs:    "http://127.0.0.1:30003",
+			InitialCluster: localCtrlSyncEtcdCluster,
+		},
+	},
+	Controllers: []process.ControllerProcess{
+		&process.ControllerLocal{
+			Name:      "ctrl1",
+			EtcdAddrs: "http://127.0.0.1:30001",
+			ApiAddr:   "127.0.0.1:35001",
+			HttpAddr:  "127.0.0.1:36001",
+		},
+		&process.ControllerLocal{
+			Name:      "ctrl2",
+			EtcdAddrs: "http://127.0.0.1:30002",
+			ApiAddr:   "127.0.0.1:35002",
+			HttpAddr:  "127.0.0.1:36002",
+		},
+		&process.ControllerLocal{
+			Name:      "ctrl3",
+			EtcdAddrs: "http://127.0.0.1:30003",
+			ApiAddr:   "127.0.0.1:35003",
+			HttpAddr:  "127.0.0.1:36003",
+		},
+	},
+}


### PR DESCRIPTION
This introduces a framework for multi-process integration testing. I'm finding it quite easy to write go code to test go code, even at the integration level (as opposed to having to think in another language like python). An advantage here is some of same support test code that is used for unit tests can also be used for integration tests (dummy data, auto-generated test code, etc).

Take a look at integration/process/process.go first. This is an abstraction layer for processes that abstracts out how they are run, and how they are connected to. My hope is that we can then write integration tests that can be run against local processes, or processes in dockers, or processes in the cloud (perhaps), just by swapping in different "setups" that define where and how these processes run and are connected to. I'm sure this is familiar pattern to many of you. 

The actual test I needed to run is to test the controller synchronization code that was just pushed.