### PR TITLE
EDGECLOUD-104: NetworkManager for Android SDK. Concurrency Tests added.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/AndroidManifest.xml
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <!-- Network Manager -->
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
 
     <application
         android:allowBackup="true"

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 // Matching Engine API:
 import com.mobiledgex.matchingengine.FindCloudletResponse;
 import com.mobiledgex.matchingengine.MatchingEngine;
+import com.mobiledgex.matchingengine.util.NetworkManager;
 import com.mobiledgex.matchingengine.util.RequestPermissions;
 
 import distributed_match_engine.AppClient;
@@ -38,6 +39,7 @@ import com.google.android.gms.tasks.Task;
 
 import java.io.IOException;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 
 
 public class MainActivity extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -51,6 +53,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     private LocationCallback mLocationCallback;
     private LocationRequest mLocationRequest;
     private boolean mDoLocationUpdates;
+
+    private NetworkManager networkManager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -66,7 +70,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         mFusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
         mLocationRequest = new LocationRequest();
 
-        mMatchingEngine = new MatchingEngine();
+        mMatchingEngine = new MatchingEngine(this);
 
         // Restore mex location preference, defaulting to false:
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
@@ -320,8 +324,12 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                             tv.setText(someText);
                         }
                     });
+                } catch (ExecutionException ee) {
+                    ee.printStackTrace();
                 } catch (IOException ioe) {
                     ioe.printStackTrace();
+                } catch (InterruptedException ie) {
+                    ie.printStackTrace();
                 } catch (StatusRuntimeException sre) {
                     sre.printStackTrace();
                 } catch (IllegalArgumentException iae) {

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -174,7 +174,7 @@ public class EngineCallTest {
     @Test
     public void registerClientTest() {
         Context context = InstrumentationRegistry.getTargetContext();
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
 
         MexLocation mexLoc = new MexLocation(me);
@@ -219,7 +219,7 @@ public class EngineCallTest {
     @Test
     public void registerClientFutureTest() {
         Context context = InstrumentationRegistry.getTargetContext();
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
 
         MexLocation mexLoc = new MexLocation(me);
@@ -259,7 +259,7 @@ public class EngineCallTest {
     @Test
     public void mexDisabledTest() {
         Context context = InstrumentationRegistry.getTargetContext();
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(false);
         MexLocation mexLoc = new MexLocation(me);
 
@@ -323,7 +323,7 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getTargetContext();
         AppClient.Match_Engine_Status registerResponse;
         FindCloudletResponse cloudletResponse = null;
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
         MexLocation mexLoc = new MexLocation(me);
 
@@ -367,7 +367,7 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getTargetContext();
         Future<FindCloudletResponse> response;
         FindCloudletResponse result = null;
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
         MexLocation mexLoc = new MexLocation(me);
 
@@ -403,7 +403,7 @@ public class EngineCallTest {
     public void verifyLocationTest() {
         Context context = InstrumentationRegistry.getTargetContext();
 
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
         MexLocation mexLoc = new MexLocation(me);
         AppClient.Match_Engine_Loc_Verify response = null;
@@ -439,14 +439,14 @@ public class EngineCallTest {
         // Temporary.
         assertEquals(response.getVer(), 0);
         assertEquals(response.getTowerStatus(), AppClient.Match_Engine_Loc_Verify.Tower_Status.TOWER_UNKNOWN);
-        assertEquals(response.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_UNKNOWN);
+        assertEquals(response.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_ERROR_OTHER);
     }
 
     @Test
     public void verifyLocationFutureTest() {
         Context context = InstrumentationRegistry.getTargetContext();
 
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
         MexLocation mexLoc = new MexLocation(me);
         AppClient.Match_Engine_Loc_Verify response = null;
@@ -478,7 +478,7 @@ public class EngineCallTest {
         // Temporary.
         assertEquals(response.getVer(), 0);
         assertEquals(response.getTowerStatus(), AppClient.Match_Engine_Loc_Verify.Tower_Status.TOWER_UNKNOWN);
-        assertEquals(response.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_UNKNOWN);
+        assertEquals(response.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_ERROR_OTHER);
     }
 
 
@@ -494,7 +494,7 @@ public class EngineCallTest {
         Location mockLoc = createLocation("verifyMockedLocationTest_NorthPole", 90d, 0d);
 
 
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
         MexLocation mexLoc = new MexLocation(me);
 
@@ -525,14 +525,14 @@ public class EngineCallTest {
         // Temporary.
         assertEquals(verifyLocationResult.getVer(), 0);
         assertEquals(verifyLocationResult.getTowerStatus(), AppClient.Match_Engine_Loc_Verify.Tower_Status.TOWER_UNKNOWN);
-        assertEquals(verifyLocationResult.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_UNKNOWN); // Based on test data.
+        assertEquals(verifyLocationResult.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_ERROR_OTHER); // Based on test data.
 
     }
 
     @Test
     public void getLocationTest() {
         Context context = InstrumentationRegistry.getTargetContext();
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
         MexLocation mexLoc = new MexLocation(me);
         Location location;
@@ -585,7 +585,7 @@ public class EngineCallTest {
     @Test
     public void getLocationFutureTest() {
         Context context = InstrumentationRegistry.getTargetContext();
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
 
         MexLocation mexLoc = new MexLocation(me);
@@ -638,7 +638,7 @@ public class EngineCallTest {
     public void dynamicLocationGroupAddTest() {
         Context context = InstrumentationRegistry.getContext();
 
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
 
         AppClient.Match_Engine_Status response = null;
@@ -680,7 +680,7 @@ public class EngineCallTest {
     public void dynamicLocationGroupAddFutureTest() {
         Context context = InstrumentationRegistry.getContext();
 
-        MatchingEngine me = new MatchingEngine();
+        MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
 
         AppClient.Match_Engine_Status response = null;

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/AndroidManifest.xml
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mobiledgex.matchingengine">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
@@ -1,7 +1,12 @@
 package com.mobiledgex.matchingengine;
 
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkRequest;
 import android.util.Log;
 
+import com.mobiledgex.matchingengine.util.NetworkManager;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
@@ -49,29 +54,10 @@ public class RegisterClient implements Callable {
         return true;
     }
 
-    private String createDmeUri() {
-        return "http://"
-                + mMatchingEngine.getHost()
-                + ":"
-                + mMatchingEngine.getPort();
+    private void isBoundToCellNetwork() {
+
     }
 
-    private String getRedirectUri(String uri) {
-        HttpUrl url = HttpUrl.parse(uri);
-        return url.queryParameter("followURL");
-    }
-
-    private String getToken(String uri) {
-        HttpUrl url = HttpUrl.parse(uri);
-        return url.queryParameter("dt-id");
-    }
-
-    /**
-     *
-     * @return
-     * @throws MissingRequestException
-     * @throws StatusRuntimeException
-     */
     @Override
     public AppClient.Match_Engine_Status call() throws MissingRequestException,
             StatusRuntimeException, IOException {
@@ -83,7 +69,10 @@ public class RegisterClient implements Callable {
         // FIXME: UsePlaintxt means no encryption is enabled to the MatchEngine server!
         ManagedChannel channel = null;
         try {
-            channel = ManagedChannelBuilder.forAddress(mMatchingEngine.getHost(), mMatchingEngine.getPort()).usePlaintext().build();
+            channel = ManagedChannelBuilder
+                    .forAddress(mMatchingEngine.getHost(), mMatchingEngine.getPort())
+                    .usePlaintext()
+                    .build();
             Match_Engine_ApiGrpc.Match_Engine_ApiBlockingStub stub = Match_Engine_ApiGrpc.newBlockingStub(channel);
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/util/MexLocation.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/util/MexLocation.java
@@ -5,6 +5,7 @@ import android.location.Location;
 
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.tasks.OnCanceledListener;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.mobiledgex.matchingengine.MatchingEngine;
@@ -59,7 +60,18 @@ public class MexLocation {
                                 mWaitingForNotify = false;
                                 syncObject.notify();
                             }
-                            Log.w(TAG, "getLastLocation: Exception (if any)", task.getException());
+                            if (task.getException() != null) {
+                                Log.w(TAG, "getLastLocation: Exception: ", task.getException());
+                            }
+                        }
+                    }
+                });
+                fusedLocationClient.getLastLocation().addOnCanceledListener(new OnCanceledListener() {
+                    @Override
+                    public void onCanceled() {
+                        synchronized (syncObject) {
+                            mWaitingForNotify = false;
+                            syncObject.notify();
                         }
                     }
                 });

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/util/NetworkManager.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/util/NetworkManager.java
@@ -1,0 +1,346 @@
+package com.mobiledgex.matchingengine.util;
+
+import android.net.ConnectivityManager;
+import android.net.LinkProperties;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkRequest;
+import android.util.Log;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET;
+import static android.net.NetworkCapabilities.TRANSPORT_BLUETOOTH;
+import static android.net.NetworkCapabilities.TRANSPORT_CELLULAR;
+import static android.net.NetworkCapabilities.TRANSPORT_ETHERNET;
+import static android.net.NetworkCapabilities.TRANSPORT_WIFI;
+
+public class NetworkManager {
+    public static final String TAG = "NetworkManager";
+
+    private ConnectivityManager mConnectivityManager;
+    private volatile boolean mWaitingForLink = false;
+
+    private final Object mWaitForActiveNetwork = new Object();
+    private long mNetworkActiveTimeoutMilliseconds = 1000;
+    private final Object mSyncObject = new Object();
+    private long mTimeoutInMilliseconds = 5000;
+
+    private Network mNetwork;
+    private NetworkRequest mDefaultRequest;
+
+    private ExecutorService mThreadPool;
+
+    public NetworkManager(ConnectivityManager connectivityManager) {
+        this.mConnectivityManager = connectivityManager;
+        mThreadPool = Executors.newSingleThreadExecutor();
+    }
+
+    public NetworkManager(ConnectivityManager connectivityManager, ExecutorService threadPool) {
+        this.mConnectivityManager = connectivityManager;
+        mThreadPool = threadPool;
+    }
+
+    public void setTimeout(long timeoutInMilliseconds) {
+        if (timeoutInMilliseconds < 1) {
+            throw new IllegalArgumentException("Network Switching Timeout should be greater than 0ms.");
+        }
+        mTimeoutInMilliseconds = timeoutInMilliseconds;
+    }
+
+    public long getTimeout() {
+        return mTimeoutInMilliseconds;
+    }
+
+    public long getNetworkActiveTimeoutMilliseconds() {
+        return mNetworkActiveTimeoutMilliseconds;
+    }
+
+    public void setNetworkActiveTimeoutMilliseconds(long networkActiveTimeoutMilliseconds) {
+        if (networkActiveTimeoutMilliseconds < 0) {
+            throw new IllegalArgumentException("networkActiveTimeoutMilliseconds should be greater than 0ms.");
+        }
+        this.mNetworkActiveTimeoutMilliseconds = networkActiveTimeoutMilliseconds;
+    }
+
+    public NetworkRequest getBluetoothNetworkRequest() {
+        NetworkRequest networkRequest = new NetworkRequest.Builder()
+                .addTransportType(TRANSPORT_BLUETOOTH)
+                .addCapability(NET_CAPABILITY_INTERNET)
+                .build();
+        return networkRequest;
+    }
+
+    public NetworkRequest getEthernetNetworkRequest() {
+        NetworkRequest networkRequest = new NetworkRequest.Builder()
+                .addTransportType(TRANSPORT_ETHERNET)
+                .addCapability(NET_CAPABILITY_INTERNET)
+                .build();
+        return networkRequest;
+    }
+
+    public NetworkRequest getWifiNetworkRequest() {
+        NetworkRequest networkRequest = new NetworkRequest.Builder()
+                .addTransportType(TRANSPORT_WIFI)
+                .addCapability(NET_CAPABILITY_INTERNET)
+                .build();
+        return networkRequest;
+    }
+
+    public NetworkRequest getCellularNetworkRequest() {
+        NetworkRequest networkRequest = new NetworkRequest.Builder()
+                .addTransportType(TRANSPORT_CELLULAR)
+                .addCapability(NET_CAPABILITY_INTERNET)
+                .build();
+        return networkRequest;
+    }
+
+    public Network getNetwork() {
+        return mNetwork;
+    }
+
+    public void resetNetworkToDefault() throws InterruptedException, ExecutionException {
+        if (mDefaultRequest == null) {
+            mConnectivityManager.bindProcessToNetwork(null);
+        } else {
+            switchToNetworkBlocking(mDefaultRequest);
+        }
+    }
+
+    class NetworkSwitcherCallable implements Callable {
+        NetworkRequest mNetworkRequest;
+
+        NetworkSwitcherCallable(NetworkRequest networkRequest) {
+            mNetworkRequest = networkRequest;
+        }
+        @Override
+        public Network call() throws InterruptedException {
+            final ConnectivityManager.OnNetworkActiveListener activeListener = new ConnectivityManager.OnNetworkActiveListener() {
+                @Override
+                public void onNetworkActive() {
+                    synchronized (mWaitForActiveNetwork) {
+                        mWaitForActiveNetwork.notify();
+                    }
+                }
+            };
+            try {
+                mWaitingForLink = true;
+
+                mConnectivityManager.addDefaultNetworkActiveListener(activeListener);
+                mConnectivityManager.requestNetwork(mNetworkRequest, new ConnectivityManager.NetworkCallback() {
+                    @Override
+                    public void onAvailable(Network network) {
+                        Log.d(TAG, "requestNetwork onAvailable(), binding process to network.");
+                        mConnectivityManager.bindProcessToNetwork(network);
+                        mNetwork = network;
+                    }
+
+                    @Override
+                    public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
+                        Log.d(TAG, "requestNetwork onCapabilitiesChanged(): " + network.toString());
+                        Log.d(TAG, " -- networkCapabilities: TRANSPORT_WIFI: " + networkCapabilities.hasTransport(TRANSPORT_WIFI));
+                        Log.d(TAG, " -- networkCapabilities: TRANSPORT_CELLULAR: " + networkCapabilities.hasTransport(TRANSPORT_CELLULAR));
+                        Log.d(TAG, " -- networkCapabilities: TRANSPORT_ETHERNET: " + networkCapabilities.hasTransport(TRANSPORT_ETHERNET));
+                        Log.d(TAG, " -- networkCapabilities: TRANSPORT_BLUETOOTH: " + networkCapabilities.hasTransport(TRANSPORT_BLUETOOTH));
+                        Log.d(TAG, " -- networkCapabilities: NET_CAPABILITY_INTERNET: " + networkCapabilities.hasCapability(NET_CAPABILITY_INTERNET));
+                    }
+
+                    @Override
+                    public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
+                        Log.d(TAG, "requestNetwork onLinkPropertiesChanged(): " + network.toString());
+                        Log.d(TAG, " -- linkProperties: " + linkProperties.getRoutes());
+                        synchronized (mSyncObject) {
+                            mWaitingForLink = false;
+                            mSyncObject.notify();
+                        }
+                    }
+
+                    @Override
+                    public void onLosing(Network network, int maxMsToLive) {
+                        Log.d(TAG, "requestNetwork onLosing(): " + network.toString());
+                    }
+
+                    @Override
+                    public void onLost(Network network) {
+                        // unbind lost network.
+                        mConnectivityManager.bindProcessToNetwork(null);
+                        Log.d(TAG, "requestNetwork onLost(): " + network.toString());
+                    }
+
+                });
+                synchronized (mSyncObject) {
+                    long timeStart = System.currentTimeMillis();
+                    long elapsed;
+                    while (mWaitingForLink == true &&
+                            (elapsed = System.currentTimeMillis() - timeStart) < mTimeoutInMilliseconds) {
+                        mSyncObject.wait(mTimeoutInMilliseconds - elapsed);
+                    }
+                    mNetworkRequest = null;
+                }
+                // Network is available, and link is up, but may not be active yet.
+                synchronized (mWaitForActiveNetwork) {
+                    mWaitForActiveNetwork.wait(mNetworkActiveTimeoutMilliseconds);
+                }
+            } finally {
+                if (activeListener != null) {
+                    mConnectivityManager.removeDefaultNetworkActiveListener(activeListener);
+                }
+            }
+            return mNetwork;
+        }
+    }
+
+    public boolean isCurrentNetworkInternetCellularDataCapable() {
+        boolean hasDataCellCapabilities = false;
+
+        if (mConnectivityManager != null) {
+            Network network = mConnectivityManager.getBoundNetworkForProcess();
+            if (network != null) {
+                NetworkCapabilities networkCapabilities = mConnectivityManager.getNetworkCapabilities(network);
+                if (networkCapabilities.hasCapability(TRANSPORT_CELLULAR) &&
+                        networkCapabilities.hasCapability(NET_CAPABILITY_INTERNET)) {
+                    hasDataCellCapabilities = true;
+                }
+            }
+        }
+        return hasDataCellCapabilities;
+    }
+
+    /**
+     * Wrapper function to switch, if possible, to a Cellular Data Network connection. This isn't instant. Callback interface.
+     */
+    public boolean switchToCellularInternetNetwork(ConnectivityManager.NetworkCallback networkCallback) {
+        boolean isCellularData = isCurrentNetworkInternetCellularDataCapable();
+        if (isCellularData) {
+            return false; // Nothing to do, have cellular data
+        }
+
+        NetworkRequest networkRequest = new NetworkRequest.Builder()
+                .addTransportType(TRANSPORT_CELLULAR)
+                .addCapability(NET_CAPABILITY_INTERNET)
+                .build();
+
+        return switchToNetwork(networkRequest, networkCallback);
+    }
+
+    /**
+     * Switch to a particular network type in a blocking fashion for synchronous execution blocks.
+     * @return
+     */
+    public Network switchToCellularInternetNetworkBlocking() throws InterruptedException, ExecutionException {
+        boolean isCellularData = isCurrentNetworkInternetCellularDataCapable();
+        if (isCellularData) {
+            return null; // Nothing to do, have cellular data
+        }
+
+        NetworkRequest request = getCellularNetworkRequest();
+
+        Network network = switchToNetworkBlocking(request);
+        return network;
+    }
+
+    /**
+     * Switch to a particular network type in a blocking fashion for synchronous execution blocks.
+     * @return
+     */
+    public Future<Network> switchToCellularInternetNetworkFuture() {
+        boolean isCellularData = isCurrentNetworkInternetCellularDataCapable();
+
+        NetworkRequest networkRequest = getCellularNetworkRequest();
+        Future<Network> cellNetworkFuture;
+
+        if (isCellularData) {
+            return null; // Nothing to do, already have cellular data
+        }
+
+        cellNetworkFuture = mThreadPool.submit(new NetworkSwitcherCallable(networkRequest));
+        return cellNetworkFuture;
+    }
+
+    /**
+     * Switch to a particular network type in a blocking fashion for synchronous execution blocks.
+     * @return
+     */
+    public Network switchToNetworkBlocking(NetworkRequest networkRequest) throws InterruptedException, ExecutionException {
+        Future<Network> networkFuture;
+
+        networkFuture = mThreadPool.submit(new NetworkSwitcherCallable(networkRequest));
+        return networkFuture.get();
+    }
+
+    /**
+     * Switch to a particular network type in a blocking fashion for synchronous execution blocks.
+     * @return
+     */
+    public Future<Network> switchToDefaultInternetNetworkFuture(NetworkRequest networkRequest) {
+        Future<Network> cellNetworkFuture;
+
+        cellNetworkFuture = mThreadPool.submit(new NetworkSwitcherCallable(networkRequest));
+        return cellNetworkFuture;
+    }
+
+    /**
+     * Switch to a network using Callbacks. This only does network binding. It does not wait for the network to become active.
+     * @param networkRequest
+     * @param networkCallback
+     * @return
+     */
+    public boolean switchToNetwork(NetworkRequest networkRequest, final ConnectivityManager.NetworkCallback networkCallback) {
+        mConnectivityManager.requestNetwork(networkRequest, new ConnectivityManager.NetworkCallback() {
+            @Override
+            public void onAvailable(Network network) {
+                Log.d(TAG, "requestNetwork onAvailable(), binding process to network.");
+                mConnectivityManager.bindProcessToNetwork(network);
+                if (networkCallback == null) {
+                    networkCallback.onAvailable(network);
+                }
+            }
+
+            @Override
+            public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
+                Log.d(TAG, "requestNetwork onCapabilitiesChanged()");
+                Log.d(TAG, " -- networkCapabilities: TRANSPORT_WIFI: " + networkCapabilities.hasTransport(TRANSPORT_WIFI));
+                Log.d(TAG, " -- networkCapabilities: TRANSPORT_CELLULAR: " + networkCapabilities.hasTransport(TRANSPORT_CELLULAR));
+                Log.d(TAG, " -- networkCapabilities: TRANSPORT_ETHERNET: " + networkCapabilities.hasTransport(TRANSPORT_ETHERNET));
+                Log.d(TAG, " -- networkCapabilities: TRANSPORT_BLUETOOTH: " + networkCapabilities.hasTransport(TRANSPORT_BLUETOOTH));
+                Log.d(TAG, " -- networkCapabilities: NET_CAPABILITY_INTERNET: " + networkCapabilities.hasCapability(NET_CAPABILITY_INTERNET));
+                if (networkCallback == null) {
+                    networkCallback.onCapabilitiesChanged(network, networkCapabilities);
+                }
+            }
+
+            @Override
+            public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
+                Log.d(TAG, "requestNetwork onLinkPropertiesChanged()");
+                Log.d(TAG, " -- linkProperties: " + linkProperties.getRoutes());
+                if (networkCallback == null) {
+                    networkCallback.onLinkPropertiesChanged(network, linkProperties);
+                }
+            }
+
+            @Override
+            public void onLosing(Network network, int maxMsToLive) {
+                Log.d(TAG, "requestNetwork onLosing()");
+                if (networkCallback == null) {
+                    networkCallback.onLosing(network, maxMsToLive);
+                }
+            }
+
+            @Override
+            public void onLost(Network network) {
+                // unbind from process, lost network.
+                mConnectivityManager.bindProcessToNetwork(null);
+                Log.d(TAG, "requestNetwork onLost()");
+                if (networkCallback == null) {
+                    networkCallback.onLost(network);
+                }
+            }
+        });
+        return true;
+    }
+
+}


### PR DESCRIPTION
Test cases writers/Developers: To change/update the DME host, call setHost() or updateDMEHostAddress(carrierName) right after creatingRequest(). The side effect is, create request happens right before a call, and thats where the MatchingEngine has enough context to retrieve the carrierName. This is otherwise an internal detail, as each GRPC call must go to the correct DME.

The ConnectivityManager does have a callback for when the network changes, so the application can set/reset networks as needed( 2 (or more!) chefs are modifying the network states). So, if the app SDK has some other default for some reason, the correct thing to do is to set a default in NetworkManager, and the NetworkManager can switch to that "defaultRequest" after it's done, or the app can do that by itself.

@wonhopark80 (Ping)