### PR TITLE
Maven only version of the Sample EmptyMatchEngineApp. Bump matchingengine to 0.0.2 for maven release compile.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/app/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'com.android.application'
 def grpcVersion='1.13.1'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.mobiledgex.emptymatchengineapp"
         minSdkVersion 23
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -25,8 +25,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     implementation 'com.android.support:design:27.1.1'
-
     implementation 'com.android.support:support-v4:27.1.1'
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
@@ -35,7 +35,7 @@ dependencies {
     implementation project(":matchingengine")
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:0.0.1'
+    //implementation 'com.mobiledgex:matchingengine:0.0.2'
     // Dependencies of Matching Engine, if using Maven:
     //implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     //implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.google.protobuf'
 apply plugin: 'maven-publish'
 
-def grpcVersion='1.14.0'
+def grpcVersion='1.13.1'
 
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
@@ -16,7 +16,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "0.0.1"
+        versionName "0.0.2"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -44,18 +44,6 @@ android {
             java {
             }
         }
-    }
-    packagingOptions {
-        exclude 'META-INF/INDEX.LIST'
-        exclude 'META-INF/DEPENDENCIES'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/license.txt'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/NOTICE.txt'
-        exclude 'META-INF/notice.txt'
-        exclude 'META-INF/ASL2.0'
-        exclude 'META-INF/io.netty.versions.properties'
     }
 }
 
@@ -97,13 +85,10 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
-    // You need to build grpc-java to obtain these libraries below.
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"
-    //implementation "io.grpc:grpc-android:${grpcVersion}"
-    //implementation "io.grpc:grpc-netty:${grpcVersion}"
-    //implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
+
     protobuf 'com.google.protobuf:protobuf-java:3.0.2' // FIXME: Timestamp, for lite version: old lib: https://github.com/google/protobuf/issues/1889
     implementation 'javax.annotation:javax.annotation-api:1.2'
 
@@ -117,7 +102,7 @@ publishing {
             def version = android.defaultConfig.versionName
             def releasesRepoUrl = "https://registry.mobiledgex.net/nexus/content/repositories/releases/"
             def snapshotsRepoUrl = "https://registry.mobiledgex.net/nexus/content/repositories/snapshots/"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            url = version.endsWith('SNAP') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
                 username nexusUser
                 password nexusPassword

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -58,7 +58,7 @@ public class EngineCallTest {
             // FIXME: Read application cert and keys.
             InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand(
                     "pm grant " + InstrumentationRegistry.getTargetContext().getPackageName()
-                            + " android.permission.ACCESS_COARSE_LOCATION");
+                            + " android.permission.READ_EXTERNAL_STORAGE");
         }
     }
 
@@ -417,6 +417,7 @@ public class EngineCallTest {
             assertFalse("mexNetworkingDisabledTest: InterruptedException!", true);
         } finally {
             enableMockLocation(context,false);
+            me.setNetworkSwitchingEnabled(true);
         }
     }
 

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AddUserToGroup.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AddUserToGroup.java
@@ -12,7 +12,6 @@ import java.util.concurrent.TimeUnit;
 import distributed_match_engine.AppClient;
 import distributed_match_engine.Match_Engine_ApiGrpc;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 
 public class AddUserToGroup implements Callable {

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
@@ -13,7 +13,6 @@ import distributed_match_engine.AppClient;
 import distributed_match_engine.Match_Engine_ApiGrpc;
 
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 
 public class FindCloudlet implements Callable {

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetCloudletList.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetCloudletList.java
@@ -12,7 +12,6 @@ import java.util.concurrent.TimeUnit;
 import distributed_match_engine.AppClient;
 import distributed_match_engine.Match_Engine_ApiGrpc;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 
 public class GetCloudletList implements Callable {

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
@@ -2,8 +2,6 @@ package com.mobiledgex.matchingengine;
 
 import android.util.Log;
 
-import com.mobiledgex.matchingengine.util.OkHttpSSLChannelHelper;
-
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -11,15 +9,10 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSocketFactory;
-
 import distributed_match_engine.AppClient;
 import distributed_match_engine.Match_Engine_ApiGrpc;
 import io.grpc.ManagedChannel;
-import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.grpc.okhttp.OkHttpChannelBuilder;
 
 public class RegisterClient implements Callable {
     public static final String TAG = "RegisterClient";

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import distributed_match_engine.AppClient;
 import distributed_match_engine.Match_Engine_ApiGrpc;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 
 public class VerifyLocation implements Callable {


### PR DESCRIPTION
Minor grab bag. Some misc cleanup, test permissions, Android API target bump, put GRPC version back to 1.13.1 for now. 1.14.0 has security issues.