### PR TITLE
EDGECLOUD-122 wrong flagset used in edgectl gencmd code

### DIFF
--- a/gencmd/app.cmd.go
+++ b/gencmd/app.cmd.go
@@ -418,7 +418,7 @@ func AppSetFields() {
 	if AppFlagSet.Lookup("key-version").Changed {
 		AppIn.Fields = append(AppIn.Fields, "2.3")
 	}
-	if AppFlagSet.Lookup("imagepath").Changed {
+	if AppNoConfigFlagSet.Lookup("imagepath").Changed {
 		AppIn.Fields = append(AppIn.Fields, "4")
 	}
 	if AppFlagSet.Lookup("imagetype").Changed {

--- a/gencmd/app_inst.cmd.go
+++ b/gencmd/app_inst.cmd.go
@@ -699,52 +699,52 @@ func AppInstSetFields() {
 	if AppInstFlagSet.Lookup("key-id").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "2.3")
 	}
-	if AppInstFlagSet.Lookup("cloudletloc-lat").Changed {
+	if AppInstNoConfigFlagSet.Lookup("cloudletloc-lat").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "3.1")
 	}
-	if AppInstFlagSet.Lookup("cloudletloc-long").Changed {
+	if AppInstNoConfigFlagSet.Lookup("cloudletloc-long").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "3.2")
 	}
-	if AppInstFlagSet.Lookup("cloudletloc-horizontalaccuracy").Changed {
+	if AppInstNoConfigFlagSet.Lookup("cloudletloc-horizontalaccuracy").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "3.3")
 	}
-	if AppInstFlagSet.Lookup("cloudletloc-verticalaccuracy").Changed {
+	if AppInstNoConfigFlagSet.Lookup("cloudletloc-verticalaccuracy").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "3.4")
 	}
-	if AppInstFlagSet.Lookup("cloudletloc-altitude").Changed {
+	if AppInstNoConfigFlagSet.Lookup("cloudletloc-altitude").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "3.5")
 	}
-	if AppInstFlagSet.Lookup("cloudletloc-course").Changed {
+	if AppInstNoConfigFlagSet.Lookup("cloudletloc-course").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "3.6")
 	}
-	if AppInstFlagSet.Lookup("cloudletloc-speed").Changed {
+	if AppInstNoConfigFlagSet.Lookup("cloudletloc-speed").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "3.7")
 	}
-	if AppInstFlagSet.Lookup("cloudletloc-timestamp-seconds").Changed {
+	if AppInstNoConfigFlagSet.Lookup("cloudletloc-timestamp-seconds").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "3.8.1")
 	}
-	if AppInstFlagSet.Lookup("cloudletloc-timestamp-nanos").Changed {
+	if AppInstNoConfigFlagSet.Lookup("cloudletloc-timestamp-nanos").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "3.8.2")
 	}
-	if AppInstFlagSet.Lookup("uri").Changed {
+	if AppInstNoConfigFlagSet.Lookup("uri").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "4")
 	}
-	if AppInstFlagSet.Lookup("clusterinstkey-clusterkey-name").Changed {
+	if AppInstNoConfigFlagSet.Lookup("clusterinstkey-clusterkey-name").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "5.1.1")
 	}
-	if AppInstFlagSet.Lookup("clusterinstkey-cloudletkey-operatorkey-name").Changed {
+	if AppInstNoConfigFlagSet.Lookup("clusterinstkey-cloudletkey-operatorkey-name").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "5.2.1.1")
 	}
-	if AppInstFlagSet.Lookup("clusterinstkey-cloudletkey-name").Changed {
+	if AppInstNoConfigFlagSet.Lookup("clusterinstkey-cloudletkey-name").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "5.2.2")
 	}
-	if AppInstFlagSet.Lookup("liveness").Changed {
+	if AppInstNoConfigFlagSet.Lookup("liveness").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "6")
 	}
-	if AppInstFlagSet.Lookup("imagepath").Changed {
+	if AppInstNoConfigFlagSet.Lookup("imagepath").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "7")
 	}
-	if AppInstFlagSet.Lookup("imagetype").Changed {
+	if AppInstNoConfigFlagSet.Lookup("imagetype").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "8")
 	}
 	if AppInstFlagSet.Lookup("mappedports-proto").Changed {
@@ -756,13 +756,13 @@ func AppInstSetFields() {
 	if AppInstFlagSet.Lookup("mappedports-publicport").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "9.3")
 	}
-	if AppInstFlagSet.Lookup("mappedpath").Changed {
+	if AppInstNoConfigFlagSet.Lookup("mappedpath").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "10")
 	}
