### PR TITLE
edgectl: yaml display ip as flow

### DIFF
--- a/protoc-gen-cmd/yaml/yaml.go
+++ b/protoc-gen-cmd/yaml/yaml.go
@@ -392,6 +392,12 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 			continue
 		}
 
+		if field.Type.Kind() == reflect.Array || field.Type.Kind() == reflect.Slice {
+			if field.Type.Elem().Kind() == reflect.Uint8 && strings.HasSuffix(field.Name, "Ip") {
+				info.Flow = true
+			}
+		}
+
 		if tag != "" {
 			info.Key = tag
 		} else {


### PR DESCRIPTION
This changes edgectl yaml output for any byte arrays that end in "Ip" to display as:
```
  accessip: [15, 15, 15, 15]
```
Rather than:
```
  accessip:
  - 15
  - 15
  - 15
  - 15
```
Although I expect accessip and such to be replaced with strings for URIs, so this change may not be so useful in the future. But it doesn't hurt.