### PR TITLE
mex_android_lib: MatchEngine cleanup.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
@@ -173,39 +173,34 @@ public class MainActivity extends AppCompatActivity {
             public void onComplete(Task<Location> task) {
                 if (task.isSuccessful() && task.getResult() != null) {
                     Location location = task.getResult();
-                    try {
-
-                        // Location found. Create a request:
-                        AppClient.Match_Engine_Request req = mMatchingEngine.createRequest(
-                                ctx,
-                                location);
-
-                        // Location Verification (Blocking, or use verifyLocationFuture):
-                        AppClient.Match_Engine_Loc_Verify verifiedLocation = mMatchingEngine.verifyLocation(req, 10000);
-                        someText = "[Location Verified: Tower: " + verifiedLocation.getTowerStatus() +
-                                ", GPS LocationStatus: " + verifiedLocation.getGpsLocationStatus() + "]\n";
 
 
-                        // Find the closest cloudlet for your application to use.
-                        // (Blocking call, or use findCloudletFuture):
-                        FindCloudletResponse closestCloudlet = mMatchingEngine.findCloudlet(req, 10000);
-                        // FIXME: It's not possible to get a complete http(s) URI on just a service IP + port!
-                        String serverip = null;
-                        if (closestCloudlet.server != null && closestCloudlet.server.length > 0) {
-                            serverip = closestCloudlet.server[0] + ", ";
-                            for (int i = 1; i < closestCloudlet.server.length-1; i++) {
-                                serverip += closestCloudlet.server[i] + ", ";
-                            }
-                            serverip += closestCloudlet.server[closestCloudlet.server.length-1];
+                    // Location found. Create a request:
+                    AppClient.Match_Engine_Request req = mMatchingEngine.createRequest(
+                            ctx,
+                            location);
+
+                    // Location Verification (Blocking, or use verifyLocationFuture):
+                    AppClient.Match_Engine_Loc_Verify verifiedLocation = mMatchingEngine.verifyLocation(req, 10000);
+                    someText = "[Location Verified: Tower: " + verifiedLocation.getTowerStatus() +
+                            ", GPS LocationStatus: " + verifiedLocation.getGpsLocationStatus() + "]\n";
+
+
+                    // Find the closest cloudlet for your application to use.
+                    // (Blocking call, or use findCloudletFuture):
+                    FindCloudletResponse closestCloudlet = mMatchingEngine.findCloudlet(req, 10000);
+                    // FIXME: It's not possible to get a complete http(s) URI on just a service IP + port!
+                    String serverip = null;
+                    if (closestCloudlet.server != null && closestCloudlet.server.length > 0) {
+                        serverip = closestCloudlet.server[0] + ", ";
+                        for (int i = 1; i < closestCloudlet.server.length-1; i++) {
+                            serverip += closestCloudlet.server[i] + ", ";
                         }
-                        someText += "[Cloudlet Server: [" + serverip + "], Port: " + closestCloudlet.port + "]";
-                        TextView tv = findViewById(R.id.mex_verified_location_content);
-                        tv.setText(someText);
-                    } catch (InterruptedException ie) {
-                        ie.printStackTrace();
-                    } catch (ExecutionException ee) {
-                        ee.printStackTrace();
+                        serverip += closestCloudlet.server[closestCloudlet.server.length-1];
                     }
+                    someText += "[Cloudlet Server: [" + serverip + "], Port: " + closestCloudlet.port + "]";
+                    TextView tv = findViewById(R.id.mex_verified_location_content);
+                    tv.setText(someText);
                 } else {
                     Log.w(TAG, "getLastLocation:exception", task.getException());
                     someText = "Last location not found, or has never been used. Location cannot be verified using 'getLastLocation()'. " +

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -142,13 +142,10 @@ public class MatchingEngine {
         return submit(registerClient);
     }
 
-    public AppClient.Match_Engine_Status registerClient(AppClient.Match_Engine_Request request, long timeoutInMilliseconds)
-            throws InterruptedException, ExecutionException {
+    public AppClient.Match_Engine_Status registerClient(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
         RegisterClient registerClient = new RegisterClient(this);
         registerClient.setRequest(request, timeoutInMilliseconds);
-        Future<AppClient.Match_Engine_Status> responseFuture = submit(registerClient);
-
-        return responseFuture.get();
+        return registerClient.call();
     }
 
     /**
@@ -158,16 +155,10 @@ public class MatchingEngine {
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    public FindCloudletResponse findCloudlet(AppClient.Match_Engine_Request request, long timeoutInMilliseconds)
-            throws InterruptedException, ExecutionException {
-        FindCloudletResponse reply;
-
+    public FindCloudletResponse findCloudlet(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
         FindCloudlet findCloudlet = new FindCloudlet(this);
         findCloudlet.setRequest(request, timeoutInMilliseconds);
-
-        Future<FindCloudletResponse> response = submit(findCloudlet);
-        reply = response.get();
-        return reply;
+        return findCloudlet.call();
     }
 
     /**
@@ -190,14 +181,10 @@ public class MatchingEngine {
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    public AppClient.Match_Engine_Loc_Verify verifyLocation(AppClient.Match_Engine_Request request, long timeoutInMilliseconds)
-                    throws InterruptedException, ExecutionException {
-
+    public AppClient.Match_Engine_Loc_Verify verifyLocation(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
         VerifyLocation verifyLocation = new VerifyLocation(this);
         verifyLocation.setRequest(request, timeoutInMilliseconds);
-
-        Future<AppClient.Match_Engine_Loc_Verify> response = submit(verifyLocation);
-        return response.get();
+        return verifyLocation.call();
     }
 
     /**
@@ -218,16 +205,14 @@ public class MatchingEngine {
      * @param timeoutInMilliseconds
      * @return
      */
-    public AppClient.Match_Engine_Loc getLocation(AppClient.Match_Engine_Request request, long timeoutInMilliseconds)
-            throws InterruptedException, ExecutionException {
+    public AppClient.Match_Engine_Loc getLocation(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
         GetLocation getLocation = new GetLocation(this);
         getLocation.setRequest(request, timeoutInMilliseconds);
-        Future<AppClient.Match_Engine_Loc> locFuture = submit(getLocation);
-        return locFuture.get();
+        return getLocation.call();
     }
 
     /**
-     * getLocation returns the network verified location of this device.
+     * getLocation returns the network verified location of this device. Returns a Future.
      * @param request
      * @param timeoutInMilliseconds
      * @return

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
@@ -37,7 +37,7 @@ public class RegisterClient implements Callable {
     @Override
     public AppClient.Match_Engine_Status call() throws MissingRequestException {
         if (mRequest == null) {
-            throw new MissingRequestException("Usage error: RegisterClient() does not have a request object to make location verification call!");
+            throw new MissingRequestException("Usage error: RegisterClient() does not have a request object to make call!");
         }
 
         AppClient.Match_Engine_Status reply;

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocationResponse.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocationResponse.java
@@ -1,4 +1,0 @@
-package com.mobiledgex.matchingengine;
-
-public class VerifyLocationResponse {
-}


### PR DESCRIPTION
- Remove thread use for blocking APIs.
- Add a very basicLatencyTest to test cases.