-	if AppInstFlagSet.Lookup("configmap").Changed {
+	if AppInstNoConfigFlagSet.Lookup("configmap").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "11")
 	}
-	if AppInstFlagSet.Lookup("flavor-name").Changed {
+	if AppInstNoConfigFlagSet.Lookup("flavor-name").Changed {
 		AppInstIn.Fields = append(AppInstIn.Fields, "12.1")
 	}
 	if AppInstFlagSet.Lookup("accesslayer").Changed {

--- a/gencmd/cloudlet.cmd.go
+++ b/gencmd/cloudlet.cmd.go
@@ -702,25 +702,25 @@ func CloudletSetFields() {
 	if CloudletFlagSet.Lookup("location-long").Changed {
 		CloudletIn.Fields = append(CloudletIn.Fields, "5.2")
 	}
-	if CloudletFlagSet.Lookup("location-horizontalaccuracy").Changed {
+	if CloudletNoConfigFlagSet.Lookup("location-horizontalaccuracy").Changed {
 		CloudletIn.Fields = append(CloudletIn.Fields, "5.3")
 	}
-	if CloudletFlagSet.Lookup("location-verticalaccuracy").Changed {
+	if CloudletNoConfigFlagSet.Lookup("location-verticalaccuracy").Changed {
 		CloudletIn.Fields = append(CloudletIn.Fields, "5.4")
 	}
 	if CloudletFlagSet.Lookup("location-altitude").Changed {
 		CloudletIn.Fields = append(CloudletIn.Fields, "5.5")
 	}
-	if CloudletFlagSet.Lookup("location-course").Changed {
+	if CloudletNoConfigFlagSet.Lookup("location-course").Changed {
 		CloudletIn.Fields = append(CloudletIn.Fields, "5.6")
 	}
-	if CloudletFlagSet.Lookup("location-speed").Changed {
+	if CloudletNoConfigFlagSet.Lookup("location-speed").Changed {
 		CloudletIn.Fields = append(CloudletIn.Fields, "5.7")
 	}
-	if CloudletFlagSet.Lookup("location-timestamp-seconds").Changed {
+	if CloudletNoConfigFlagSet.Lookup("location-timestamp-seconds").Changed {
 		CloudletIn.Fields = append(CloudletIn.Fields, "5.8.1")
 	}
-	if CloudletFlagSet.Lookup("location-timestamp-nanos").Changed {
+	if CloudletNoConfigFlagSet.Lookup("location-timestamp-nanos").Changed {
 		CloudletIn.Fields = append(CloudletIn.Fields, "5.8.2")
 	}
 	if CloudletFlagSet.Lookup("ipsupport").Changed {

--- a/gencmd/cluster.cmd.go
+++ b/gencmd/cluster.cmd.go
@@ -302,7 +302,7 @@ func ClusterSetFields() {
 	if ClusterFlagSet.Lookup("defaultflavor-name").Changed {
 		ClusterIn.Fields = append(ClusterIn.Fields, "3.1")
 	}
-	if ClusterFlagSet.Lookup("auto").Changed {
+	if ClusterNoConfigFlagSet.Lookup("auto").Changed {
 		ClusterIn.Fields = append(ClusterIn.Fields, "5")
 	}
 }

--- a/gencmd/clusterinst.cmd.go
+++ b/gencmd/clusterinst.cmd.go
@@ -479,13 +479,13 @@ func ClusterInstSetFields() {
 	if ClusterInstFlagSet.Lookup("key-cloudletkey-name").Changed {
 		ClusterInstIn.Fields = append(ClusterInstIn.Fields, "2.2.2")
 	}
-	if ClusterInstFlagSet.Lookup("flavor-name").Changed {
+	if ClusterInstNoConfigFlagSet.Lookup("flavor-name").Changed {
 		ClusterInstIn.Fields = append(ClusterInstIn.Fields, "3.1")
 	}
-	if ClusterInstFlagSet.Lookup("liveness").Changed {
+	if ClusterInstNoConfigFlagSet.Lookup("liveness").Changed {
 		ClusterInstIn.Fields = append(ClusterInstIn.Fields, "9")
 	}
-	if ClusterInstFlagSet.Lookup("auto").Changed {
+	if ClusterInstNoConfigFlagSet.Lookup("auto").Changed {
 		ClusterInstIn.Fields = append(ClusterInstIn.Fields, "10")
 	}
 }


### PR DESCRIPTION
This fixes a crash in the autogenerated code for edgectl. There are two flagsets, the normal one and a "noconfig" one used for fields that should not be specified on create. On update, fields that should have been using the "noconfig" one were using the normal one, causing the flag lookup to fail and dereference a null pointer.
Fix makes the noconfig fields use the noconfig flagset.