### PR TITLE
allow cloudflare dns updates via e2e tool

### DIFF
--- a/setup-env/e2e-tests/setups/gcp_vm1.yml
+++ b/setup-env/e2e-tests/setups/gcp_vm1.yml
@@ -3,6 +3,13 @@ vars:
 - vm1_internal_ip: 10.10.0.11
 - vm1_external_ip: 35.199.188.102
 
+cloudflare:
+   zone: mobiledgex.net
+   records:
+   - name: MobiledgeXSDKDemo.tdgcloud1.mobiledgex.net
+     type: A
+     content: "{{vm1_external_ip}}"
+
 sampleapps:
 - sampleapplocal:
     name: mexexample1

--- a/setup-env/test-mex/test-mex.go
+++ b/setup-env/test-mex/test-mex.go
@@ -61,7 +61,7 @@ var actionChoices = map[string]string{
 	"stop":          "procname",
 	"status":        "procname",
 	"ctrlapi":       "procname",
-        "ctrlinfo":      "procname",
+	"ctrlinfo":      "procname",
 	"dmeapi":        "procname",
 	"deploy":        "",
 	"cleanup":       "",
@@ -277,16 +277,18 @@ func main() {
 			if util.Deployment.GCloud.Cluster != "" {
 				dir := path.Dir(*setupFile)
 				err := util.DeleteK8sServices(dir)
+
 				if err != nil {
 					errorsFound += 1
 					errors = append(errors, err.Error())
-				} else {
-					if !setupmex.CleanupRemoteProcesses() {
-						errorsFound += 1
-						errors = append(errors, "cleanup failed")
-					}
+				}
+			} else {
+				if !setupmex.CleanupRemoteProcesses() {
+					errorsFound += 1
+					errors = append(errors, "cleanup failed")
 				}
 			}
+
 		case "fetchlogs":
 			if !setupmex.FetchRemoteLogs(*outputDir) {
 				errorsFound += 1

--- a/setup-env/util/util.go
+++ b/setup-env/util/util.go
@@ -101,6 +101,18 @@ type SampleAppProcess struct {
 	Hostname string
 }
 
+type DnsRecord struct {
+	Name    string
+	Type    string
+	Content string
+}
+
+//cloudflare dns records
+type CloudflareDNS struct {
+	Zone    string
+	Records []DnsRecord
+}
+
 type DeploymentData struct {
 	GCloud        GoogleCloudInfo     `yaml:"gcloud"`
 	K8sDeployment []K8sDeploymentStep `yaml:"k8s-deployment"`
@@ -111,6 +123,7 @@ type DeploymentData struct {
 	Dmes          []DmeProcess        `yaml:"dmes"`
 	Crms          []CrmProcess        `yaml:"crms"`
 	SampleApps    []SampleAppProcess  `yaml:"sampleapps"`
+	Cloudflare    CloudflareDNS       `yaml:"cloudflare"`
 }
 
 //these are strings which may be present in the yaml but not in the corresponding data structures.


### PR DESCRIPTION
Borrow the CRM mechanism to update cloudfare within the e2e tool.  This is to facilitate Bruce's testing by allowing us to to setup DNS entries for app instance URIs from the e2e tool.