### PR TITLE
mex_android_lib: Blocking API threaded ExecutionException is now exposed directly as io.gprc.StatusRuntimeException

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -19,16 +19,19 @@ import java.util.concurrent.Future;
 
 import distributed_match_engine.AppClient;
 import distributed_match_engine.LocOuterClass;
+import io.grpc.StatusRuntimeException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import android.location.Location;
-
 import android.util.Log;
+
 
 @RunWith(AndroidJUnit4.class)
 public class EngineCallTest {
+    public static final String TAG = "EngineCallTest";
+    public static final long GRPC_TIMEOUT_MS = 100;
 
     FusedLocationProviderClient fusedLocationClient;
 
@@ -129,34 +132,35 @@ public class EngineCallTest {
         MatchingEngine me = new MatchingEngine();
 
         MexLocation mexLoc = new MexLocation(me);
-        Location location = null;
+        Location location;
         AppClient.Match_Engine_Status response = null;
 
         enableMockLocation(context,true);
         Location loc = createLocation("registerClientTest", -122.149349, 37.459609);
 
         try {
-            // Directly create request for testing:
-            // Passed in Location (which is a callback interface)
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, 10000);
+            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
-            response = me.registerClient(request, 10000);
+            response = me.registerClient(request, GRPC_TIMEOUT_MS);
             assert(response != null);
         } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("registerClientTest Execution Failed!", true);
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("registerClientTest: Execution Failed!", true);
+        } catch (StatusRuntimeException sre) {
+            Log.i(TAG, Log.getStackTraceString(sre));
+            assertFalse("registerClientTest: Execution Failed!", true);
         } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("registerClientTest Execution Interrupted!", true);
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("registerClientTest: Execution Interrupted!", true);
         } finally {
             enableMockLocation(context,false);
         }
 
         // Temporary.
-        System.out.println("registerClientTest response: " + response.toString());
+        Log.i(TAG, "registerClientTest response: " + response.toString());
         assertEquals(response.getVer(), 0);
         assertEquals(response.getToken(), ""); // FIXME: We DO expect a token
         assertEquals(response.getErrorCode(), AppClient.Match_Engine_Status.ME_Status.ME_SUCCESS_VALUE);
@@ -168,36 +172,34 @@ public class EngineCallTest {
         MatchingEngine me = new MatchingEngine();
 
         MexLocation mexLoc = new MexLocation(me);
-        Location location = null;
-        Future<AppClient.Match_Engine_Status> responseFuture = null;
+        Location location;
+        Future<AppClient.Match_Engine_Status> responseFuture;
         AppClient.Match_Engine_Status response = null;
 
         enableMockLocation(context,true);
         Location loc = createLocation("RegisterClientFutureTest", -122.149349, 37.459609);
 
         try {
-            // Directly create request for testing:
-            // Passed in Location (which is a callback interface)
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, 10000);
+            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
-            responseFuture = me.registerClientFuture(request, 10000);
+            responseFuture = me.registerClientFuture(request, GRPC_TIMEOUT_MS);
             response = responseFuture.get();
             assert(response != null);
         } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("registerClientFutureTest Execution Failed!", true);
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("registerClientFutureTest: Execution Failed!", true);
         } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("registerClientFutureTest Execution Interrupted!", true);
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("registerClientFutureTest: Execution Interrupted!", true);
         } finally {
             enableMockLocation(context,false);
         }
 
         // Temporary.
-        System.out.println("registerClientFutureTest() response: " + response.toString());
+        Log.i(TAG, "registerClientFutureTest() response: " + response.toString());
         assertEquals(response.getVer(), 0);
         assertEquals(response.getToken(), ""); // FIXME: We DO expect a token
         assertEquals(response.getErrorCode(), AppClient.Match_Engine_Status.ME_Status.ME_SUCCESS_VALUE);
