### PR TITLE
Partial support for SessionCookie Tracking (RegisterClient saves cookie to engine sdk). Tests updated. Proto FieldName change: getCommCookie --> getSessionCookie

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/LimitsTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/LimitsTest.java
@@ -23,6 +23,7 @@ import distributed_match_engine.AppClient;
 import distributed_match_engine.LocOuterClass;
 import io.grpc.StatusRuntimeException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 @RunWith(AndroidJUnit4.class)
@@ -94,7 +95,7 @@ public class LimitsTest {
         fusedLocationClient.flushLocations();
     }
 
-    public AppClient.Match_Engine_Request createMockMatchingEngineRequest(Location location) {
+    public AppClient.Match_Engine_Request createMockMatchingEngineRequest(MatchingEngine me, Location location) {
         AppClient.Match_Engine_Request request;
 
         // Directly create request for testing:
@@ -117,10 +118,19 @@ public class LimitsTest {
                 .setDevName("EmptyMatchEngineApp") // From signing certificate?
                 .setAppName("EmptyMatchEngineApp")
                 .setAppVers("1") // Or versionName, which is visual name?
-                .setCommCookie("") // None.
+                .setSessionCookie(me.getSessionCookie() == null ? "" : me.getSessionCookie()) // None.
                 .build();
 
         return request;
+    }
+
+    // Every call needs registration to be called first.
+    public void registerClient(MatchingEngine me, Location location) {
+        AppClient.Match_Engine_Status registerResponse;
+        AppClient.Match_Engine_Request regRequest = createMockMatchingEngineRequest(me, location);
+        registerResponse = me.registerClient(regRequest, GRPC_TIMEOUT_MS);
+        assertEquals("Response SessionCookie should equal MatchingEngine SessionCookie",
+                registerResponse.getSessionCookie(), me.getSessionCookie());
     }
 
     /**
@@ -149,7 +159,8 @@ public class LimitsTest {
             assertFalse(location == null);
 
             long sum1 = 0, sum2 = 0;
-            AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
+            registerClient(me, location);
+            AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(me, location);
             for (int i = 0; i < elapsed1.length; i++){
                 start = System.currentTimeMillis();
                 response1 = me.verifyLocation(request, GRPC_TIMEOUT_MS);
@@ -164,7 +175,7 @@ public class LimitsTest {
             assert(response1 != null);
 
             // Future
-            request = createMockMatchingEngineRequest(location);
+            request = createMockMatchingEngineRequest(me, location);
             AppClient.Match_Engine_Loc_Verify response2 = null;
             try {
                 for (int i = 0; i < elapsed2.length; i++) {
@@ -201,7 +212,8 @@ public class LimitsTest {
     }
 
     /**
-     * Basic threading test using a thread pool to talk to dme-server.
+     * Basic threading test using a thread pool to talk to dme-server. 2 calls are made per iteration,
+     * as async futures: RegisterClient, then VerifyLocation.
      */
     @Test
     public void threadpoolTest() {
@@ -220,7 +232,8 @@ public class LimitsTest {
             location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
-            AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(location);
+            registerClient(me, location);
+            AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(me, location);
             Future<AppClient.Match_Engine_Loc_Verify> responseFutures[] = new Future[10000];
 
             for (int i = 0; i < responseFutures.length; i++) {

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
@@ -78,7 +78,7 @@ public class FindCloudlet implements Callable {
                         reply.getServicePort(),
                         loc,
                         FindCloudletResponse.Find_Status.forNumber(reply.getStatus().getNumber()),
-                        reply.getCommCookie());
+                        reply.getSessionCookie());
             } else {
                 cloudletResponse = new FindCloudletResponse(reply.getVer(),
                         reply.getUri(),
@@ -86,12 +86,11 @@ public class FindCloudlet implements Callable {
                         reply.getServicePort(),
                         null,
                         FindCloudletResponse.Find_Status.forNumber(reply.getStatus().getNumber()),
-                        reply.getCommCookie());
+                        reply.getSessionCookie());
             }
 
         }
         // Let MatchingEngine know of the latest cookie.
-        mMatchingEngine.setCommCookie(reply.getCommCookie());
         mMatchingEngine.setFindCloudletResponse(reply);
         return cloudletResponse;
     }

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudletResponse.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudletResponse.java
@@ -31,7 +31,7 @@ public class FindCloudletResponse {
         }
     }
     public Find_Status status;
