### PR TITLE
EDGECLOUD-171 fix clusterflavor not found misleading error message

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -127,6 +127,9 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 		if in.Flavor.Name == "" {
 			in.Flavor = cluster.DefaultFlavor
 		}
+		if in.Flavor.Name == "" {
+			return errors.New("No ClusterFlavor specified and no default ClusterFlavor for Cluster")
+		}
 		clusterFlavor := edgeproto.ClusterFlavor{}
 		if !clusterFlavorApi.store.STMGet(stm, &in.Flavor, &clusterFlavor) {
 			return fmt.Errorf("Cluster flavor %s not found", in.Flavor.Name)

--- a/notify/notify_client.go
+++ b/notify/notify_client.go
@@ -380,12 +380,6 @@ func (s *Client) recv(stream edgeproto.NotifyApi_StreamNoticeClient) {
 			s.stats.Recv++
 		}
 		clusterflavor := reply.GetClusterFlavor()
-		if clusterflavor != nil {
-			log.DebugLog(log.DebugLevelNotify,
-				"client cluster flavor update",
-				"key", clusterflavor.Key.GetKeyString(),
-				"recv", recvClusterFlavor)
-		}
 		if recvClusterFlavor != nil && clusterflavor != nil {
 			if reply.Action == edgeproto.NoticeAction_UPDATE {
 				log.DebugLog(log.DebugLevelNotify,


### PR DESCRIPTION
This fixes the misleading error message noted in 171, and removes an unnecessary INFO log.