### PR TITLE
EDGECLOUD-140 fix DME no data after restart

### DIFF
--- a/d-match-engine/dme-server/match-engine.go
+++ b/d-match-engine/dme-server/match-engine.go
@@ -24,6 +24,7 @@ type carrierAppInst struct {
 	ip []byte
 	// Location of the cloudlet site (lat, long?)
 	location dme.Loc
+	id       uint64
 }
 
 type carrierAppKey struct {
@@ -103,6 +104,7 @@ func addApp(appInst *edgeproto.AppInst) {
 		cNew.carrierName = key.carrierName
 		cNew.uri = appInst.Uri
 		cNew.location = appInst.CloudletLoc
+		cNew.id = appInst.Key.Id
 		app.insts[cNew.cloudletKey] = cNew
 		log.DebugLog(log.DebugLevelDmedb, "Adding app inst",
 			"appName", app.key.appKey.Name,
@@ -160,7 +162,9 @@ func pruneApps(appInsts map[edgeproto.AppInstKey]struct{}) {
 		for _, inst := range app.insts {
 			key.AppKey = app.key.appKey
 			key.CloudletKey = inst.cloudletKey
+			key.Id = inst.id
 			if _, found := appInsts[key]; !found {
+				log.DebugLog(log.DebugLevelDmereq, "pruning app", "key", key)
 				delete(app.insts, key.CloudletKey)
 			}
 		}

--- a/setup-env/apis/dmeapi.go
+++ b/setup-env/apis/dmeapi.go
@@ -108,14 +108,16 @@ func RunDmeAPI(api string, procname string, apiFile string, outputDir string) bo
 		// to be sorted to allow a consistent yaml compare
 		log.Printf("DME REQUEST: %+v\n", apiRequest.MatchEngineRequest)
 		mel, err := client.GetCloudlets(ctx, &apiRequest.MatchEngineRequest)
-		sort.Slice((*mel).Cloudlets, func(i, j int) bool {
-			return (*mel).Cloudlets[i].CloudletName < (*mel).Cloudlets[j].CloudletName
-		})
-		//appinstances within the cloudlet must be sorted too
-		for _, c := range (*mel).Cloudlets {
-			sort.Slice(c.Appinstances, func(i, j int) bool {
-				return c.Appinstances[i].Appname < c.Appinstances[j].Appname
+		if err == nil {
+			sort.Slice((*mel).Cloudlets, func(i, j int) bool {
+				return (*mel).Cloudlets[i].CloudletName < (*mel).Cloudlets[j].CloudletName
 			})
+			//appinstances within the cloudlet must be sorted too
+			for _, c := range (*mel).Cloudlets {
+				sort.Slice(c.Appinstances, func(i, j int) bool {
+					return c.Appinstances[i].Appname < c.Appinstances[j].Appname
+				})
+			}
 		}
 		dmereply = mel
 		dmeerror = err

--- a/setup-env/e2e-tests/testfiles/get_cloudlets.yml
+++ b/setup-env/e2e-tests/testfiles/get_cloudlets.yml
@@ -12,6 +12,27 @@ tests:
     yaml2: "{{datadir}}/show10.yml"
     filetype: appdata
 
+- includefile: register.yml
+
+- name: get cloudlets
+  actions: [dmeapi-getcloudlets] 
+  apifile: "{{datadir}}/mer_get_cloudlets_all.yml"
+  compareyaml:
+     yaml1: "{{outputdir}}/getcloudlets.yml"
+     yaml2: "{{datadir}}/get_cloudlets_result_all.yml"
+     filetype: getcloudlets
+
+- name: stop and restart dme
+  actions: [stop=dme1,start=dme1,sleep=1]
+
+- name: get cloudlets
+  actions: [dmeapi-getcloudlets]
+  apifile: "{{datadir}}/mer_get_cloudlets_all.yml"
+  compareyaml:
+     yaml1: "{{outputdir}}/getcloudlets.yml"
+     yaml2: "{{datadir}}/get_cloudlets_result_all.yml"
+     filetype: getcloudlets
+ 
 - name: delete provisioning, verify it is empty
   actions: [ctrlapi-delete,ctrlapi-show]
   apifile: "{{datadir}}/appdata_10.yml"


### PR DESCRIPTION
Fixes the following scenario:

1) provision cloudlets and appinst's
2) perform DME APIs such as GetCloudlets --> everything works
3) restart DME
4) repeat step 2 --> no data

The problem is that function pruneApps removes what is perceives to be extraneous entries from the table.  It ends up deleting every single entry every time.  The reason is that there is a new "Id" field in the appinst which was not reflected in the DME table, so all entries mismatched.

Also re-add the FindCloudlets testcase to regression and include in this test a DME restart.  This test will fail without this fix.  Finally, fix e2e dme API tests to bypass sorting on an error, this is not really related to the problem above but I noticed it while testing.