### PR TITLE
Android MEX lib SDK: Fix an edge case UI infinite loop on forcing app permissions on start.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/util/RequestPermissions.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/util/RequestPermissions.java
@@ -86,8 +86,6 @@ public class RequestPermissions {
                         activity.getString(R.string.request_permission))
                         .show(activity.getSupportFragmentManager(), "dialog");
             }
-        } else {
-            activity.onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
 


### PR DESCRIPTION
This infinite loop is triggered by removing required permissions after initially having granted them.