@@ -205,7 +207,6 @@ public class EngineCallTest {
 
     @Test
     public void findCloudletTest() {
-        // Context of the app under test.
         Context context = InstrumentationRegistry.getTargetContext();
         FindCloudletResponse cloudletResponse = null;
         MatchingEngine me = new MatchingEngine();
@@ -217,17 +218,20 @@ public class EngineCallTest {
         try {
             enableMockLocation(context, true);
             setMockLocation(context, loc);
-            Location location = mexLoc.getBlocking(context, 10000);
+            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
 
-            cloudletResponse = me.findCloudlet(request, 10000);
+            cloudletResponse = me.findCloudlet(request, GRPC_TIMEOUT_MS);
 
         } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("FindCloudlet Execution Failed!", true);
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("FindCloudlet: Execution Failed!", true);
+        } catch (StatusRuntimeException sre) {
+            Log.i(TAG, Log.getStackTraceString(sre));
+            assertFalse("FindCloudlet: Execution Failed!", true);
         } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("FindCloudlet Execution Interrupted!", true);
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("FindCloudlet: Execution Interrupted!", true);
         } finally {
             enableMockLocation(context,false);
         }
@@ -242,9 +246,8 @@ public class EngineCallTest {
 
     @Test
     public void findCloudletFutureTest() {
-        // Context of the app under test.
         Context context = InstrumentationRegistry.getTargetContext();
-        Future<FindCloudletResponse> response = null;
+        Future<FindCloudletResponse> response;
         FindCloudletResponse result = null;
         MatchingEngine me = new MatchingEngine();
         MexLocation mexLoc = new MexLocation(me);
@@ -260,11 +263,11 @@ public class EngineCallTest {
             response = me.findCloudletFuture(request, 10000);
             result = response.get();
         } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("FindCloudletFuture Execution Failed!", true);
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("FindCloudletFuture: Execution Failed!", true);
         } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("FindCloudletFuture Execution Interrupted!", true);
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("FindCloudletFuture: Execution Interrupted!", true);
         }
 
         // Temporary.
@@ -273,7 +276,6 @@ public class EngineCallTest {
 
     @Test
     public void verifyLocationTest() {
-        // Context of the app under test.
         Context context = InstrumentationRegistry.getTargetContext();
 
         MatchingEngine me = new MatchingEngine();
@@ -284,19 +286,22 @@ public class EngineCallTest {
             enableMockLocation(context, true);
             Location mockLoc = createLocation("verifyLocationTest", -122.149349, 37.459609);
             setMockLocation(context, mockLoc);
-            Location location = mexLoc.getBlocking(context, 10000);
+            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
 
             AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
 
 
-            response = me.verifyLocation(request, 10000);
+            response = me.verifyLocation(request, GRPC_TIMEOUT_MS);
             assert(response != null);
         } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("VerifyLocation Execution Failed!", true);
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("VerifyLocation: Execution Failed!", true);
+        } catch (StatusRuntimeException sre) {
+            Log.i(TAG, Log.getStackTraceString(sre));
+            assertFalse("VerifyLocation: Execution Failed!", true);
         } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("VerifyLocation Execution Interrupted!", true);
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("VerifyLocation: Execution Interrupted!", true);
         } finally {
             enableMockLocation(context, false);
         }
@@ -322,18 +327,18 @@ public class EngineCallTest {
             enableMockLocation(context, true);
             Location mockLoc = createLocation("verifyLocationFutureTest", -122.149349, 37.459609);
             setMockLocation(context, mockLoc);
-            Location location = mexLoc.getBlocking(context, 10000);
+            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
 
             AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
 
-            locFuture = me.verifyLocationFuture(request, 10000);
+            locFuture = me.verifyLocationFuture(request, GRPC_TIMEOUT_MS);
             response = locFuture.get();
         } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("verifyLocationFutureTest Execution Failed!", true);
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("verifyLocationFutureTest: Execution Failed!", true);
         } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("verifyLocationFutureTest Execution Interrupted!", true);
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("verifyLocationFutureTest: Execution Interrupted!", true);
         }
 
         // Temporary.
@@ -362,19 +367,19 @@ public class EngineCallTest {
         AppClient.Match_Engine_Loc_Verify verifyLocationResult = null;
         try {
             setMockLocation(context, mockLoc); // North Pole.
-            Location location = mexLoc.getBlocking(context, 10000);
+            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
 
-            verifyLocationResult = me.verifyLocation(request, 10000);
+            verifyLocationResult = me.verifyLocation(request, GRPC_TIMEOUT_MS);
             assert(verifyLocationResult != null);
         } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("verifyMockedLocationTest_NorthPole Execution Failed!", true);
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("verifyMockedLocationTest_NorthPole: Execution Failed!", true);
         } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("verifyMockedLocationTest_NorthPole Execution Interrupted!", true);
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("verifyMockedLocationTest_NorthPole: Execution Interrupted!", true);
         }
 
         // Temporary.
