### PR TITLE
change notify, dme/crm is client and controller is server

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/notify.go
+++ b/cloud-resource-manager/cmd/crmserver/notify.go
@@ -14,11 +14,11 @@ func NewNotifyHandler(cd *crmutil.ControllerData) *NotifyHandler {
 	return &NotifyHandler{cd: cd}
 }
 
-func (s *NotifyHandler) HandleSendAllDone(allMaps *notify.NotifySendAllMaps) {
+func (s *NotifyHandler) HandleSendAllDone(allMaps *notify.AllMaps) {
 	s.cd.HandleNotifyDone(allMaps)
 }
 
-func (s *NotifyHandler) HandleNotice(notice *edgeproto.Notice) error {
+func (s *NotifyHandler) HandleNotice(notice *edgeproto.NoticeReply) error {
 	appInst := notice.GetAppInst()
 	if appInst != nil {
 		if notice.Action == edgeproto.NoticeAction_UPDATE {

--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -65,7 +65,7 @@ func (cd *ControllerData) GetCloudlet(key *edgeproto.CloudletKey, inst *edgeprot
 	return false
 }
 
-func (cd *ControllerData) HandleNotifyDone(allMaps *notify.NotifySendAllMaps) {
+func (cd *ControllerData) HandleNotifyDone(allMaps *notify.AllMaps) {
 	cd.appInstsMux.Lock()
 	for key, val := range cd.appInsts {
 		if _, found := allMaps.AppInsts[key]; !found {

--- a/controller/main.go
+++ b/controller/main.go
@@ -26,8 +26,7 @@ var region = flag.Uint("region", 1, "Region")
 var etcdUrls = flag.String("etcdUrls", "http://127.0.0.1:2380", "etcd client listener URLs")
 var apiAddr = flag.String("apiAddr", "127.0.0.1:55001", "API listener address")
 var httpAddr = flag.String("httpAddr", "127.0.0.1:8091", "HTTP listener address")
-var matcherAddrs = flag.String("matcherAddrs", "", "comma separated list of distributed matching engine addresses")
-var crmAddrs = flag.String("crmAddrs", "", "comma separated list of cloudlet resource manager addresses")
+var notifyAddr = flag.String("notifyAddr", "127.0.0.1:50001", "Notify listener address")
 var debugLevels = flag.String("d", "", "comma separated list of debug levels")
 
 func GetRootDir() string {
@@ -95,9 +94,8 @@ func main() {
 	cloudletApi.WaitInitDone()
 	appInstApi.WaitInitDone()
 
-	notify.InitNotifySenders(NewControllerNotifier(appInstApi, cloudletApi))
-	notify.RegisterMatcherAddrs(*matcherAddrs)
-	notify.RegisterCloudletAddrs(*crmAddrs)
+	notifyHandler := NewControllerNotifier(appInstApi, cloudletApi)
+	notify.ServerMgrStart(*notifyAddr, notifyHandler)
 
 	server := grpc.NewServer()
 	edgeproto.RegisterDeveloperApiServer(server, developerApi)

--- a/d-match-engine/dme-server/dme-notify.go
+++ b/d-match-engine/dme-server/dme-notify.go
@@ -10,25 +10,25 @@ import (
 var cloudletID = 5000
 
 type app struct {
-	id uint64
-	name string
-	vers string
+	id        uint64
+	name      string
+	vers      string
 	developer string
 }
 
 type NotifyHandler struct {
 }
 
-func (s *NotifyHandler) HandleSendAllDone(allMaps *notify.NotifySendAllMaps) {
+func (s *NotifyHandler) HandleSendAllDone(allMaps *notify.AllMaps) {
 	util.InfoLog("Handle send all")
 }
 
-func (s *NotifyHandler) HandleNotice(notice *edgeproto.Notice) error {
+func (s *NotifyHandler) HandleNotice(notice *edgeproto.NoticeReply) error {
 	var app_inst app
 	var cloudlet_inst cloudlet
 	var appkey *edgeproto.AppInstKey
 	var cloudletkey *edgeproto.CloudletKey
-	
+
 	appInst := notice.GetAppInst()
 	if appInst != nil {
 		if notice.Action == edgeproto.NoticeAction_UPDATE {
@@ -56,4 +56,3 @@ func (s *NotifyHandler) HandleNotice(notice *edgeproto.Notice) error {
 	}
 	return nil
 }
-

--- a/edgeproto/app.pb.go
+++ b/edgeproto/app.pb.go
@@ -28,8 +28,8 @@
 		DeveloperKey
 		Developer
 		Loc
-		Notice
 		NoticeReply
+		NoticeRequest
 		OperatorCode
 		OperatorKey
 		Operator

--- a/edgeproto/notice.pb.go
+++ b/edgeproto/notice.pb.go
@@ -50,94 +50,116 @@ func (x NoticeAction) String() string {
 }
 func (NoticeAction) EnumDescriptor() ([]byte, []int) { return fileDescriptorNotice, []int{0} }
 
-type Notice struct {
+type NoticeRequestor int32
+
+const (
+	NoticeRequestor_NoticeRequestorNone NoticeRequestor = 0
+	NoticeRequestor_NoticeRequestorDME  NoticeRequestor = 1
+	NoticeRequestor_NoticeRequestorCRM  NoticeRequestor = 2
+)
+
+var NoticeRequestor_name = map[int32]string{
+	0: "NoticeRequestorNone",
+	1: "NoticeRequestorDME",
+	2: "NoticeRequestorCRM",
+}
+var NoticeRequestor_value = map[string]int32{
+	"NoticeRequestorNone": 0,
+	"NoticeRequestorDME":  1,
+	"NoticeRequestorCRM":  2,
+}
+
+func (x NoticeRequestor) String() string {
+	return proto.EnumName(NoticeRequestor_name, int32(x))
+}
+func (NoticeRequestor) EnumDescriptor() ([]byte, []int) { return fileDescriptorNotice, []int{1} }
+
+type NoticeReply struct {
 	// action to perform
 	Action NoticeAction `protobuf:"varint,1,opt,name=action,proto3,enum=edgeproto.NoticeAction" json:"action,omitempty"`
-	// connect count, used to ignore invalid buffered messages
-	ConnectionId uint64 `protobuf:"varint,2,opt,name=connectionId,proto3" json:"connectionId,omitempty"`
 	// protocol version supported by sender
 	Version uint32 `protobuf:"varint,3,opt,name=version,proto3" json:"version,omitempty"`
 	// data included (for UPDATE and DELETE)
 	//
 	// Types that are valid to be assigned to Data:
-	//	*Notice_AppInst
-	//	*Notice_Cloudlet
-	Data isNotice_Data `protobuf_oneof:"data"`
+	//	*NoticeReply_AppInst
+	//	*NoticeReply_Cloudlet
+	Data isNoticeReply_Data `protobuf_oneof:"data"`
 }
 
-func (m *Notice) Reset()                    { *m = Notice{} }
-func (m *Notice) String() string            { return proto.CompactTextString(m) }
-func (*Notice) ProtoMessage()               {}
-func (*Notice) Descriptor() ([]byte, []int) { return fileDescriptorNotice, []int{0} }
+func (m *NoticeReply) Reset()                    { *m = NoticeReply{} }
+func (m *NoticeReply) String() string            { return proto.CompactTextString(m) }
+func (*NoticeReply) ProtoMessage()               {}
+func (*NoticeReply) Descriptor() ([]byte, []int) { return fileDescriptorNotice, []int{0} }
 
-type isNotice_Data interface {
-	isNotice_Data()
+type isNoticeReply_Data interface {
+	isNoticeReply_Data()
 	MarshalTo([]byte) (int, error)
 	Size() int
 }
 
-type Notice_AppInst struct {
+type NoticeReply_AppInst struct {
 	AppInst *AppInst `protobuf:"bytes,4,opt,name=appInst,oneof"`
 }
-type Notice_Cloudlet struct {
+type NoticeReply_Cloudlet struct {
 	Cloudlet *Cloudlet `protobuf:"bytes,5,opt,name=cloudlet,oneof"`
 }
 
-func (*Notice_AppInst) isNotice_Data()  {}
-func (*Notice_Cloudlet) isNotice_Data() {}
+func (*NoticeReply_AppInst) isNoticeReply_Data()  {}
+func (*NoticeReply_Cloudlet) isNoticeReply_Data() {}
 
-func (m *Notice) GetData() isNotice_Data {
+func (m *NoticeReply) GetData() isNoticeReply_Data {
 	if m != nil {
 		return m.Data
 	}
 	return nil
 }
 
-func (m *Notice) GetAppInst() *AppInst {
-	if x, ok := m.GetData().(*Notice_AppInst); ok {
+func (m *NoticeReply) GetAppInst() *AppInst {
+	if x, ok := m.GetData().(*NoticeReply_AppInst); ok {
 		return x.AppInst
 	}
 	return nil
 }
 
-func (m *Notice) GetCloudlet() *Cloudlet {
-	if x, ok := m.GetData().(*Notice_Cloudlet); ok {
+func (m *NoticeReply) GetCloudlet() *Cloudlet {
+	if x, ok := m.GetData().(*NoticeReply_Cloudlet); ok {
 		return x.Cloudlet
 	}
 	return nil
 }
 
 // XXX_OneofFuncs is for the internal use of the proto package.
-func (*Notice) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Notice_OneofMarshaler, _Notice_OneofUnmarshaler, _Notice_OneofSizer, []interface{}{
-		(*Notice_AppInst)(nil),
-		(*Notice_Cloudlet)(nil),
+func (*NoticeReply) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
+	return _NoticeReply_OneofMarshaler, _NoticeReply_OneofUnmarshaler, _NoticeReply_OneofSizer, []interface{}{
+		(*NoticeReply_AppInst)(nil),
+		(*NoticeReply_Cloudlet)(nil),
 	}
 }
 
-func _Notice_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Notice)
+func _NoticeReply_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*NoticeReply)
 	// data
 	switch x := m.Data.(type) {
-	case *Notice_AppInst:
+	case *NoticeReply_AppInst:
 		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.AppInst); err != nil {
 			return err
 		}
-	case *Notice_Cloudlet:
+	case *NoticeReply_Cloudlet:
 		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Cloudlet); err != nil {
 			return err
 		}
 	case nil:
 	default:
-		return fmt.Errorf("Notice.Data has unexpected type %T", x)
+		return fmt.Errorf("NoticeReply.Data has unexpected type %T", x)
 	}
 	return nil
 }
 
-func _Notice_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Notice)
+func _NoticeReply_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*NoticeReply)
 	switch tag {
 	case 4: // data.appInst
 		if wire != proto.WireBytes {
@@ -145,7 +167,7 @@ func _Notice_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer)
 		}
 		msg := new(AppInst)
 		err := b.DecodeMessage(msg)
-		m.Data = &Notice_AppInst{msg}
+		m.Data = &NoticeReply_AppInst{msg}
 		return true, err
 	case 5: // data.cloudlet
 		if wire != proto.WireBytes {
@@ -153,23 +175,23 @@ func _Notice_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer)
 		}
 		msg := new(Cloudlet)
 		err := b.DecodeMessage(msg)
-		m.Data = &Notice_Cloudlet{msg}
+		m.Data = &NoticeReply_Cloudlet{msg}
 		return true, err
 	default:
 		return false, nil
 	}
 }
 
-func _Notice_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Notice)
+func _NoticeReply_OneofSizer(msg proto.Message) (n int) {
+	m := msg.(*NoticeReply)
 	// data
 	switch x := m.Data.(type) {
-	case *Notice_AppInst:
+	case *NoticeReply_AppInst:
 		s := proto.Size(x.AppInst)
 		n += proto.SizeVarint(4<<3 | proto.WireBytes)
 		n += proto.SizeVarint(uint64(s))
 		n += s
-	case *Notice_Cloudlet:
+	case *NoticeReply_Cloudlet:
 		s := proto.Size(x.Cloudlet)
 		n += proto.SizeVarint(5<<3 | proto.WireBytes)
 		n += proto.SizeVarint(uint64(s))
@@ -181,22 +203,27 @@ func _Notice_OneofSizer(msg proto.Message) (n int) {
 	return n
 }
 
-type NoticeReply struct {
+type NoticeRequest struct {
 	// action
 	Action NoticeAction `protobuf:"varint,1,opt,name=action,proto3,enum=edgeproto.NoticeAction" json:"action,omitempty"`
 	// protocol version supported by receiver
 	Version uint32 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
+	// client requestor type
+	Requestor NoticeRequestor `protobuf:"varint,3,opt,name=requestor,proto3,enum=edgeproto.NoticeRequestor" json:"requestor,omitempty"`
+	// revision of database
+	Revision uint64 `protobuf:"varint,4,opt,name=revision,proto3" json:"revision,omitempty"`
 }
 
-func (m *NoticeReply) Reset()                    { *m = NoticeReply{} }
-func (m *NoticeReply) String() string            { return proto.CompactTextString(m) }
-func (*NoticeReply) ProtoMessage()               {}
-func (*NoticeReply) Descriptor() ([]byte, []int) { return fileDescriptorNotice, []int{1} }
+func (m *NoticeRequest) Reset()                    { *m = NoticeRequest{} }
+func (m *NoticeRequest) String() string            { return proto.CompactTextString(m) }
+func (*NoticeRequest) ProtoMessage()               {}
+func (*NoticeRequest) Descriptor() ([]byte, []int) { return fileDescriptorNotice, []int{1} }
 
 func init() {
-	proto.RegisterType((*Notice)(nil), "edgeproto.Notice")
 	proto.RegisterType((*NoticeReply)(nil), "edgeproto.NoticeReply")
+	proto.RegisterType((*NoticeRequest)(nil), "edgeproto.NoticeRequest")
 	proto.RegisterEnum("edgeproto.NoticeAction", NoticeAction_name, NoticeAction_value)
+	proto.RegisterEnum("edgeproto.NoticeRequestor", NoticeRequestor_name, NoticeRequestor_value)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -210,7 +237,7 @@ const _ = grpc.SupportPackageIsVersion4
 // Client API for NotifyApi service
 
 type NotifyApiClient interface {
-	// Send update is used to send database changes to other nodes
+	// Stream notice sends info from Server to Client
 	StreamNotice(ctx context.Context, opts ...grpc.CallOption) (NotifyApi_StreamNoticeClient, error)
 }
 
@@ -232,7 +259,7 @@ func (c *notifyApiClient) StreamNotice(ctx context.Context, opts ...grpc.CallOpt
 }
 
 type NotifyApi_StreamNoticeClient interface {
-	Send(*Notice) error
+	Send(*NoticeRequest) error
 	Recv() (*NoticeReply, error)
 	grpc.ClientStream
 }
@@ -241,7 +268,7 @@ type notifyApiStreamNoticeClient struct {
 	grpc.ClientStream
 }
 
-func (x *notifyApiStreamNoticeClient) Send(m *Notice) error {
+func (x *notifyApiStreamNoticeClient) Send(m *NoticeRequest) error {
 	return x.ClientStream.SendMsg(m)
 }
 
@@ -256,7 +283,7 @@ func (x *notifyApiStreamNoticeClient) Recv() (*NoticeReply, error) {
 // Server API for NotifyApi service
 
 type NotifyApiServer interface {
-	// Send update is used to send database changes to other nodes
+	// Stream notice sends info from Server to Client
 	StreamNotice(NotifyApi_StreamNoticeServer) error
 }
 
@@ -270,7 +297,7 @@ func _NotifyApi_StreamNotice_Handler(srv interface{}, stream grpc.ServerStream) 
 
 type NotifyApi_StreamNoticeServer interface {
 	Send(*NoticeReply) error
-	Recv() (*Notice, error)
+	Recv() (*NoticeRequest, error)
 	grpc.ServerStream
 }
 
@@ -282,8 +309,8 @@ func (x *notifyApiStreamNoticeServer) Send(m *NoticeReply) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func (x *notifyApiStreamNoticeServer) Recv() (*Notice, error) {
-	m := new(Notice)
+func (x *notifyApiStreamNoticeServer) Recv() (*NoticeRequest, error) {
+	m := new(NoticeRequest)
 	if err := x.ServerStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
@@ -305,74 +332,6 @@ var _NotifyApi_serviceDesc = grpc.ServiceDesc{
 	Metadata: "notice.proto",
 }
 
-func (m *Notice) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *Notice) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if m.Action != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintNotice(dAtA, i, uint64(m.Action))
-	}
-	if m.ConnectionId != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintNotice(dAtA, i, uint64(m.ConnectionId))
-	}
-	if m.Version != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintNotice(dAtA, i, uint64(m.Version))
-	}
-	if m.Data != nil {
-		nn1, err := m.Data.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += nn1
-	}
-	return i, nil
-}
-
-func (m *Notice_AppInst) MarshalTo(dAtA []byte) (int, error) {
-	i := 0
-	if m.AppInst != nil {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintNotice(dAtA, i, uint64(m.AppInst.Size()))
-		n2, err := m.AppInst.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n2
-	}
-	return i, nil
-}
-func (m *Notice_Cloudlet) MarshalTo(dAtA []byte) (int, error) {
-	i := 0
-	if m.Cloudlet != nil {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintNotice(dAtA, i, uint64(m.Cloudlet.Size()))
-		n3, err := m.Cloudlet.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n3
-	}
-	return i, nil
-}
 func (m *NoticeReply) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -394,9 +353,82 @@ func (m *NoticeReply) MarshalTo(dAtA []byte) (int, error) {
 		i = encodeVarintNotice(dAtA, i, uint64(m.Action))
 	}
 	if m.Version != 0 {
+		dAtA[i] = 0x18
+		i++
+		i = encodeVarintNotice(dAtA, i, uint64(m.Version))
+	}
+	if m.Data != nil {
+		nn1, err := m.Data.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += nn1
+	}
+	return i, nil
+}
+
+func (m *NoticeReply_AppInst) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.AppInst != nil {
+		dAtA[i] = 0x22
+		i++
+		i = encodeVarintNotice(dAtA, i, uint64(m.AppInst.Size()))
+		n2, err := m.AppInst.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	return i, nil
+}
+func (m *NoticeReply_Cloudlet) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Cloudlet != nil {
+		dAtA[i] = 0x2a
+		i++
+		i = encodeVarintNotice(dAtA, i, uint64(m.Cloudlet.Size()))
+		n3, err := m.Cloudlet.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
+	}
+	return i, nil
+}
+func (m *NoticeRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NoticeRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Action != 0 {
+		dAtA[i] = 0x8
+		i++
+		i = encodeVarintNotice(dAtA, i, uint64(m.Action))
+	}
+	if m.Version != 0 {
 		dAtA[i] = 0x10
 		i++
 		i = encodeVarintNotice(dAtA, i, uint64(m.Version))
+	}
+	if m.Requestor != 0 {
+		dAtA[i] = 0x18
+		i++
+		i = encodeVarintNotice(dAtA, i, uint64(m.Requestor))
+	}
+	if m.Revision != 0 {
+		dAtA[i] = 0x20
+		i++
+		i = encodeVarintNotice(dAtA, i, uint64(m.Revision))
 	}
 	return i, nil
 }
@@ -410,25 +442,23 @@ func encodeVarintNotice(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
-func (m *Notice) CopyInFields(src *Notice) {
-	m.Action = src.Action
-	m.ConnectionId = src.ConnectionId
-	m.Version = src.Version
-}
-
 func (m *NoticeReply) CopyInFields(src *NoticeReply) {
 	m.Action = src.Action
 	m.Version = src.Version
 }
 
-func (m *Notice) Size() (n int) {
+func (m *NoticeRequest) CopyInFields(src *NoticeRequest) {
+	m.Action = src.Action
+	m.Version = src.Version
+	m.Requestor = src.Requestor
+	m.Revision = src.Revision
+}
+
+func (m *NoticeReply) Size() (n int) {
 	var l int
 	_ = l
 	if m.Action != 0 {
 		n += 1 + sovNotice(uint64(m.Action))
-	}
-	if m.ConnectionId != 0 {
-		n += 1 + sovNotice(uint64(m.ConnectionId))
 	}
 	if m.Version != 0 {
 		n += 1 + sovNotice(uint64(m.Version))
@@ -439,7 +469,7 @@ func (m *Notice) Size() (n int) {
 	return n
 }
 
-func (m *Notice_AppInst) Size() (n int) {
+func (m *NoticeReply_AppInst) Size() (n int) {
 	var l int
 	_ = l
 	if m.AppInst != nil {
@@ -448,7 +478,7 @@ func (m *Notice_AppInst) Size() (n int) {
 	}
 	return n
 }
-func (m *Notice_Cloudlet) Size() (n int) {
+func (m *NoticeReply_Cloudlet) Size() (n int) {
 	var l int
 	_ = l
 	if m.Cloudlet != nil {
@@ -457,7 +487,7 @@ func (m *Notice_Cloudlet) Size() (n int) {
 	}
 	return n
 }
-func (m *NoticeReply) Size() (n int) {
+func (m *NoticeRequest) Size() (n int) {
 	var l int
 	_ = l
 	if m.Action != 0 {
@@ -465,6 +495,12 @@ func (m *NoticeReply) Size() (n int) {
 	}
 	if m.Version != 0 {
 		n += 1 + sovNotice(uint64(m.Version))
+	}
+	if m.Requestor != 0 {
+		n += 1 + sovNotice(uint64(m.Requestor))
+	}
+	if m.Revision != 0 {
+		n += 1 + sovNotice(uint64(m.Revision))
 	}
 	return n
 }
@@ -482,7 +518,7 @@ func sovNotice(x uint64) (n int) {
 func sozNotice(x uint64) (n int) {
 	return sovNotice(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *Notice) Unmarshal(dAtA []byte) error {
+func (m *NoticeReply) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -505,10 +541,10 @@ func (m *Notice) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Notice: wiretype end group for non-group")
+			return fmt.Errorf("proto: NoticeReply: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Notice: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: NoticeReply: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -526,25 +562,6 @@ func (m *Notice) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.Action |= (NoticeAction(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ConnectionId", wireType)
-			}
-			m.ConnectionId = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowNotice
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.ConnectionId |= (uint64(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -598,7 +615,7 @@ func (m *Notice) Unmarshal(dAtA []byte) error {
 			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.Data = &Notice_AppInst{v}
+			m.Data = &NoticeReply_AppInst{v}
 			iNdEx = postIndex
 		case 5:
 			if wireType != 2 {
@@ -630,7 +647,7 @@ func (m *Notice) Unmarshal(dAtA []byte) error {
 			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.Data = &Notice_Cloudlet{v}
+			m.Data = &NoticeReply_Cloudlet{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -653,7 +670,7 @@ func (m *Notice) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *NoticeReply) Unmarshal(dAtA []byte) error {
+func (m *NoticeRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -676,10 +693,10 @@ func (m *NoticeReply) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: NoticeReply: wiretype end group for non-group")
+			return fmt.Errorf("proto: NoticeRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: NoticeReply: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: NoticeRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -716,6 +733,44 @@ func (m *NoticeReply) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.Version |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Requestor", wireType)
+			}
+			m.Requestor = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowNotice
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Requestor |= (NoticeRequestor(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Revision", wireType)
+			}
+			m.Revision = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowNotice
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Revision |= (uint64(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -849,31 +904,35 @@ var (
 func init() { proto.RegisterFile("notice.proto", fileDescriptorNotice) }
 
 var fileDescriptorNotice = []byte{
-	// 413 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x91, 0x41, 0x6b, 0xdb, 0x30,
-	0x1c, 0xc5, 0xad, 0xd4, 0x73, 0xda, 0x7f, 0xb2, 0xce, 0xd3, 0x60, 0x33, 0x61, 0x84, 0x90, 0x93,
-	0x19, 0xd4, 0xde, 0xb2, 0xcb, 0x6e, 0xc3, 0x5d, 0x04, 0x0d, 0x04, 0x77, 0x38, 0xdd, 0xd8, 0xad,
-	0xc8, 0xb6, 0xea, 0x19, 0x1c, 0x49, 0xc4, 0xca, 0x58, 0xbf, 0x61, 0x8f, 0xfb, 0x08, 0x9b, 0x3f,
-	0xc9, 0xb0, 0x6c, 0x07, 0x97, 0x9c, 0x7a, 0x31, 0xef, 0xe9, 0xff, 0x7b, 0x7f, 0xeb, 0x21, 0x18,
-	0x73, 0xa1, 0xf2, 0x84, 0x79, 0x72, 0x27, 0x94, 0xc0, 0x67, 0x2c, 0xcd, 0x98, 0x96, 0x93, 0xb7,
-	0x99, 0x10, 0x59, 0xc1, 0x7c, 0x2a, 0x73, 0x9f, 0x72, 0x2e, 0x14, 0x55, 0xb9, 0xe0, 0x65, 0x03,
-	0x4e, 0x3e, 0x65, 0xb9, 0xfa, 0xb9, 0x8f, 0xbd, 0x44, 0x6c, 0xfd, 0xad, 0x88, 0xf3, 0xa2, 0x0e,
-	0xfe, 0xf6, 0xeb, 0xef, 0x45, 0x52, 0x88, 0x7d, 0xea, 0x6b, 0x2e, 0x63, 0xfc, 0x20, 0xda, 0xe4,
-	0x39, 0x95, 0xf2, 0x36, 0xe7, 0xa5, 0xea, 0xbc, 0xc6, 0x0b, 0xd6, 0xf9, 0x8b, 0xde, 0xe6, 0x4c,
-	0x64, 0xa2, 0xc9, 0xc7, 0xfb, 0x3b, 0xed, 0xb4, 0xd1, 0xaa, 0xc1, 0xe7, 0x15, 0x02, 0x2b, 0xd4,
-	0x15, 0xb0, 0x0f, 0x16, 0x4d, 0xea, 0x4b, 0x3a, 0x68, 0x86, 0xdc, 0xf3, 0xc5, 0x1b, 0xef, 0xd0,
-	0xc6, 0x6b, 0x90, 0x40, 0x8f, 0xa3, 0x16, 0xc3, 0x73, 0x18, 0x27, 0x82, 0x73, 0xa6, 0xdd, 0x2a,
-	0x75, 0x06, 0x33, 0xe4, 0x9a, 0xd1, 0xa3, 0x33, 0xec, 0xc0, 0xf0, 0x17, 0xdb, 0x95, 0xf5, 0xd6,
-	0x93, 0x19, 0x72, 0x9f, 0x47, 0x9d, 0xc5, 0x1e, 0x0c, 0xa9, 0x94, 0x2b, 0x5e, 0x2a, 0xc7, 0x9c,
-	0x21, 0x77, 0xb4, 0xc0, 0xbd, 0xff, 0x05, 0xcd, 0xe4, 0xca, 0x88, 0x3a, 0x08, 0x7f, 0x80, 0xd3,
-	0xae, 0xaa, 0xf3, 0x4c, 0x07, 0x5e, 0xf5, 0x02, 0x5f, 0xda, 0xd1, 0x95, 0x11, 0x1d, 0xb0, 0x4b,
-	0x0b, 0xcc, 0x94, 0x2a, 0x3a, 0xff, 0x01, 0xa3, 0xa6, 0x40, 0xc4, 0x64, 0x71, 0xff, 0xf4, 0xa2,
-	0xbd, 0x12, 0x83, 0x47, 0x25, 0xde, 0x85, 0x30, 0xee, 0x27, 0xf0, 0x29, 0x98, 0xe1, 0x75, 0x48,
-	0x6c, 0x03, 0x03, 0x58, 0xdf, 0xbe, 0x2e, 0x83, 0x1b, 0x62, 0xa3, 0x5a, 0x2f, 0xc9, 0x9a, 0xdc,
-	0x10, 0x7b, 0x80, 0x47, 0x30, 0xfc, 0x4e, 0xa2, 0xcd, 0xea, 0x3a, 0xb4, 0x4f, 0xf0, 0x0b, 0x18,
-	0x6d, 0x48, 0xb8, 0x0c, 0xd6, 0xeb, 0x5b, 0x12, 0x2e, 0x6d, 0x73, 0xb1, 0x86, 0xb3, 0x7a, 0xdf,
-	0xdd, 0x7d, 0x20, 0x73, 0xfc, 0x19, 0xc6, 0x1b, 0xb5, 0x63, 0x74, 0xdb, 0x3e, 0xd0, 0xcb, 0xa3,
-	0x7b, 0x4e, 0x5e, 0x1f, 0x1d, 0xe9, 0x8a, 0x73, 0xc3, 0x45, 0xef, 0xd1, 0xa5, 0xfd, 0xf0, 0x6f,
-	0x6a, 0x3c, 0x54, 0x53, 0xf4, 0xa7, 0x9a, 0xa2, 0xbf, 0xd5, 0x14, 0xc5, 0x96, 0x46, 0x3f, 0xfe,
-	0x0f, 0x00, 0x00, 0xff, 0xff, 0x0c, 0xf1, 0x04, 0xc2, 0xb7, 0x02, 0x00, 0x00,
+	// 466 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x90, 0xcf, 0x6e, 0xd3, 0x40,
+	0x10, 0xc6, 0xbd, 0xa9, 0xc9, 0x9f, 0x49, 0x9a, 0x5a, 0x5b, 0xa9, 0xb5, 0x2c, 0x14, 0x45, 0x39,
+	0x45, 0x95, 0x6a, 0x43, 0xb8, 0xf4, 0xea, 0xd6, 0x46, 0xad, 0x94, 0xba, 0x68, 0x53, 0x38, 0x70,
+	0xa9, 0x36, 0xc9, 0xd6, 0x58, 0x72, 0xbc, 0x8b, 0xbd, 0xa9, 0xc8, 0x5b, 0xf1, 0x0e, 0x5c, 0x7a,
+	0xe4, 0x11, 0x20, 0x4f, 0x82, 0xbc, 0x8e, 0x83, 0x49, 0xe0, 0xc4, 0xc5, 0x9a, 0x6f, 0xe6, 0xf7,
+	0x8d, 0xe7, 0x5b, 0xe8, 0x24, 0x5c, 0x46, 0x33, 0x66, 0x8b, 0x94, 0x4b, 0x8e, 0x5b, 0x6c, 0x1e,
+	0x32, 0x55, 0x5a, 0x2f, 0x43, 0xce, 0xc3, 0x98, 0x39, 0x54, 0x44, 0x0e, 0x4d, 0x12, 0x2e, 0xa9,
+	0x8c, 0x78, 0x92, 0x15, 0xa0, 0x75, 0x11, 0x46, 0xf2, 0xd3, 0x72, 0x6a, 0xcf, 0xf8, 0xc2, 0x59,
+	0xf0, 0x69, 0x14, 0xe7, 0xc6, 0x2f, 0x4e, 0xfe, 0x3d, 0x9f, 0xc5, 0x7c, 0x39, 0x77, 0x14, 0x17,
+	0xb2, 0x64, 0x5b, 0x6c, 0x9c, 0x5d, 0x2a, 0xc4, 0x43, 0x94, 0x64, 0xb2, 0xd4, 0x0a, 0x8f, 0x59,
+	0xa9, 0xcf, 0x2b, 0x9b, 0x43, 0x1e, 0xf2, 0xc2, 0x3f, 0x5d, 0x3e, 0x2a, 0xa5, 0x84, 0xaa, 0x0a,
+	0x7c, 0xf0, 0x0d, 0x41, 0x3b, 0x50, 0x11, 0x08, 0x13, 0xf1, 0x0a, 0x3b, 0x50, 0xa7, 0xb3, 0xfc,
+	0x52, 0x13, 0xf5, 0xd1, 0xb0, 0x3b, 0x3a, 0xb5, 0xb7, 0x91, 0xec, 0x82, 0x73, 0xd5, 0x98, 0x6c,
+	0x30, 0x6c, 0x42, 0xe3, 0x89, 0xa5, 0x59, 0xee, 0x38, 0xe8, 0xa3, 0xe1, 0x21, 0x29, 0x25, 0xb6,
+	0xa1, 0x41, 0x85, 0xb8, 0x49, 0x32, 0x69, 0xea, 0x7d, 0x34, 0x6c, 0x8f, 0x70, 0x65, 0x97, 0x5b,
+	0x4c, 0xae, 0x35, 0x52, 0x42, 0xf8, 0x35, 0x34, 0xcb, 0x2c, 0xe6, 0x0b, 0x65, 0x38, 0xae, 0x18,
+	0xae, 0x36, 0xa3, 0x6b, 0x8d, 0x6c, 0xb1, 0xcb, 0x3a, 0xe8, 0x73, 0x2a, 0xe9, 0xe0, 0x2b, 0x82,
+	0xc3, 0x32, 0xc5, 0xe7, 0x25, 0xcb, 0xe4, 0x7f, 0xe5, 0xa8, 0xfd, 0x99, 0xe3, 0x02, 0x5a, 0x69,
+	0xb1, 0x95, 0xa7, 0x2a, 0x63, 0x77, 0x64, 0xed, 0x6d, 0x23, 0x25, 0x41, 0x7e, 0xc3, 0xd8, 0x82,
+	0x66, 0xca, 0x9e, 0x22, 0xb5, 0x34, 0x7f, 0x02, 0x9d, 0x6c, 0xf5, 0x59, 0x00, 0x9d, 0xea, 0x1d,
+	0xb8, 0x09, 0x7a, 0x70, 0x17, 0xf8, 0x86, 0x86, 0x01, 0xea, 0xef, 0xdf, 0x79, 0xee, 0xbd, 0x6f,
+	0xa0, 0xbc, 0xf6, 0xfc, 0xb1, 0x7f, 0xef, 0x1b, 0x35, 0xdc, 0x86, 0xc6, 0x07, 0x9f, 0x4c, 0x6e,
+	0xee, 0x02, 0xe3, 0x00, 0x1f, 0x41, 0x7b, 0xe2, 0x07, 0x9e, 0x3b, 0x1e, 0x3f, 0xf8, 0x81, 0x67,
+	0xe8, 0x67, 0x1f, 0xe1, 0x68, 0xe7, 0x12, 0x7c, 0x0a, 0xc7, 0x3b, 0xad, 0x80, 0x27, 0xcc, 0xd0,
+	0xf0, 0x09, 0xe0, 0x9d, 0x81, 0x77, 0x9b, 0xff, 0x6d, 0xbf, 0x7f, 0x45, 0x6e, 0x8d, 0xda, 0x68,
+	0x02, 0xad, 0xbc, 0xff, 0xb8, 0x72, 0x45, 0x84, 0xdf, 0x42, 0x67, 0x22, 0x53, 0x46, 0x17, 0x05,
+	0x8a, 0xcd, 0x7f, 0xbd, 0x85, 0x75, 0xf2, 0x97, 0x89, 0x88, 0x57, 0x03, 0x6d, 0x88, 0x5e, 0xa1,
+	0x4b, 0xe3, 0xf9, 0x67, 0x4f, 0x7b, 0x5e, 0xf7, 0xd0, 0xf7, 0x75, 0x0f, 0xfd, 0x58, 0xf7, 0xd0,
+	0xb4, 0xae, 0xd0, 0x37, 0xbf, 0x02, 0x00, 0x00, 0xff, 0xff, 0xbe, 0x3e, 0x96, 0x72, 0x54, 0x03,
+	0x00, 0x00,
 }

--- a/edgeproto/notice.proto
+++ b/edgeproto/notice.proto
@@ -17,11 +17,15 @@ enum NoticeAction {
   SENDALL_END = 4;
 }
 
-message Notice {
+enum NoticeRequestor {
+  NoticeRequestorNone = 0;
+  NoticeRequestorDME = 1;
+  NoticeRequestorCRM = 2;
+}
+
+message NoticeReply {
   // action to perform
   NoticeAction action = 1;
-  // connect count, used to ignore invalid buffered messages
-  uint64 connectionId = 2;
   // protocol version supported by sender
   uint32 version = 3;
   // data included (for UPDATE and DELETE)
@@ -31,14 +35,18 @@ message Notice {
   }
 }
 
-message NoticeReply {
+message NoticeRequest {
   // action
   NoticeAction action = 1;
   // protocol version supported by receiver
   uint32 version = 2;
+  // client requestor type
+  NoticeRequestor requestor = 3;
+  // revision of database
+  uint64 revision = 4;
 }
 
 service NotifyApi {
-  // Send update is used to send database changes to other nodes
-  rpc StreamNotice(stream Notice) returns (stream NoticeReply) {}
+  // Stream notice sends info from Server to Client
+  rpc StreamNotice(stream NoticeRequest) returns (stream NoticeReply) {}
 }

--- a/gencmd/app.cmd.go
+++ b/gencmd/app.cmd.go
@@ -28,8 +28,8 @@ It has these top-level messages:
 	DeveloperKey
 	Developer
 	Loc
-	Notice
 	NoticeReply
+	NoticeRequest
 	OperatorCode
 	OperatorKey
 	Operator

--- a/gencmd/cloud-resource-manager.cmd.go
+++ b/gencmd/cloud-resource-manager.cmd.go
@@ -25,11 +25,11 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 var CloudResourceManagerCmd edgeproto.CloudResourceManagerClient
-var EdgeCloudApplicationIn edgeproto.EdgeCloudApplication
-var EdgeCloudApplicationFlagSet = pflag.NewFlagSet("EdgeCloudApplication", pflag.ExitOnError)
 var CloudResourceIn edgeproto.CloudResource
 var CloudResourceFlagSet = pflag.NewFlagSet("CloudResource", pflag.ExitOnError)
 var CloudResourceInCategory string
+var EdgeCloudApplicationIn edgeproto.EdgeCloudApplication
+var EdgeCloudApplicationFlagSet = pflag.NewFlagSet("EdgeCloudApplication", pflag.ExitOnError)
 
 func CloudResourceSlicer(in *edgeproto.CloudResource) []string {
 	s := make([]string, 0, 6)

--- a/gencmd/notice.cmd.go
+++ b/gencmd/notice.cmd.go
@@ -20,33 +20,35 @@ var _ = math.Inf
 // Auto-generated code: DO NOT EDIT
 var NotifyApiCmd edgeproto.NotifyApiClient
 
-func NoticeSlicer(in *edgeproto.Notice) []string {
-	s := make([]string, 0, 5)
-	s = append(s, edgeproto.NoticeAction_name[int32(in.Action)])
-	s = append(s, strconv.FormatUint(uint64(in.ConnectionId), 10))
-	s = append(s, strconv.FormatUint(uint64(in.Version), 10))
-	return s
-}
-
-func NoticeHeaderSlicer() []string {
-	s := make([]string, 0, 5)
-	s = append(s, "Action")
-	s = append(s, "ConnectionId")
-	s = append(s, "Version")
-	return s
-}
-
 func NoticeReplySlicer(in *edgeproto.NoticeReply) []string {
-	s := make([]string, 0, 2)
+	s := make([]string, 0, 4)
 	s = append(s, edgeproto.NoticeAction_name[int32(in.Action)])
 	s = append(s, strconv.FormatUint(uint64(in.Version), 10))
 	return s
 }
 
 func NoticeReplyHeaderSlicer() []string {
-	s := make([]string, 0, 2)
+	s := make([]string, 0, 4)
 	s = append(s, "Action")
 	s = append(s, "Version")
+	return s
+}
+
+func NoticeRequestSlicer(in *edgeproto.NoticeRequest) []string {
+	s := make([]string, 0, 4)
+	s = append(s, edgeproto.NoticeAction_name[int32(in.Action)])
+	s = append(s, strconv.FormatUint(uint64(in.Version), 10))
+	s = append(s, edgeproto.NoticeRequestor_name[int32(in.Requestor)])
+	s = append(s, strconv.FormatUint(uint64(in.Revision), 10))
+	return s
+}
+
+func NoticeRequestHeaderSlicer() []string {
+	s := make([]string, 0, 4)
+	s = append(s, "Action")
+	s = append(s, "Version")
+	s = append(s, "Requestor")
+	s = append(s, "Revision")
 	return s
 }
 

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -47,17 +47,16 @@ func (p *EtcdLocal) ResetData() error {
 // ControllerLocal
 
 type ControllerLocal struct {
-	Name         string
-	EtcdAddrs    string
-	ApiAddr      string
-	HttpAddr     string
-	MatcherAddrs string
-	CRMAddrs     string
-	cmd          *exec.Cmd
+	Name       string
+	EtcdAddrs  string
+	ApiAddr    string
+	HttpAddr   string
+	NotifyAddr string
+	cmd        *exec.Cmd
 }
 
 func (p *ControllerLocal) Start(opts ...StartOp) error {
-	args := []string{"--etcdUrls", p.EtcdAddrs, "--matcherAddrs", p.MatcherAddrs, "--crmAddrs", p.CRMAddrs}
+	args := []string{"--etcdUrls", p.EtcdAddrs, "--notifyAddr", p.NotifyAddr}
 	if p.ApiAddr != "" {
 		args = append(args, "--apiAddr")
 		args = append(args, p.ApiAddr)
@@ -102,13 +101,13 @@ func (p *ControllerLocal) ConnectAPI(timeout time.Duration) (*grpc.ClientConn, e
 // DmeLocal
 
 type DmeLocal struct {
-	Name       string
-	NotifyAddr string
-	cmd        *exec.Cmd
+	Name        string
+	NotifyAddrs string
+	cmd         *exec.Cmd
 }
 
 func (p *DmeLocal) Start() error {
-	args := []string{"--notifyAddr", p.NotifyAddr}
+	args := []string{"--notifyAddrs", p.NotifyAddrs}
 	var err error
 	p.cmd, err = StartLocal(p.Name, "dme-server", args)
 	return err
@@ -126,13 +125,13 @@ func (p *DmeLocal) ConnectAPI() (*grpc.ClientConn, error) {
 // CrmLocal
 
 type CrmLocal struct {
-	Name       string
-	NotifyAddr string
-	cmd        *exec.Cmd
+	Name        string
+	NotifyAddrs string
+	cmd         *exec.Cmd
 }
 
 func (p *CrmLocal) Start() error {
-	args := []string{"--notifyAddr", p.NotifyAddr}
+	args := []string{"--notifyAddrs", p.NotifyAddrs}
 	var err error
 	p.cmd, err = StartLocal(p.Name, "crmserver", args)
 	return err

--- a/integration/setups/local_basic.go
+++ b/integration/setups/local_basic.go
@@ -4,6 +4,7 @@ import "github.com/mobiledgex/edge-cloud/integration/process"
 
 var localBasicEtcdCluster = "etcd1=http://127.0.0.1:30011,etcd2=http://127.0.0.1:30012,etcd3=http://127.0.0.1:30013"
 var localBasicEtcdAddrs = "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
+var localBasicNotifyAddrs = "127.0.0.1:37001,127.0.0.1:37002,127.0.0.1:37003"
 
 var LocalBasic = process.ProcessSetup{
 	Etcds: []process.EtcdProcess{
@@ -31,42 +32,45 @@ var LocalBasic = process.ProcessSetup{
 	},
 	Controllers: []process.ControllerProcess{
 		&process.ControllerLocal{
-			Name:      "ctrl1",
-			EtcdAddrs: localBasicEtcdAddrs,
-			ApiAddr:   "127.0.0.1:35001",
-			HttpAddr:  "127.0.0.1:36001",
+			Name:       "ctrl1",
+			EtcdAddrs:  localBasicEtcdAddrs,
+			ApiAddr:    "127.0.0.1:35001",
+			HttpAddr:   "127.0.0.1:36001",
+			NotifyAddr: "127.0.0.1:37001",
 		},
 		&process.ControllerLocal{
-			Name:      "ctrl2",
-			EtcdAddrs: localBasicEtcdAddrs,
-			ApiAddr:   "127.0.0.1:35002",
-			HttpAddr:  "127.0.0.1:36002",
+			Name:       "ctrl2",
+			EtcdAddrs:  localBasicEtcdAddrs,
+			ApiAddr:    "127.0.0.1:35002",
+			HttpAddr:   "127.0.0.1:36002",
+			NotifyAddr: "127.0.0.1:37002",
 		},
 		&process.ControllerLocal{
-			Name:      "ctrl3",
-			EtcdAddrs: localBasicEtcdAddrs,
-			ApiAddr:   "127.0.0.1:35003",
-			HttpAddr:  "127.0.0.1:36003",
+			Name:       "ctrl3",
+			EtcdAddrs:  localBasicEtcdAddrs,
+			ApiAddr:    "127.0.0.1:35003",
+			HttpAddr:   "127.0.0.1:36003",
+			NotifyAddr: "127.0.0.1:37003",
 		},
 	},
 	Dmes: []process.DmeProcess{
 		&process.DmeLocal{
-			Name:       "dme1",
-			NotifyAddr: "127.0.0.1:31001",
+			Name:        "dme1",
+			NotifyAddrs: localBasicNotifyAddrs,
 		},
 		&process.DmeLocal{
-			Name:       "dme2",
-			NotifyAddr: "127.0.0.1:31002",
+			Name:        "dme2",
+			NotifyAddrs: localBasicNotifyAddrs,
 		},
 	},
 	Crms: []process.CrmProcess{
 		&process.CrmLocal{
-			Name:       "crm1",
-			NotifyAddr: "127.0.0.1:33001",
+			Name:        "crm1",
+			NotifyAddrs: localBasicNotifyAddrs,
 		},
 		&process.CrmLocal{
-			Name:       "crm2",
-			NotifyAddr: "127.0.0.1:33002",
+			Name:        "crm2",
+			NotifyAddrs: localBasicNotifyAddrs,
 		},
 	},
 }

--- a/notify/dummy_notify.go
+++ b/notify/dummy_notify.go
@@ -5,31 +5,30 @@
 package notify
 
 import (
-	"os"
 	"time"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 )
 
-type DummySendHandler struct {
+type DummyServerHandler struct {
 	appInsts  map[edgeproto.AppInstKey]edgeproto.AppInst
 	cloudlets map[edgeproto.CloudletKey]edgeproto.Cloudlet
 }
 
-func NewDummySendHandler() *DummySendHandler {
-	handler := &DummySendHandler{}
+func NewDummyServerHandler() *DummyServerHandler {
+	handler := &DummyServerHandler{}
 	handler.appInsts = make(map[edgeproto.AppInstKey]edgeproto.AppInst)
 	handler.cloudlets = make(map[edgeproto.CloudletKey]edgeproto.Cloudlet)
 	return handler
 }
 
-func (s *DummySendHandler) GetAllAppInstKeys(keys map[edgeproto.AppInstKey]struct{}) {
+func (s *DummyServerHandler) GetAllAppInstKeys(keys map[edgeproto.AppInstKey]struct{}) {
 	for key, _ := range s.appInsts {
 		keys[key] = struct{}{}
 	}
 }
 
-func (s *DummySendHandler) GetAppInst(key *edgeproto.AppInstKey, buf *edgeproto.AppInst) bool {
+func (s *DummyServerHandler) GetAppInst(key *edgeproto.AppInstKey, buf *edgeproto.AppInst) bool {
 	obj, found := s.appInsts[*key]
 	if found {
 		*buf = obj
@@ -37,13 +36,13 @@ func (s *DummySendHandler) GetAppInst(key *edgeproto.AppInstKey, buf *edgeproto.
 	return found
 }
 
-func (s *DummySendHandler) GetAllCloudletKeys(keys map[edgeproto.CloudletKey]struct{}) {
+func (s *DummyServerHandler) GetAllCloudletKeys(keys map[edgeproto.CloudletKey]struct{}) {
 	for key, _ := range s.cloudlets {
 		keys[key] = struct{}{}
 	}
 }
 
-func (s *DummySendHandler) GetCloudlet(key *edgeproto.CloudletKey, buf *edgeproto.Cloudlet) bool {
+func (s *DummyServerHandler) GetCloudlet(key *edgeproto.CloudletKey, buf *edgeproto.Cloudlet) bool {
 	obj, found := s.cloudlets[*key]
 	if found {
 		*buf = obj
@@ -51,55 +50,42 @@ func (s *DummySendHandler) GetCloudlet(key *edgeproto.CloudletKey, buf *edgeprot
 	return found
 }
 
-func (s *DummySendHandler) CreateAppInst(in *edgeproto.AppInst) {
+func (s *DummyServerHandler) CreateAppInst(in *edgeproto.AppInst) {
 	s.appInsts[in.Key] = *in
 	UpdateAppInst(&in.Key)
 }
 
-func (s *DummySendHandler) DeleteAppInst(in *edgeproto.AppInst) {
+func (s *DummyServerHandler) DeleteAppInst(in *edgeproto.AppInst) {
 	delete(s.appInsts, in.Key)
 	UpdateAppInst(&in.Key)
 }
 
-func (s *DummySendHandler) CreateCloudlet(in *edgeproto.Cloudlet) {
+func (s *DummyServerHandler) CreateCloudlet(in *edgeproto.Cloudlet) {
 	s.cloudlets[in.Key] = *in
 	UpdateCloudlet(&in.Key)
 }
 
-func (s *DummySendHandler) DeleteCloudlet(in *edgeproto.Cloudlet) {
+func (s *DummyServerHandler) DeleteCloudlet(in *edgeproto.Cloudlet) {
 	delete(s.cloudlets, in.Key)
 	UpdateCloudlet(&in.Key)
 }
 
-type DummyRecvHandler struct {
+type DummyClientHandler struct {
 	AppInsts           map[edgeproto.AppInstKey]edgeproto.AppInst
 	Cloudlets          map[edgeproto.CloudletKey]edgeproto.Cloudlet
 	NumAppInstUpdates  int
 	NumCloudletUpdates int
 	NumUpdates         int
-	Recv               *NotifyReceiver
 }
 
-func NewDummyRecvHandler() *DummyRecvHandler {
-	handler := &DummyRecvHandler{}
+func NewDummyClientHandler() *DummyClientHandler {
+	handler := &DummyClientHandler{}
 	handler.AppInsts = make(map[edgeproto.AppInstKey]edgeproto.AppInst)
 	handler.Cloudlets = make(map[edgeproto.CloudletKey]edgeproto.Cloudlet)
 	return handler
 }
 
-func (s *DummyRecvHandler) Start(network, addr string) {
-	if network == "unix" {
-		os.Remove(addr)
-	}
-	s.Recv = NewNotifyReceiver(network, addr, s)
-	go s.Recv.Run()
-}
-
-func (s *DummyRecvHandler) Stop() {
-	s.Recv.Stop()
-}
-
-func (s *DummyRecvHandler) HandleSendAllDone(maps *NotifySendAllMaps) {
+func (s *DummyClientHandler) HandleSendAllDone(maps *AllMaps) {
 	for key, _ := range s.AppInsts {
 		if _, ok := maps.AppInsts[key]; !ok {
 			delete(s.AppInsts, key)
@@ -112,7 +98,7 @@ func (s *DummyRecvHandler) HandleSendAllDone(maps *NotifySendAllMaps) {
 	}
 }
 
-func (s *DummyRecvHandler) HandleNotice(notice *edgeproto.Notice) error {
+func (s *DummyClientHandler) HandleNotice(notice *edgeproto.NoticeReply) error {
 	appInst := notice.GetAppInst()
 	if appInst != nil {
 		if notice.Action == edgeproto.NoticeAction_UPDATE {
@@ -135,7 +121,7 @@ func (s *DummyRecvHandler) HandleNotice(notice *edgeproto.Notice) error {
 	return nil
 }
 
-func (s *DummyRecvHandler) WaitForAppInsts(count int) {
+func (s *DummyClientHandler) WaitForAppInsts(count int) {
 	for i := 0; i < 10; i++ {
 		if len(s.AppInsts) == count {
 			break
@@ -144,7 +130,7 @@ func (s *DummyRecvHandler) WaitForAppInsts(count int) {
 	}
 }
 
-func (s *DummyRecvHandler) WaitForCloudlets(count int) {
+func (s *DummyClientHandler) WaitForCloudlets(count int) {
 	for i := 0; i < 10; i++ {
 		if len(s.Cloudlets) == count {
 			break
@@ -153,9 +139,21 @@ func (s *DummyRecvHandler) WaitForCloudlets(count int) {
 	}
 }
 
-func (s *DummyRecvHandler) WaitForConnect(connect uint64) {
+func (s *Client) WaitForConnect(connect uint64) {
 	for i := 0; i < 10; i++ {
-		if s.Recv.GetConnnectionId() == connect {
+		if s.stats.Connects == connect {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func WaitServerCount(count int) {
+	for i := 0; i < 10; i++ {
+		serverMgr.mux.Lock()
+		cnt := len(serverMgr.table)
+		serverMgr.mux.Unlock()
+		if cnt == count {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -1,9 +1,11 @@
 package notify
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/testutil"
 	"github.com/mobiledgex/edge-cloud/util"
 	"github.com/stretchr/testify/assert"
@@ -15,96 +17,129 @@ func TestNotify(t *testing.T) {
 	// override retry time
 	NotifyRetryTime = 10 * time.Millisecond
 
-	// This tests the sender sending notices to
-	// a Receiver. The controller as initialized above is the
-	// sender. The receiver is dummy'd out below.
+	// This tests the server sending notices to
+	// a client.
+	addr := "127.0.0.1:61234"
+	serverAddrs := []string{addr}
 
-	// Set up the sender
-	sendHandler := NewDummySendHandler()
-	InitNotifySenders(sendHandler)
+	// Set up server
+	serverHandler := NewDummyServerHandler()
+	ServerMgrStart(addr, serverHandler)
 
-	// This is the receiver
-	recvHandler := NewDummyRecvHandler()
-	unixSocket := "/var/tmp/testNotify.socket"
-	recvHandler.Start("unix", unixSocket)
+	// Set up client DME
+	dmeHandler := NewDummyClientHandler()
+	clientDME := NewDMEClient(serverAddrs, dmeHandler)
+	go clientDME.Run()
 
-	// Register the receiver so the controller sends notices to it
-	addr := "unix:" + unixSocket
-	RegisterReceiver(addr, NotifyTypeMatcher)
+	// Set up client CRM
+	crmHandler := NewDummyClientHandler()
+	clientCRM := NewCRMClient(serverAddrs, crmHandler)
+	go clientCRM.Run()
+
 	// It takes a little while for the Run thread to start up
 	// Wait until it's connected
-	recvHandler.WaitForConnect(1)
-	assert.Equal(t, 0, len(recvHandler.AppInsts), "num appInsts")
-	assert.Equal(t, 0, recvHandler.NumUpdates, "num updates")
-	assert.Equal(t, uint64(1), recvHandler.Recv.connectionId, "connection id")
-	assert.Equal(t, NotifyVersion, recvHandler.Recv.version, "version")
+	clientDME.WaitForConnect(1)
+	clientCRM.WaitForConnect(1)
+	assert.Equal(t, 0, len(dmeHandler.AppInsts), "num appInsts")
+	assert.Equal(t, 0, dmeHandler.NumUpdates, "num updates")
+	assert.Equal(t, NotifyVersion, clientDME.version, "version")
+	assert.Equal(t, uint64(1), clientDME.stats.Connects, "connects")
+	assert.Equal(t, uint64(1), clientCRM.stats.Connects, "connects")
+	checkServerConnections(t, 2)
 
 	// Create some app insts which will trigger updates
-	sendHandler.CreateAppInst(&testutil.AppInstData[0])
-	sendHandler.CreateAppInst(&testutil.AppInstData[1])
-	sendHandler.CreateAppInst(&testutil.AppInstData[2])
-	recvHandler.WaitForAppInsts(3)
-	assert.Equal(t, 3, len(recvHandler.AppInsts), "num appInsts")
-	assert.Equal(t, 3, recvHandler.NumAppInstUpdates, "num app inst updates")
-	assert.Equal(t, 3, recvHandler.NumUpdates, "num updates")
-	stats := GetNotifySenderStats(addr)
+	serverHandler.CreateAppInst(&testutil.AppInstData[0])
+	serverHandler.CreateAppInst(&testutil.AppInstData[1])
+	serverHandler.CreateAppInst(&testutil.AppInstData[2])
+	dmeHandler.WaitForAppInsts(3)
+	assert.Equal(t, 3, len(dmeHandler.AppInsts), "num appInsts")
+	assert.Equal(t, 3, dmeHandler.NumAppInstUpdates, "num app inst updates")
+	assert.Equal(t, 3, dmeHandler.NumUpdates, "num updates")
+	stats := GetServerStats(clientDME.GetLocalAddr())
 	assert.Equal(t, uint64(3), stats.AppInstsSent)
 
 	// Kill connection out from under the code, forcing reconnect
-	recvHandler.Recv.server.Stop()
+	fmt.Println("DME cancel")
+	clientDME.cancel()
+	// wait for it to reconnect
+	clientDME.WaitForConnect(2)
+	assert.Equal(t, uint64(2), clientDME.stats.Connects, "connects")
+	checkServerConnections(t, 2)
 
-	// Create another app inst to trigger update/reconnect
 	// All cloudlets and all app insts will be sent again
-	sendHandler.CreateAppInst(&testutil.AppInstData[3])
-	recvHandler.WaitForAppInsts(4)
-	assert.Equal(t, 4, len(recvHandler.AppInsts), "num appInsts")
-	assert.Equal(t, 7, recvHandler.NumUpdates, "num updates")
-	stats = GetNotifySenderStats(addr)
-	assert.Equal(t, uint64(2), stats.Connects)
-	assert.Equal(t, uint64(7), stats.AppInstsSent)
+	// Note on server side, this is a new connection so stats are reset
+	serverHandler.CreateAppInst(&testutil.AppInstData[3])
+	dmeHandler.WaitForAppInsts(4)
+	assert.Equal(t, 4, len(dmeHandler.AppInsts), "num appInsts")
+	assert.Equal(t, 7, dmeHandler.NumUpdates, "num updates")
+	stats = GetServerStats(clientDME.GetLocalAddr())
+	assert.Equal(t, uint64(4), stats.AppInstsSent)
 
 	// Delete an inst
-	sendHandler.DeleteAppInst(&testutil.AppInstData[0])
-	recvHandler.WaitForAppInsts(3)
-	assert.Equal(t, 3, len(recvHandler.AppInsts), "num appInsts")
-	assert.Equal(t, 8, recvHandler.NumUpdates, "num updates")
-	assert.Equal(t, 8, recvHandler.NumAppInstUpdates, "num app inst updates")
-	stats = GetNotifySenderStats(addr)
-	assert.Equal(t, uint64(2), stats.Connects)
-	assert.Equal(t, uint64(8), stats.AppInstsSent)
+	serverHandler.DeleteAppInst(&testutil.AppInstData[0])
+	dmeHandler.WaitForAppInsts(3)
+	assert.Equal(t, 3, len(dmeHandler.AppInsts), "num appInsts")
+	assert.Equal(t, 8, dmeHandler.NumUpdates, "num updates")
+	assert.Equal(t, 8, dmeHandler.NumAppInstUpdates, "num app inst updates")
+	stats = GetServerStats(clientDME.GetLocalAddr())
+	assert.Equal(t, uint64(5), stats.AppInstsSent)
 
-	// This time stop receiver, delete an inst, then start the
-	// receiver again. The recvHandler remains the same so none of
+	// Stop DME, check that server closes connection as well
+	fmt.Println("DME stop")
+	clientDME.Stop()
+	WaitServerCount(1)
+	checkServerConnections(t, 1)
+	// reset data in handler, check that is it restored on reconnect
+	dmeHandler.AppInsts = make(map[edgeproto.AppInstKey]edgeproto.AppInst)
+	go clientDME.Run()
+	clientDME.WaitForConnect(3)
+	assert.Equal(t, uint64(3), clientDME.stats.Connects, "connects")
+	dmeHandler.WaitForAppInsts(3)
+	assert.Equal(t, 3, len(dmeHandler.AppInsts), "num appInsts")
+
+	// This time stop server, delete an inst, then start the
+	// receiver again. The dmeHandler remains the same so none of
 	// the data/stats changes. This tests that a delete during
 	// disconnect is properly accounted for during the handling
 	// of the sendall done command by removing the stale entry.
-	recvHandler.Recv.Stop()
-	sendHandler.DeleteAppInst(&testutil.AppInstData[1])
-	recvHandler.Start("unix", unixSocket)
-	recvHandler.WaitForAppInsts(2)
-	assert.Equal(t, 2, len(recvHandler.AppInsts), "num appInsts")
-	assert.Equal(t, 10, recvHandler.NumAppInstUpdates, "num app inst updates")
-	stats = GetNotifySenderStats(addr)
-	assert.Equal(t, uint64(3), stats.Connects)
-	assert.Equal(t, uint64(10), stats.AppInstsSent)
-
-	UnregisterReceiver(addr)
+	fmt.Println("ServerMgr done")
+	ServerMgrDone()
+	serverHandler.DeleteAppInst(&testutil.AppInstData[1])
+	ServerMgrStart(addr, serverHandler)
+	clientDME.WaitForConnect(4)
+	dmeHandler.WaitForAppInsts(2)
+	assert.Equal(t, uint64(4), clientDME.stats.Connects, "connects")
+	assert.Equal(t, 2, len(dmeHandler.AppInsts), "num appInsts")
+	assert.Equal(t, 13, dmeHandler.NumAppInstUpdates, "num app inst updates")
+	stats = GetServerStats(clientDME.GetLocalAddr())
+	assert.Equal(t, uint64(2), stats.AppInstsSent)
 
 	// Now test cloudlets. Use the same receiver, but register it
-	// as a cloudlet mananger
-	RegisterReceiver(addr, NotifyTypeCloudletMgr)
-	recvHandler.WaitForConnect(1)
-	assert.Equal(t, uint64(1), recvHandler.Recv.connectionId, "connection id")
-	sendHandler.CreateCloudlet(&testutil.CloudletData[0])
-	sendHandler.CreateCloudlet(&testutil.CloudletData[1])
-	recvHandler.WaitForCloudlets(2)
-	sendHandler.DeleteCloudlet(&testutil.CloudletData[1])
-	recvHandler.WaitForCloudlets(1)
-	assert.Equal(t, 1, len(recvHandler.Cloudlets), "num cloudlets")
-	assert.Equal(t, 3, recvHandler.NumCloudletUpdates, "num cloudlet updates")
-	stats = GetNotifySenderStats(addr)
+	// as a cloudlet mananger. CRM should have 2 connects since
+	// server was restarted.
+	clientCRM.WaitForConnect(1)
+	assert.Equal(t, uint64(2), clientCRM.stats.Connects, "connects")
+	serverHandler.CreateCloudlet(&testutil.CloudletData[0])
+	serverHandler.CreateCloudlet(&testutil.CloudletData[1])
+	crmHandler.WaitForCloudlets(2)
+	assert.Equal(t, 2, len(crmHandler.Cloudlets), "num cloudlets")
+	serverHandler.DeleteCloudlet(&testutil.CloudletData[1])
+	crmHandler.WaitForCloudlets(1)
+	assert.Equal(t, 1, len(crmHandler.Cloudlets), "num cloudlets")
+	assert.Equal(t, 3, crmHandler.NumCloudletUpdates, "num cloudlet updates")
+	stats = GetServerStats(clientCRM.GetLocalAddr())
 	assert.Equal(t, uint64(3), stats.CloudletsSent, "sent cloudlets")
+	checkServerConnections(t, 2)
 
-	UnregisterReceiver(addr)
-	recvHandler.Stop()
+	clientDME.Stop()
+	clientCRM.Stop()
+}
+
+func checkServerConnections(t *testing.T, expected int) {
+	serverMgr.mux.Lock()
+	for addr, server := range serverMgr.table {
+		util.DebugLog(util.DebugLevelNotify, "server connections", "client", addr, "stats", server.stats)
+	}
+	assert.Equal(t, expected, len(serverMgr.table), "num server connections")
+	serverMgr.mux.Unlock()
 }

--- a/procfiles/Procfile
+++ b/procfiles/Procfile
@@ -1,7 +1,0 @@
-# etcd instances
-etcd1: etcd --name etcd1 --data-dir /var/tmp/edge-cloud-local-cluster/etcd1 --listen-client-urls http://127.0.0.1:30001 --advertise-client-urls http://127.0.0.1:30001 --listen-peer-urls http://127.0.0.1:30011
-etcd2: etcd --name etcd2 --data-dir /var/tmp/edge-cloud-local-cluster/etcd2 --listen-client-urls http://127.0.0.1:30002 --advertise-client-urls http://127.0.0.1:30002 --listen-peer-urls http://127.0.0.1:30012
-etcd3: etcd --name etcd3 --data-dir /var/tmp/edge-cloud-local-cluster/etcd3 --listen-client-urls http://127.0.0.1:30003 --advertise-client-urls http://127.0.0.1:30003 --listen-peer-urls http://127.0.0.1:30013
-ctrl1: controller -r /var/tmp/edge-cloud-local-cluster/controller1 --etcdUrls "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003" --apiAddr "127.0.0.1:40101" --httpAddr "127.0.0.1:50101" --matcherAddrs "127.0.0.1:30021" --crmAddrs "127.0.0.1:30101" -d api,notify,etcd
-dme1: dme-server --notifyAddr "127.0.0.1:30021"
-crm1: crmserver --controller "127.0.0.1:40101" --notifyAddr "127.0.0.1:30101"

--- a/testutil/app_testutil.go
+++ b/testutil/app_testutil.go
@@ -28,8 +28,8 @@ It has these top-level messages:
 	DeveloperKey
 	Developer
 	Loc
-	Notice
 	NoticeReply
+	NoticeRequest
 	OperatorCode
 	OperatorKey
 	Operator


### PR DESCRIPTION
This swaps the client/server relationship of the notify protocol. Previously, the controller was the client and would connect to dme/crms (as servers). The problem was that the controller then needed to keep track of every dme/crm. Dme/crms are expected to be more ephemeral than controllers, so it makes more sense to have the controllers act as servers with static ips/dns entries, and have the dme/crms act as clients. So that's what this change entails. Functionally there is little change, although I have done more testing of thread cleanup on disconnect, and the dme/crm clients are passed an array of controller addresses so can failover to another one if disconnected. I have also put in keepalives in the case of ungraceful disconnect, but that needs more testing.