### PR TITLE
- EDGECLOUD-58 Gradle updates for maven remote.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/app/lint.xml
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="InvalidPackage">
+        <ignore path="*/io.grpc/grpc-core/*"/>
+    </issue>
+</lint>

--- a/edge-mvp/android/EmptyMatchEngineApp/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/build.gradle
@@ -1,7 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+def nexusUser = properties.getProperty("nexus.user")
+def nexusPassword = properties.getProperty("nexus.password")
+
+
 buildscript {
-    
+
     repositories {
         mavenLocal()
         google()
@@ -18,6 +24,14 @@ buildscript {
 
 allprojects {
     repositories {
+        maven {
+            credentials {
+                // Create these variables if you don't have them.
+                username nexusUser
+                password nexusPassword
+            }
+            url "https://registry.mobiledgex.net/nexus/content/repositories/releases/"
+        }
         mavenLocal()
         google()
         jcenter()

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -4,10 +4,13 @@ apply plugin: 'maven-publish'
 
 def grpcVersion='1.13.1'
 
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+def nexusUser = properties.getProperty("nexus.user")
+def nexusPassword = properties.getProperty("nexus.password")
+
 android {
     compileSdkVersion 27
-
-
 
     defaultConfig {
         minSdkVersion 21
@@ -95,30 +98,29 @@ dependencies {
 }
 
 publishing {
-    // Publish to local repository
     repositories {
         maven {
-            //name "plugin-repository"
-            url "http://localhost:8081/nexus/"
+            def version = android.defaultConfig.versionName
+            def releasesRepoUrl = "https://registry.mobiledgex.net/nexus/content/repositories/releases/"
+            def snapshotsRepoUrl = "https://registry.mobiledgex.net/nexus/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
-                username "admin"
-                password "admin123"
+                username nexusUser
+                password nexusPassword
             }
             authentication {
-                basic(BasicAuthentication)
                 digest(DigestAuthentication)
             }
         }
         mavenLocal()
     }
 
-    publications { // Doesn't include generated protobufs?
+    publications {
         maven(MavenPublication) {
             // AAR of each library
             version android.defaultConfig.versionName
             groupId "com.mobiledgex"
             artifactId "${project.name}"
-            //artifact "${project.buildDir}/outputs/aar/${project.name}-debug.aar"
             artifact "${project.buildDir}/outputs/aar/${project.name}-release.aar"
         }
     }


### PR DESCRIPTION
- Fix grpc gradle lint error with app lint.xml config.
- Builds local and remote now. Remote url points to: "https://registry.mobiledgex.net/nexus/content/repositories/releases/"
app sample points to: 0.0.1 currently.
- There is no build automation yet, but matchingengine SDK versions ending with SNAPSHOT will conditionally deploy to snapshots repo.
- User credentials go to local.properties, nexus.user, nexus.password.

Repo could potentially change (Nexus Pro eval trial keys arrived 7/25 as of writing).