@@ -391,34 +396,35 @@ public class EngineCallTest {
         MatchingEngine me = new MatchingEngine();
 
         MexLocation mexLoc = new MexLocation(me);
-        Location location = null;
+        Location location;
         AppClient.Match_Engine_Loc response = null;
 
         enableMockLocation(context,true);
         Location loc = createLocation("getLocationTest", -122.149349, 37.459609);
 
         try {
-            // Directly create request for testing:
-            // Passed in Location (which is a callback interface)
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, 10000);
+            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
-            response = me.getLocation(request, 10000);
+            response = me.getLocation(request, GRPC_TIMEOUT_MS);
             assert(response != null);
         } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("VerifyLocation Execution Failed!", true);
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("VerifyLocation: Execution Failed!", true);
+        } catch (StatusRuntimeException sre) {
+            Log.i(TAG, Log.getStackTraceString(sre));
+            assertFalse("VerifyLocation: Execution Failed!", true);
         } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("VerifyLocation Execution Interrupted!", true);
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("VerifyLocation: Execution Interrupted!", true);
         } finally {
             enableMockLocation(context,false);
         }
 
         // Temporary.
-        System.out.println("getLocation() response: " + response.toString());
+        Log.i(TAG, "getLocation() response: " + response.toString());
         assertEquals(response.getVer(), 0);
         assertEquals(response.getToken(), ""); // FIXME: We DO expect a token
 
@@ -438,8 +444,8 @@ public class EngineCallTest {
         MatchingEngine me = new MatchingEngine();
 
         MexLocation mexLoc = new MexLocation(me);
-        Location location = null;
-        Future<AppClient.Match_Engine_Loc> responseFuture = null;
+        Location location;
+        Future<AppClient.Match_Engine_Loc> responseFuture;
         AppClient.Match_Engine_Loc response = null;
 
         enableMockLocation(context,true);
@@ -449,25 +455,25 @@ public class EngineCallTest {
             // Directly create request for testing:
             // Passed in Location (which is a callback interface)
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, 10000);
+            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
-            responseFuture = me.getLocationFuture(request, 10000);
+            responseFuture = me.getLocationFuture(request, GRPC_TIMEOUT_MS);
             response = responseFuture.get();
             assert(response != null);
         } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("getLocationFutureTest Execution Failed!", true);
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("getLocationFutureTest: Execution Failed!", true);
         } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("getLocationFutureTest Execution Interrupted!", true);
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("getLocationFutureTest: Execution Interrupted!", true);
         } finally {
             enableMockLocation(context,false);
         }
 
         // Temporary.
-        System.out.println("getLocationFutureTest() response: " + response.toString());
+        Log.i(TAG, "getLocationFutureTest() response: " + response.toString());
         assertEquals(response.getVer(), 0);
         assertEquals(response.getToken(), ""); // FIXME: We DO expect a token
 
@@ -480,78 +486,4 @@ public class EngineCallTest {
         assertEquals((int) response.getNetworkLocation().getLat(), (int) loc.getLatitude());
         assertEquals((int) response.getNetworkLocation().getLong(), (int) loc.getLongitude());
     }
