### PR TITLE
Shorten Maven groupID to com.mobiledgex. artifactId: matchingengine

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/app/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation project(":matchingengine")
     implementation 'io.grpc:grpc-protobuf-lite:1.12.0' // CURRENT_GRPC_VERSION
     // Use maven:
-    //implementation 'com.mobiledgex.matchingengine:matchingengine:0.0.1'
+    //implementation 'com.mobiledgex:matchingengine:0.0.1'
     // Dependencies of Matching Engine, if using Maven:
     //implementation 'io.grpc:grpc-okhttp:1.12.0' // CURRENT_GRPC_VERSION
     //implementation 'io.grpc:grpc-stub:1.12.0' // CURRENT_GRPC_VERSION

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -100,7 +100,7 @@ publishing {
         maven(MavenPublication) {
             // AAR of each library
             version android.defaultConfig.versionName
-            groupId "com.mobiledgex.matchingengine"
+            groupId "com.mobiledgex"
             artifactId "${project.name}"
             //artifact "${project.buildDir}/outputs/aar/${project.name}-debug.aar"
             artifact "${project.buildDir}/outputs/aar/${project.name}-release.aar"


### PR DESCRIPTION
Simple change to reflect how mavenCentral works. This affects how to refer to the SDK library from the implementing app.