-    public String token = "";
+    public String sessionCookie;
 
     FindCloudletResponse(long version, String uri, byte[] service_ip, int port, GPSLocation loc, Find_Status status, String token) {
         this.version = version;
@@ -40,6 +40,6 @@ public class FindCloudletResponse {
         this.port = port;
         this.loc = loc;
         this.status = status;
-        this.token = token;
+        this.sessionCookie = token;
     }
 }

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -3,7 +3,6 @@ package com.mobiledgex.matchingengine;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
-import android.location.Location;
 import android.support.annotation.NonNull;
 import android.telephony.NeighboringCellInfo;
 import android.telephony.TelephonyManager;
@@ -30,7 +29,7 @@ import android.util.Log;
 public class MatchingEngine {
     public static final String TAG = "MatchingEngine";
     private String host = "192.168.28.162"; // FIXME: Your available external server IP until the real server is up.
-    //private String host = "192.168.1.91"; // FIXME: Your available external server IP until the real server is up.
+    //private String host = "localhost"; // FIXME: Your available external server IP until the real server is up.
     private int port = 50051;
 
     // A threadpool for all the MatchEngine API callable interfaces:
@@ -39,7 +38,7 @@ public class MatchingEngine {
     // State info for engine
     private AppClient.Match_Engine_Status mStatus;
     private UUID mUUID;
-    private String mCommCookie;
+    private String mSessionCookie;
     private AppClient.Match_Engine_Reply mMatchEngineFindCloudletReply; // FindCloudlet.
     private AppClient.Match_Engine_Status mMatchEngineStatus;
     private AppClient.Match_Engine_Loc mMatchEngineLocation;
@@ -82,8 +81,11 @@ public class MatchingEngine {
         return mUUID;
     }
 
-    void setCommCookie(String mCommCookie) {
-        this.mCommCookie = mCommCookie;
+    void setSessionCookie(String sessionCookie) {
+        this.mSessionCookie = sessionCookie;
+    }
+    String getSessionCookie() {
+        return this.mSessionCookie;
     }
 
     void setMatchEngineStatus(AppClient.Match_Engine_Status status) {
@@ -188,7 +190,7 @@ public class MatchingEngine {
                 .setDevName(packageLabel) // From signing certificate?
                 .setAppName(appName)
                 .setAppVers(versionName) // Or versionName, which is visual name?
-                .setCommCookie(mCommCookie == null ? "" : mCommCookie) // "" if null/unknown.
+                .setSessionCookie(mSessionCookie == null ? "" : mSessionCookie) // "" if null/unknown.
                 .build();
 
 
@@ -243,7 +245,7 @@ public class MatchingEngine {
                 .setTower(cid)
                 .setGpsLocation(aLoc)
                 .setLgId(groupLocationId)
-                .setCommCookie(mCommCookie)
+                .setSessionCookie(mSessionCookie)
                 .setCommType(type)
                 .setUserData(userData)
                 .build();

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
@@ -68,6 +68,7 @@ public class RegisterClient implements Callable {
             Log.d(TAG, "Version of Match_Engine_Status: " + ver);
         }
 
+        mMatchingEngine.setSessionCookie(reply.getSessionCookie());
         mMatchingEngine.setMatchEngineStatus(reply);
         return reply;
     }


### PR DESCRIPTION
Mostly proto sync. Session Cookies are now saved on RegisterClient. SessionTimeout/Expiration behavior TBD.

dme-main.go does not carry forward the ip.src as the session key to the other RPC calls besides partially in RegisterClient, so the tests currently expect "" until set.

Tests now call registerClient first before findCloudlet, getLocation, verifyLocation, addUserToGroup.

Limits test case is now actually 20,000 instead of 10,000 reply/requests. This just makes it a bit harder on the dme-server to pass successfully, though most go through on a stock Mac "server" config without UNAVAILABLE being thrown.