-
-    /**
-     * This is an extremely simple and basic end to end test of blocking versus Future using
-     * VerifyLocation.
-     */
-    @Test
-    public void basicLatencyTest() {
-        Context context = InstrumentationRegistry.getTargetContext();
-        MatchingEngine me = new MatchingEngine();
-
-        MexLocation mexLoc = new MexLocation(me);
-        Location location;
-        AppClient.Match_Engine_Loc_Verify response1 = null;
-
-        enableMockLocation(context,true);
-        Location loc = createLocation("getLocationTest", -122.149349, 37.459609);
-
-        long start;
-        long elapsed1[] = new long[20];
-        long elapsed2[] = new long[20];
-        try {
-            setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, 10000);
-            assertFalse(location == null);
-
-            long sum1 = 0, sum2 = 0;
-            AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
-            for (int i = 0; i < elapsed1.length; i++){
-                start = System.currentTimeMillis();
-                response1 = me.verifyLocation(request, 10000);
-                elapsed1[i] = System.currentTimeMillis() - start;
-            }
-
-            for (int i = 0; i < elapsed1.length; i++) {
-                Log.i("LatencyTest", i + " VerifyLocation elapsed time: Elapsed1: " + elapsed1[i]);
-                sum1 += elapsed1[i];
-            }
-            Log.i("LatencyTest", "Average1: " + sum1/elapsed1.length);
-            assert(response1 != null);
-
-            // Future
-            request = createMockMatchingEngineRequest(location);
-            AppClient.Match_Engine_Loc_Verify response2 = null;
-            try {
-                for (int i = 0; i < elapsed2.length; i++) {
-                    start = System.currentTimeMillis();
-                    Future<AppClient.Match_Engine_Loc_Verify> locFuture = me.verifyLocationFuture(request, 10000);
-                    // Do something busy()
-                    response2 = locFuture.get();
-                    elapsed2[i] = System.currentTimeMillis() - start;
-                }
-                for (int i = 0; i < elapsed2.length; i++) {
-                    Log.i("LatencyTest", i + " VerifyLocationFuture elapsed time: Elapsed2: " + elapsed2[i]);
-                    sum2 += elapsed2[i];
-                }
-                Log.i("LatencyTest", "Average2: " + sum2/elapsed2.length);
-                assert(response2 != null);
-            } catch (Exception e) {
-                e.printStackTrace();
-                throw e;
-            }
-
-
-        } catch (ExecutionException ee) {
-            ee.printStackTrace();
-            assertFalse("getLocationFutureTest Execution Failed!", true);
-        } catch (InterruptedException ie) {
-            ie.printStackTrace();
-            assertFalse("getLocationFutureTest Execution Interrupted!", true);
-        } finally {
-            enableMockLocation(context,false);
-        }
-    }
-
 }

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/LimitsTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/LimitsTest.java
@@ -1,0 +1,248 @@
+package com.mobiledgex.matchingengine;
+
+import android.content.Context;
+import android.location.Location;
+import android.os.Build;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.protobuf.ByteString;
+import com.mobiledgex.matchingengine.util.MexLocation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import distributed_match_engine.AppClient;
+import distributed_match_engine.LocOuterClass;
+import io.grpc.StatusRuntimeException;
+
+import static org.junit.Assert.assertFalse;
+
+@RunWith(AndroidJUnit4.class)
+public class LimitsTest {
+    public static final String TAG = "LimitsTest";
+    public static final long GRPC_TIMEOUT_MS = 4000;
+
+    FusedLocationProviderClient fusedLocationClient;
+
+
+    @Before
+    public void grantPermissions() {
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand(
+                    "pm grant " + InstrumentationRegistry.getTargetContext().getPackageName()
+                            + " android.permission.READ_PHONE_STATE");
+            InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand(
+                    "pm grant " + InstrumentationRegistry.getTargetContext().getPackageName()
+                            + " android.permission.ACCESS_COARSE_LOCATION");
+        }
+    }
+
+    /**
+     * Enable or Disable MockLocation.
+     * @param context
+     * @param enableMock
+     * @return
+     */
+    public boolean enableMockLocation(Context context, boolean enableMock) {
+        if (fusedLocationClient == null) {
+            fusedLocationClient = new FusedLocationProviderClient(context);
+        }
+        if (enableMock == false) {
+            fusedLocationClient.setMockMode(false);
+            return false;
+        } else {
+            fusedLocationClient.setMockMode(true);
+            return true;
+        }
+    }
+
+    public Location createLocation(String provider, double longitude, double latitude) {
+        Location loc = new Location(provider);
+        loc.setLongitude(longitude);
+        loc.setLatitude(latitude);
+        return loc;
+    }
+
+    /**
+     * Utility Func. Single point mock location, fills in some extra fields. Does not calculate speed, nor update interval.
+     * @param context
+     * @param location
+     */
+    public void setMockLocation(Context context, Location location) throws InterruptedException {
+        if (fusedLocationClient == null) {
+            fusedLocationClient = new FusedLocationProviderClient(context);
+        }
+
+        location.setTime(System.currentTimeMillis());
+        location.setElapsedRealtimeNanos(1000);
+        location.setAccuracy(3f);
+        fusedLocationClient.setMockLocation(location);
+        try {
+            Thread.sleep(100); // Give Mock a bit of time to take effect.
+        } catch (InterruptedException ie) {
+            throw ie;
+        }
+        fusedLocationClient.flushLocations();
+    }
+
+    public AppClient.Match_Engine_Request createMockMatchingEngineRequest(Location location) {
+        AppClient.Match_Engine_Request request;
+
+        // Directly create request for testing:
+        LocOuterClass.Loc aLoc = LocOuterClass.Loc.newBuilder()
+                .setLat(location.getLatitude())
+                .setLong(location.getLongitude())
+                .build();
+
+        request = AppClient.Match_Engine_Request.newBuilder()
+                .setVer(5)
+                .setIdType(AppClient.Match_Engine_Request.IDType.MSISDN)
+                .setId("")
+                .setCarrierID(3l) // uint64 --> String? mnc, mcc?
+                .setCarrierName("TMUS") // Mobile Network Carrier
+                .setTower(0) // cid and lac (int)
+                .setGpsLocation(aLoc)
+                .setAppId(5011l) // uint64 --> String again. TODO: Clarify use.
+                .setProtocol(ByteString.copyFromUtf8("http")) // This one is appId context sensitive.
+                .setServerPort(ByteString.copyFromUtf8("1234")) // App dependent.
+                .setDevName("EmptyMatchEngineApp") // From signing certificate?
+                .setAppName("EmptyMatchEngineApp")
+                .setAppVers("1") // Or versionName, which is visual name?
+                .setToken("") // None.
+                .build();
+
+        return request;
+    }
+
+    /**
+     * This is an extremely simple and basic end to end test of blocking versus Future using
+     * VerifyLocation. FIXME: Manual inspection only for now.
+     */
+    @Test
+    public void basicLatencyTest() {
+        Context context = InstrumentationRegistry.getTargetContext();
+        MatchingEngine me = new MatchingEngine();
+
+        MexLocation mexLoc = new MexLocation(me);
+        Location location;
+        AppClient.Match_Engine_Loc_Verify response1 = null;
+
+        enableMockLocation(context,true);
+        Location loc = createLocation("basicLatencyTest", -122.149349, 37.459609);
+
+        long start;
+        long elapsed1[] = new long[20];
+        long elapsed2[] = new long[20];
+        try {
+            setMockLocation(context, loc);
+            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            assertFalse(location == null);
+
+            long sum1 = 0, sum2 = 0;
+            AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
+            for (int i = 0; i < elapsed1.length; i++){
+                start = System.currentTimeMillis();
+                response1 = me.verifyLocation(request, GRPC_TIMEOUT_MS);
+                elapsed1[i] = System.currentTimeMillis() - start;
+            }
+
+            for (int i = 0; i < elapsed1.length; i++) {
+                Log.i("basicLatencyTest", i + " VerifyLocation elapsed time: Elapsed1: " + elapsed1[i]);
+                sum1 += elapsed1[i];
+            }
+            Log.i("basicLatencyTest", "Average1: " + sum1/elapsed1.length);
+            assert(response1 != null);
+
+            // Future
+            request = createMockMatchingEngineRequest(location);
+            AppClient.Match_Engine_Loc_Verify response2 = null;
+            try {
+                for (int i = 0; i < elapsed2.length; i++) {
+                    start = System.currentTimeMillis();
+                    Future<AppClient.Match_Engine_Loc_Verify> locFuture = me.verifyLocationFuture(request, GRPC_TIMEOUT_MS);
+                    // Do something busy()
+                    response2 = locFuture.get();
+                    elapsed2[i] = System.currentTimeMillis() - start;
+                }
+                for (int i = 0; i < elapsed2.length; i++) {
+                    Log.i("basicLatencyTest", i + " VerifyLocationFuture elapsed time: Elapsed2: " + elapsed2[i]);
+                    sum2 += elapsed2[i];
+                }
+                Log.i("basicLatencyTest", "Average2: " + sum2/elapsed2.length);
+                assert(response2 != null);
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw e;
+            }
+
+
+        } catch (ExecutionException ee) {
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("basicLatencyTest: Execution Failed!", true);
+        } catch (StatusRuntimeException sre) {
+            Log.i(TAG, Log.getStackTraceString(sre));
+            assertFalse("basicLatencyTest: Execution Failed!", true);
+        }  catch (InterruptedException ie) {
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("basicLatencyTest: Execution Interrupted!", true);
+        } finally {
+            enableMockLocation(context,false);
+        }
+    }
+
+    /**
+     * Basic threading test using a thread pool to talk to dme-server.
+     */
+    @Test
+    public void threadpoolTest() {
+        Context context = InstrumentationRegistry.getTargetContext();
+        MatchingEngine me = new MatchingEngine(Executors.newFixedThreadPool(100));
+
+        MexLocation mexLoc = new MexLocation(me);
+        Location location;
+
+        enableMockLocation(context,true);
+        Location loc = createLocation("threadpoolTest", -122.149349, 37.459609);
+
+        try {
+            setMockLocation(context, loc);
+            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            assertFalse(location == null);
+
+            AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
+            Future<AppClient.Match_Engine_Loc_Verify> responseFutures[] = new Future[10000];
+
+            for (int i = 0; i < responseFutures.length; i++) {
+                responseFutures[i] = me.verifyLocationFuture(request, GRPC_TIMEOUT_MS);
+                assert(responseFutures[i] != null);
+            }
+
+            for (int i = 0; i < responseFutures.length; i++) {
+                AppClient.Match_Engine_Loc_Verify locv = responseFutures[i].get();
+                assert (locv != null);
+                Log.i(TAG, "Locv: " + locv.getVer());
+            }
+        } catch (ExecutionException ee) {
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("threadpoolTest: Execution Failed!", true);
+        } catch (StatusRuntimeException sre) {
+            Log.i(TAG, Log.getStackTraceString(sre));
+            assertFalse("threadpoolTest: Execution Failed!", true);
+        } catch (InterruptedException ie) {
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("threadpoolTest: Execution Interrupted!", true);
+        } finally {
+            enableMockLocation(context,false);
+        }
+    }
+
+}

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
@@ -3,12 +3,14 @@ package com.mobiledgex.matchingengine;
 import android.util.Log;
 
 import java.util.concurrent.TimeUnit;
