### PR TITLE
EDGECLOUD-18 - startup CRM and DME with configured ports:

### DIFF
--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -112,6 +112,10 @@ type DmeLocal struct {
 
 func (p *DmeLocal) Start(logfile string) error {
 	args := []string{"--notifyAddrs", p.NotifyAddrs}
+	if p.ApiAddr != "" {
+		args = append(args, "--apiAddr")
+		args = append(args, p.ApiAddr)
+	}
 	var err error
 	p.cmd, err = StartLocal(p.Name, "dme-server", args, logfile)
 	return err
@@ -136,6 +140,10 @@ type CrmLocal struct {
 
 func (p *CrmLocal) Start(logfile string) error {
 	args := []string{"--notifyAddrs", p.NotifyAddrs}
+	if p.ApiAddr != "" {
+		args = append(args, "--apiAddr")
+		args = append(args, p.ApiAddr)
+	}
 	var err error
 	p.cmd, err = StartLocal(p.Name, "crmserver", args, logfile)
 	return err

--- a/setup-env/setup-local/data.yml
+++ b/setup-env/setup-local/data.yml
@@ -11,7 +11,8 @@ cloudlets:
     operatorkey:
        name: TMUS
     name: tmocloud1
-  accessip: [0x0a,0x64,0x0a,0x04] 
+  accessip: [10,100,10,4] 
+  accessip_str: 0a640a04 #for ansible to cli
   location: 
      lat: 99.99
      long: 123.456
@@ -20,7 +21,8 @@ cloudlets:
     operatorkey:
        name: TMUS
     name: tmocloud2
-  accessip: [0x0a,0x64,0x0a,0x05]
+  accessip: [10,100,10,5]
+  accessip_str: 0a640a05 #for ansible to cli
   location:
      lat: 67.89
      long: 11.223
@@ -54,7 +56,8 @@ appinstances:
        name: tmocloud1   
     id: 123
   liveness: 1
-  ip: [0x0a,0x64,0x0a,0x04]
+  ip: [10,100,10,4]
+  ip_str: 0a640a04 #for ansible to cli
   cloudletloc: 
      lat: 55
      long: 66

--- a/setup-env/setup-local/processes-multi.yml
+++ b/setup-env/setup-local/processes-multi.yml
@@ -20,19 +20,19 @@ etcds:
 controllers:
 - name: ctrl1
   etcdaddrs: http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003
-  apiaddr: 127.0.0.1:35001
+  apiaddr: 127.0.0.1:55001
   httpaddr: 127.0.0.1:36001
   notifyaddr: 127.0.0.1:37001
 
 - name: ctrl2
   etcdaddrs: http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003
-  apiaddr: 127.0.0.1:35002
+  apiaddr: 127.0.0.1:55002
   httpaddr: 127.0.0.1:36002
   notifyaddr: 127.0.0.1:37002
 
 - name: ctrl3
   etcdaddrs: http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003
-  apiaddr: 127.0.0.1:35003
+  apiaddr: 127.0.0.1:55003
   httpaddr: 127.0.0.1:36003
   notifyaddr: 127.0.0.1:37003
 
@@ -42,22 +42,22 @@ dmes:
   notifyaddrs: 127.0.0.1:37001,127.0.0.1:37002,127.0.0.1:37003
 
 - name: dme2
-  apiaddr: 127.0.0.1:50051 ## TODO: needs to be configured in dme
+  apiaddr: 127.0.0.1:50052
   notifyaddrs: 127.0.0.1:37001,127.0.0.1:37002,127.0.0.1:37003
 
 - name: dme3
-  apiaddr: 127.0.0.1:50051
+  apiaddr: 127.0.0.1:50053
   notifyaddrs: 127.0.0.1:37001,127.0.0.1:37002,127.0.0.1:37003
 
 crms:
 - name: crm1
-  apiaddr: 127.0.0.1:55099
+  apiaddr: 127.0.0.1:55091
   notifyaddrs: 127.0.0.1:37001,127.0.0.1:37002,127.0.0.1:37003
 
 - name: crm2
-  apiaddr: 127.0.0.1:55099  ##TODO: needs to be configured in crm
+  apiaddr: 127.0.0.1:55092 
   notifyaddrs: 127.0.0.1:37001,127.0.0.1:37002,127.0.0.1:37003
 
 - name: crm3
-  apiaddr: 127.0.0.1:55099
+  apiaddr: 127.0.0.1:55093
   notifyaddrs: 127.0.0.1:37001,127.0.0.1:37002,127.0.0.1:37003

--- a/setup-env/setup-local/processes.yml
+++ b/setup-env/setup-local/processes.yml
@@ -20,7 +20,7 @@ etcds:
 controllers:
 - name: ctrl1
   etcdaddrs: http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003
-  apiaddr: 127.0.0.1:55001
+  apiaddr: 0.0.0.0:55001
   httpaddr: 127.0.0.1:36001
   notifyaddr: 127.0.0.1:37001
 
@@ -31,6 +31,6 @@ dmes:
 
 crms:
 - name: crm1
-  apiaddr: 127.0.0.1:55099
+  apiaddr: 0.0.0.0:55091
   notifyaddrs: 127.0.0.1:37001
 


### PR DESCRIPTION
-  add arguments to startup DME and CRM with bind address if present
- fix bug in setup-local in which the same object was getting used for multiple threads
- update yamls
- as a temp workaround for ansible, add a text based field which can be used by ansible when loading config thru the cli; add workaround to allow unmarshal failures to ignore this.