### PR TITLE
MEX_ANDROID_LIB: Improve Permissions Consent error handling.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/.gitignore
+++ b/edge-mvp/android/EmptyMatchEngineApp/.gitignore
@@ -1,10 +1,8 @@
 *.iml
 .gradle
 /local.properties
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
+.idea/
 .DS_Store
-/build
+build/
 /captures
 .externalNativeBuild

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
@@ -137,6 +137,11 @@ public class MainActivity extends AppCompatActivity {
      * See documentation for Google's FusedLocationProviderClient for additional usage information.
      */
     private void startLocationUpdates() {
+        // As of Android 23, permissions can be asked for while the app is still running.
+        if (mRpUtil.getNeededPermissions(this).size() > 0) {
+            return;
+        }
+
         try {
             if (mFusedLocationClient == null) {
                 mFusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
@@ -156,6 +161,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         // Or replace with an app specific dialog set.
         mRpUtil.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
     }


### PR DESCRIPTION
Minor updates. If the user denies all permissions, and also asks to not be ask again for each permission, then once per session, the optional util RequestPermissions will show why it's needed again, then it stays quiet for the session. In every case, the application is allowed to show a splash screen in any why desired before calling the RequestPermissions utility to explain why permissions are needed both for itself and for those inherited from the MEX library.