### PR TITLE
EDGECLOUD-115 Add API and tests for GetCloudLetList()

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -439,7 +439,7 @@ public class EngineCallTest {
         // Temporary.
         assertEquals(response.getVer(), 0);
         assertEquals(response.getTowerStatus(), AppClient.Match_Engine_Loc_Verify.Tower_Status.TOWER_UNKNOWN);
-        assertEquals(response.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_UNKNOWN);
+        assertEquals(response.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_ERROR_OTHER);
     }
 
     @Test
@@ -478,7 +478,7 @@ public class EngineCallTest {
         // Temporary.
         assertEquals(response.getVer(), 0);
         assertEquals(response.getTowerStatus(), AppClient.Match_Engine_Loc_Verify.Tower_Status.TOWER_UNKNOWN);
-        assertEquals(response.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_UNKNOWN);
+        assertEquals(response.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_ERROR_OTHER);
     }
 
 
@@ -525,7 +525,7 @@ public class EngineCallTest {
         // Temporary.
         assertEquals(verifyLocationResult.getVer(), 0);
         assertEquals(verifyLocationResult.getTowerStatus(), AppClient.Match_Engine_Loc_Verify.Tower_Status.TOWER_UNKNOWN);
-        assertEquals(verifyLocationResult.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_UNKNOWN); // Based on test data.
+        assertEquals(verifyLocationResult.getGpsLocationStatus(), AppClient.Match_Engine_Loc_Verify.GPS_Location_Status.LOC_ERROR_OTHER); // Based on test data.
 
     }
 