-
 import java.util.concurrent.Callable;
+
 import distributed_match_engine.AppClient;
 import distributed_match_engine.Match_Engine_ApiGrpc;
+
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
 
 public class FindCloudlet implements Callable {
     public static final String TAG = "FindCloudlet";
@@ -34,14 +36,14 @@ public class FindCloudlet implements Callable {
     }
 
     @Override
-    public FindCloudletResponse call() throws MissingRequestException {
+    public FindCloudletResponse call() throws MissingRequestException, StatusRuntimeException {
         if (mRequest == null) {
             throw new MissingRequestException("Usage error: FindCloudlet does not have a request object to use MatchEngine!");
         }
 
         FindCloudletResponse cloudletResponse = null;
 
-        AppClient.Match_Engine_Reply reply = null;
+        AppClient.Match_Engine_Reply reply;
         // FIXME: UsePlaintxt means no encryption is enabled to the MatchEngine server!
         ManagedChannel channel = null;
         try {
@@ -50,9 +52,6 @@ public class FindCloudlet implements Callable {
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .findCloudlet(mRequest);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetLocation.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetLocation.java
@@ -7,8 +7,10 @@ import java.util.concurrent.TimeUnit;
 
 import distributed_match_engine.AppClient;
 import distributed_match_engine.Match_Engine_ApiGrpc;
+
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
 
 public class GetLocation implements Callable {
     public static final String TAG = "GetLocation";
@@ -35,7 +37,7 @@ public class GetLocation implements Callable {
     }
 
     @Override
-    public AppClient.Match_Engine_Loc call() throws MissingRequestException {
+    public AppClient.Match_Engine_Loc call() throws MissingRequestException, StatusRuntimeException {
         if (mRequest == null) {
             throw new MissingRequestException("Usage error: GetLocation does not have a request object to make location verification call!");
         }
@@ -49,9 +51,6 @@ public class GetLocation implements Callable {
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .getLocation(mRequest);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -10,7 +10,6 @@ import com.google.protobuf.ByteString;
 
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -18,6 +17,7 @@ import java.util.concurrent.Future;
 import distributed_match_engine.AppClient;
 import distributed_match_engine.AppClient.Match_Engine_Request;
 import distributed_match_engine.LocOuterClass.Loc;
+import io.grpc.StatusRuntimeException;
 
 import android.content.pm.PackageInfo;
 
@@ -131,7 +131,21 @@ public class MatchingEngine {
     }
 
     /**
-     * Registers device on the MatchingEngine server.
+     * Registers Client using blocking API call.
+     * @param request
+     * @param timeoutInMilliseconds
+     * @return
+     * @throws StatusRuntimeException
+     */
+    public AppClient.Match_Engine_Status registerClient(AppClient.Match_Engine_Request request, long timeoutInMilliseconds)
+            throws StatusRuntimeException {
+        RegisterClient registerClient = new RegisterClient(this);
+        registerClient.setRequest(request, timeoutInMilliseconds);
+        return registerClient.call();
+    }
+
+    /**
+     * Registers device on the MatchingEngine server. Returns a Future.
      * @param request
      * @param timeoutInMilliseconds
      * @return
@@ -142,20 +156,14 @@ public class MatchingEngine {
         return submit(registerClient);
     }
 
-    public AppClient.Match_Engine_Status registerClient(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
-        RegisterClient registerClient = new RegisterClient(this);
-        registerClient.setRequest(request, timeoutInMilliseconds);
-        return registerClient.call();
-    }
-
     /**
      * findCloudlet finds the closest cloudlet instance as per request.
      * @param request
      * @return cloudlet URI.
-     * @throws InterruptedException
-     * @throws ExecutionException
+     * @throws StatusRuntimeException
      */
-    public FindCloudletResponse findCloudlet(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
+    public FindCloudletResponse findCloudlet(AppClient.Match_Engine_Request request, long timeoutInMilliseconds)
+            throws StatusRuntimeException {
         FindCloudlet findCloudlet = new FindCloudlet(this);
         findCloudlet.setRequest(request, timeoutInMilliseconds);
         return findCloudlet.call();
@@ -178,10 +186,10 @@ public class MatchingEngine {
      * parameters on the subscriber network side.
      * @param request
      * @return boolean validated or not.
-     * @throws InterruptedException
-     * @throws ExecutionException
+     * @throws StatusRuntimeException
      */
-    public AppClient.Match_Engine_Loc_Verify verifyLocation(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
+    public AppClient.Match_Engine_Loc_Verify verifyLocation(AppClient.Match_Engine_Request request, long timeoutInMilliseconds)
+            throws StatusRuntimeException {
         VerifyLocation verifyLocation = new VerifyLocation(this);
         verifyLocation.setRequest(request, timeoutInMilliseconds);
         return verifyLocation.call();
@@ -204,8 +212,10 @@ public class MatchingEngine {
      * @param request
      * @param timeoutInMilliseconds
      * @return
+     * @throws StatusRuntimeException
      */
-    public AppClient.Match_Engine_Loc getLocation(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
+    public AppClient.Match_Engine_Loc getLocation(AppClient.Match_Engine_Request request, long timeoutInMilliseconds)
+            throws StatusRuntimeException {
         GetLocation getLocation = new GetLocation(this);
         getLocation.setRequest(request, timeoutInMilliseconds);
         return getLocation.call();

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
@@ -9,6 +9,7 @@ import distributed_match_engine.AppClient;
 import distributed_match_engine.Match_Engine_ApiGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
 
 public class RegisterClient implements Callable {
     public static final String TAG = "RegisterClient";
@@ -35,7 +36,7 @@ public class RegisterClient implements Callable {
     }
 
     @Override
-    public AppClient.Match_Engine_Status call() throws MissingRequestException {
+    public AppClient.Match_Engine_Status call() throws MissingRequestException, StatusRuntimeException {
         if (mRequest == null) {
             throw new MissingRequestException("Usage error: RegisterClient() does not have a request object to make call!");
         }
@@ -49,9 +50,6 @@ public class RegisterClient implements Callable {
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .registerClient(mRequest);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
@@ -9,6 +9,7 @@ import distributed_match_engine.AppClient;
 import distributed_match_engine.Match_Engine_ApiGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
 
 public class VerifyLocation implements Callable {
     public static final String TAG = "VerifyLocationTask";
@@ -35,7 +36,7 @@ public class VerifyLocation implements Callable {
     }
 
     @Override
-    public AppClient.Match_Engine_Loc_Verify call() throws MissingRequestException {
+    public AppClient.Match_Engine_Loc_Verify call() throws MissingRequestException, StatusRuntimeException {
         if (mRequest == null) {
             throw new MissingRequestException("Usage error: VerifyLocation does not have a request object to make location verification call!");
         }
@@ -49,9 +50,6 @@ public class VerifyLocation implements Callable {
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .verifyLocation(mRequest);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();


### PR DESCRIPTION
- Test case addition LimitsTest, with basic threadPool on client side to load server.
- Test case cleanup.
- Fix Sample MainActivity.java to catch new GRPC exception.