### PR TITLE
fix missing notifycb for crm cloudletinfo

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -98,6 +98,7 @@ func main() {
 		// set callbacks to trigger send of infos
 		controllerData.AppInstInfoCache.SetNotifyCb(notifyClient.UpdateAppInstInfo)
 		controllerData.ClusterInstInfoCache.SetNotifyCb(notifyClient.UpdateClusterInstInfo)
+		controllerData.CloudletInfoCache.SetNotifyCb(notifyClient.UpdateCloudletInfo)
 		notifyClient.Start()
 		defer notifyClient.Stop()
 	}

--- a/controller/cloudletinfo_api.go
+++ b/controller/cloudletinfo_api.go
@@ -26,9 +26,6 @@ func (s *CloudletInfoApi) ShowCloudletInfo(in *edgeproto.CloudletInfo, cb edgepr
 }
 
 func (s *CloudletInfoApi) Update(in *edgeproto.CloudletInfo, notifyId int64) {
-	if !cloudletApi.HasKey(in.GetKey()) {
-		return
-	}
 	// for now assume all fields have been specified
 	in.Fields = edgeproto.CloudletInfoAllFields
 	s.store.Put(in, nil)


### PR DESCRIPTION
Bob ran into an issue last night where communication between controller and crm wasn't working properly. I tracked this down to a missing setnotifycb. e2e tests passed because as long as the notify thread started after the update call, the cloudlet info would get sent as part of the initial send-all. However, if the cloudletinfo was updated after the notify thread had already done a send-all, the update would not trigger a send (because of the missing notifycb). This is a timing issue that was exposed by Bob running the CRM in a real cloudlet where the order of events was changed.

I also removed a filter in the controller in case the cloudlet isn't defined yet on the controller side, although that wasn't the main culprit in this case.