@@ -717,5 +717,94 @@ public class EngineCallTest {
 
         // Temporary.
         assertEquals("SessionCookies must match", response.getSessionCookie(), "");
+    }
+
+    @Test
+    public void getCloudletListTest() {
+        Context context = InstrumentationRegistry.getContext();
+
+        MatchingEngine me = new MatchingEngine();
+        me.setMexLocationAllowed(true);
+
+        AppClient.Match_Engine_Status response = null;
+
+        enableMockLocation(context,true);
+        Location location = createLocation("getCloudletListTest", -122.149349, 37.459609);
+        MexLocation mexLoc = new MexLocation(me);
+
+        try {
+            setMockLocation(context, location);
+            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            assertFalse("Mock'ed Location is missing!", location == null);
+
+            registerClient(me, location);
+            AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(me, location);
+
+            AppClient.Match_Engine_Cloudlet_List list = me.getCloudletList(request, GRPC_TIMEOUT_MS);
+
+            assertEquals(list.getVer(), 0);
+            assertEquals(list.getStatus(), AppClient.Match_Engine_Cloudlet_List.CL_Status.CL_UNDEFINED);
+            assertEquals(list.getCloudletsCount(), 0); // NOTE: This is entirely test server dependent.
+            for (int i = 0; i < list.getCloudletsCount(); i++) {
+                Log.v(TAG, "Cloudlet: " + list.getCloudlets(i).toString());
+            }
+
+        } catch (ExecutionException ee) {
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("getCloudletListTest: ExecutionException!", true);
+        } catch (StatusRuntimeException sre) {
+            Log.i(TAG, Log.getStackTraceString(sre));
+            assertFalse("getCloudletListTest: StatusRuntimeException!", true);
+        } catch (InterruptedException ie) {
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("getCloudletListTest: InterruptedException!", true);
+        } finally {
+            enableMockLocation(context,false);
+        }
+    }
+
+    @Test
+    public void getCloudletListFutureTest() {
+        Context context = InstrumentationRegistry.getContext();
+
+        MatchingEngine me = new MatchingEngine();
+        me.setMexLocationAllowed(true);
+
+        AppClient.Match_Engine_Status response = null;
+
+        enableMockLocation(context,true);
+        Location location = createLocation("getCloudletListFutureTest", -122.149349, 37.459609);
+        MexLocation mexLoc = new MexLocation(me);
+
+        try {
+            setMockLocation(context, location);
+            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            assertFalse("Mock'ed Location is missing!", location == null);
+
+            registerClient(me, location);
+            AppClient.Match_Engine_Request request = createMockMatchingEngineRequest(me, location);
+
+            Future<AppClient.Match_Engine_Cloudlet_List> listFuture = me.getCloudletListFuture(request, GRPC_TIMEOUT_MS);
+            AppClient.Match_Engine_Cloudlet_List list = listFuture.get();
+
+            assertEquals(list.getVer(), 0);
+            assertEquals(list.getStatus(), AppClient.Match_Engine_Cloudlet_List.CL_Status.CL_UNDEFINED);
+            assertEquals(list.getCloudletsCount(), 0); // NOTE: This is entirely test server dependent.
+            for (int i = 0; i < list.getCloudletsCount(); i++) {
+                Log.v(TAG, "Cloudlet: " + list.getCloudlets(i).toString());
+            }
+
+        } catch (ExecutionException ee) {
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("getCloudletListFutureTest: ExecutionException!", true);
+        } catch (StatusRuntimeException sre) {
+            Log.i(TAG, Log.getStackTraceString(sre));
+            assertFalse("getCloudletListFutureTest: StatusRuntimeException!", true);
+        } catch (InterruptedException ie) {
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("getCloudletListFutureTest: InterruptedException!", true);
+        } finally {
+            enableMockLocation(context,false);
+        }
     }
 }

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetCloudletList.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetCloudletList.java
@@ -1,0 +1,74 @@
+package com.mobiledgex.matchingengine;
+
+import android.util.Log;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import distributed_match_engine.AppClient;
+import distributed_match_engine.Match_Engine_ApiGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+
+public class GetCloudletList implements Callable {
+    public static final String TAG = "GetLocation";
+
+    private MatchingEngine mMatchingEngine;
+    private AppClient.Match_Engine_Request mRequest;
+    private long mTimeoutInMilliseconds = -1;
+
+    GetCloudletList(MatchingEngine matchingEngine) {
+        mMatchingEngine = matchingEngine;
+    }
+
+    public boolean setRequest(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
+        if (request == null) {
+            throw new IllegalArgumentException("Request object must not be null.");
+        } else if (!mMatchingEngine.isMexLocationAllowed()) {
+            Log.d(TAG, "Mex Location is disabled.");
+            mRequest = null;
+            return false;
+        }
+        mRequest = request;
+
+        if (timeoutInMilliseconds <= 0) {
+            throw new IllegalArgumentException("GetCloudletList() timeout must be positive.");
+        }
+        mTimeoutInMilliseconds = timeoutInMilliseconds;
+        return true;
+    }
+
+    @Override
+    public AppClient.Match_Engine_Cloudlet_List call()
+            throws MissingRequestException, StatusRuntimeException {
+        if (mRequest == null) {
+            throw new MissingRequestException("Usage error: GetCloudletList does not have a request object!");
+        }
+
+        AppClient.Match_Engine_Cloudlet_List reply;
+        // FIXME: UsePlaintxt means no encryption is enabled to the MatchEngine server!
+        ManagedChannel channel = null;
+        try {
+            channel = ManagedChannelBuilder.forAddress(mMatchingEngine.getHost(), mMatchingEngine.getPort()).usePlaintext().build();
+            Match_Engine_ApiGrpc.Match_Engine_ApiBlockingStub stub = Match_Engine_ApiGrpc.newBlockingStub(channel);
+
+            reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
+                    .getCloudlets(mRequest);
+        } finally {
+            if (channel != null) {
+                channel.shutdown();
+            }
+        }
+        mRequest = null;
+
+        int ver;
+        if (reply != null) {
+            ver = reply.getVer();
+            Log.d(TAG, "Version of Match_Engine_Cloudlet_List: " + ver);
+        }
+
+        return reply;
+    }
+}

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -404,6 +405,25 @@ public class MatchingEngine {
         AddUserToGroup addUserToGroup = new AddUserToGroup(this);
         addUserToGroup.setRequest(request, timeoutInMilliseconds);
         return submit(addUserToGroup);
+    }
+
+    /**
+     * Retrieve nearby Cloudlets (or AppInsts) for registered application. This is a blocking call.
+     * @param request
+     * @param timeoutInMilliseconds
+     * @return
+     */
+    public AppClient.Match_Engine_Cloudlet_List getCloudletList(AppClient.Match_Engine_Request request, long timeoutInMilliseconds)
+            throws InterruptedException, ExecutionException {
+        GetCloudletList getCloudletList = new GetCloudletList(this);
+        getCloudletList.setRequest(request, timeoutInMilliseconds);
+        return getCloudletList.call();
+    }
+
+    public Future<AppClient.Match_Engine_Cloudlet_List> getCloudletListFuture(AppClient.Match_Engine_Request request, long timeoutInMilliseconds) {
+        GetCloudletList getCloudletList = new GetCloudletList(this);
+        getCloudletList.setRequest(request, timeoutInMilliseconds);
+        return submit(getCloudletList);
     }
 
     public String getHost() {


### PR DESCRIPTION
Adds the requested wrapped GRPC API to get list of cloudlets, if still needed. The tests assume there is a list of 0 cloudlets for now, as this is dependent on the actual server setup outside the test case.

This does not require the upcoming NetworkManager API.