### PR TITLE
fix cluster not found error when deleting app inst

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -71,7 +71,7 @@ func GatherCloudletInfo(info *edgeproto.CloudletInfo) {
 // the notify receive thread. If the actions done here not quick,
 // they should be done in a separate worker thread.
 
-func (cd *ControllerData) flavorChanged(key *edgeproto.FlavorKey) {
+func (cd *ControllerData) flavorChanged(key *edgeproto.FlavorKey, old *edgeproto.Flavor) {
 	flavor := edgeproto.Flavor{}
 	found := cd.FlavorCache.Get(key, &flavor)
 	if found {
@@ -82,7 +82,7 @@ func (cd *ControllerData) flavorChanged(key *edgeproto.FlavorKey) {
 	}
 }
 
-func (cd *ControllerData) clusterFlavorChanged(key *edgeproto.ClusterFlavorKey) {
+func (cd *ControllerData) clusterFlavorChanged(key *edgeproto.ClusterFlavorKey, old *edgeproto.ClusterFlavor) {
 	flavor := edgeproto.ClusterFlavor{}
 	found := cd.ClusterFlavorCache.Get(key, &flavor)
 	if found {
@@ -93,7 +93,7 @@ func (cd *ControllerData) clusterFlavorChanged(key *edgeproto.ClusterFlavorKey) 
 	}
 }
 
-func (cd *ControllerData) clusterInstChanged(key *edgeproto.ClusterInstKey) {
+func (cd *ControllerData) clusterInstChanged(key *edgeproto.ClusterInstKey, old *edgeproto.ClusterInst) {
 	log.DebugLog(log.DebugLevelMexos, "clusterInstChange", "key", key)
 	clusterInst := edgeproto.ClusterInst{}
 	found := cd.ClusterInstCache.Get(key, &clusterInst)
@@ -166,7 +166,7 @@ func (cd *ControllerData) clusterInstChanged(key *edgeproto.ClusterInstKey) {
 	}
 }
 
-func (cd *ControllerData) appInstChanged(key *edgeproto.AppInstKey) {
+func (cd *ControllerData) appInstChanged(key *edgeproto.AppInstKey, old *edgeproto.AppInst) {
 	log.DebugLog(log.DebugLevelMexos, "app inst changed", "key", key)
 	appInst := edgeproto.AppInst{}
 	found := cd.AppInstCache.Get(key, &appInst)
@@ -208,7 +208,7 @@ func (cd *ControllerData) appInstChanged(key *edgeproto.AppInstKey) {
 		}()
 	} else {
 		clusterInst := edgeproto.ClusterInst{}
-		clusterInstFound := cd.ClusterInstCache.Get(&appInst.ClusterInstKey, &clusterInst)
+		clusterInstFound := cd.ClusterInstCache.Get(&old.ClusterInstKey, &clusterInst)
 		if !clusterInstFound {
 			str := fmt.Sprintf("Cluster instance %s not found",
 				appInst.ClusterInstKey.ClusterKey.Name)

--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -236,12 +236,13 @@ func (s *AppApi) UpdatedCb(old *edgeproto.App, new *edgeproto.App) {
 		appInstApi.cache.Mux.Lock()
 		for _, inst := range appInstApi.cache.Objs {
 			if inst.Key.AppKey.Matches(&new.Key) {
+				old := inst
 				inst.ImagePath = new.ImagePath
 				inst.ImageType = new.ImageType
 				inst.Config = new.Config
 				// TODO: update mapped ports if needed
 				if appInstApi.cache.NotifyCb != nil {
-					appInstApi.cache.NotifyCb(inst.GetKey())
+					appInstApi.cache.NotifyCb(inst.GetKey(), old)
 				}
 			}
 		}

--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -137,9 +137,10 @@ func (s *CloudletApi) UpdatedCb(old *edgeproto.Cloudlet, new *edgeproto.Cloudlet
 		appInstApi.cache.Mux.Lock()
 		for _, inst := range appInstApi.cache.Objs {
 			if inst.Key.CloudletKey.Matches(&new.Key) {
+				old := inst
 				inst.CloudletLoc = new.Location
 				if appInstApi.cache.NotifyCb != nil {
-					appInstApi.cache.NotifyCb(inst.GetKey())
+					appInstApi.cache.NotifyCb(inst.GetKey(), old)
 				}
 			}
 		}

--- a/controller/dummy_info_responder.go
+++ b/controller/dummy_info_responder.go
@@ -39,11 +39,11 @@ func (d *DummyInfoResponder) SetSimulateFailure(state bool) {
 	d.simulateFailure = state
 }
 
-func (d *DummyInfoResponder) runClusterInstChanged(key *edgeproto.ClusterInstKey) {
+func (d *DummyInfoResponder) runClusterInstChanged(key *edgeproto.ClusterInstKey, old *edgeproto.ClusterInst) {
 	go d.clusterInstChanged(key)
 }
 
-func (d *DummyInfoResponder) runAppInstChanged(key *edgeproto.AppInstKey) {
+func (d *DummyInfoResponder) runAppInstChanged(key *edgeproto.AppInstKey, old *edgeproto.AppInst) {
 	go d.appInstChanged(key)
 }
 

--- a/notify/notify_client.go
+++ b/notify/notify_client.go
@@ -588,21 +588,21 @@ func (s *Client) logDisconnect(err error) {
 	}
 }
 
-func (s *Client) UpdateAppInstInfo(key *edgeproto.AppInstKey) {
+func (s *Client) UpdateAppInstInfo(key *edgeproto.AppInstKey, old *edgeproto.AppInstInfo) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	s.appInstInfos[*key] = struct{}{}
 	s.wakeupSend()
 }
 
-func (s *Client) UpdateClusterInstInfo(key *edgeproto.ClusterInstKey) {
+func (s *Client) UpdateClusterInstInfo(key *edgeproto.ClusterInstKey, old *edgeproto.ClusterInstInfo) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	s.clusterInstInfos[*key] = struct{}{}
 	s.wakeupSend()
 }
 
-func (s *Client) UpdateCloudletInfo(key *edgeproto.CloudletKey) {
+func (s *Client) UpdateCloudletInfo(key *edgeproto.CloudletKey, old *edgeproto.CloudletInfo) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	s.cloudletInfos[*key] = struct{}{}

--- a/notify/notify_server.go
+++ b/notify/notify_server.go
@@ -267,7 +267,7 @@ func (mgr *ServerMgr) GetStats(peerAddr string) *ServerStats {
 	return stats
 }
 
-func (mgr *ServerMgr) UpdateAppInst(key *edgeproto.AppInstKey) {
+func (mgr *ServerMgr) UpdateAppInst(key *edgeproto.AppInstKey, old *edgeproto.AppInst) {
 	mgr.mux.Lock()
 	defer mgr.mux.Unlock()
 	for _, server := range mgr.table {
@@ -275,7 +275,7 @@ func (mgr *ServerMgr) UpdateAppInst(key *edgeproto.AppInstKey) {
 	}
 }
 
-func (mgr *ServerMgr) UpdateCloudlet(key *edgeproto.CloudletKey) {
+func (mgr *ServerMgr) UpdateCloudlet(key *edgeproto.CloudletKey, old *edgeproto.Cloudlet) {
 	mgr.mux.Lock()
 	defer mgr.mux.Unlock()
 	for _, server := range mgr.table {
@@ -286,7 +286,7 @@ func (mgr *ServerMgr) UpdateCloudlet(key *edgeproto.CloudletKey) {
 	}
 }
 
-func (mgr *ServerMgr) UpdateFlavor(key *edgeproto.FlavorKey) {
+func (mgr *ServerMgr) UpdateFlavor(key *edgeproto.FlavorKey, old *edgeproto.Flavor) {
 	mgr.mux.Lock()
 	defer mgr.mux.Unlock()
 	for _, server := range mgr.table {
@@ -297,7 +297,7 @@ func (mgr *ServerMgr) UpdateFlavor(key *edgeproto.FlavorKey) {
 	}
 }
 
-func (mgr *ServerMgr) UpdateClusterFlavor(key *edgeproto.ClusterFlavorKey) {
+func (mgr *ServerMgr) UpdateClusterFlavor(key *edgeproto.ClusterFlavorKey, old *edgeproto.ClusterFlavor) {
 	mgr.mux.Lock()
 	defer mgr.mux.Unlock()
 	for _, server := range mgr.table {
@@ -308,7 +308,7 @@ func (mgr *ServerMgr) UpdateClusterFlavor(key *edgeproto.ClusterFlavorKey) {
 	}
 }
 
-func (mgr *ServerMgr) UpdateClusterInst(key *edgeproto.ClusterInstKey) {
+func (mgr *ServerMgr) UpdateClusterInst(key *edgeproto.ClusterInstKey, old *edgeproto.ClusterInst) {
 	mgr.mux.Lock()
 	defer mgr.mux.Unlock()
 	for _, server := range mgr.table {


### PR DESCRIPTION
When doing a notifycb, code now passes back the old object as well. This was needed by the CRM on appinst delete to be able to look up the cluster, because the clusterkey was part of the appinst data, not the appinstkey. Since the appinst was already deleted by that point, the clusterkey in the empty object was blank.

Make test now passes again.