### PR TITLE
Expose ability to disable NetworkManager to the applciation, in case there is no actual carrier network. This is mainly to support testing.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -78,6 +78,14 @@ public class MatchingEngine {
         mMexLocationAllowed = allowMexLocation;
     }
 
+    public boolean isNetworkSwitchingEnabled() {
+        return this.getNetworkManager().isNetworkSwitchingEnabled();
+    }
+
+    public void setNetworkSwitchingEnabled(boolean networkSwitchingEnabled) {
+        this.getNetworkManager().setNetworkSwitchingEnabled(networkSwitchingEnabled);
+    }
+
     /**
      * Check if Roaming Data is enabled on the System.
      * @return

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
@@ -41,7 +41,7 @@ public class NetworkManager {
     private ExecutorService mThreadPool;
     private boolean mNetworkSwitchingEnabled = true;
 
-    public boolean ismNetworkSwitchingEnabled() {
+    public boolean isNetworkSwitchingEnabled() {
         return mNetworkSwitchingEnabled;
     }
 

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
@@ -47,7 +47,7 @@ public class VerifyLocation implements Callable {
         return true;
     }
 
-    private String getToken() throws InterruptedException, IOException, ExecutionException {
+    private String getToken() throws IOException {
         String token;
 
         OkHttpClient httpClient = new OkHttpClient();


### PR DESCRIPTION
Small change, with test case. There is a reference in the test case to a test server at nosim.dme.mobiledgex.net. It's probably a good idea to create a server there.