### PR TITLE
sanitize k8s strings

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -86,6 +86,7 @@ func main() {
 			err = crmutil.MEXPlatformInitCloudletKey(controllerData.CRMRootLB, *cloudletKeyStr)
 			if err != nil {
 				log.DebugLog(log.DebugLevelMexos, "Error running MEX Agent", "error", err)
+				return
 			}
 			log.DebugLog(log.DebugLevelMexos, "init platform with cloudlet key ok")
 			//XXX we initialize platform when crmserver starts. But when do we clean up the platform?

--- a/util/validate.go
+++ b/util/validate.go
@@ -42,7 +42,7 @@ func DockerSanitize(name string) string {
 }
 
 // DNSSanitize santizies the name string to make it usable in
-// a DNS name. Valid chars are only 0-9, a-z (both cases), and '-'.
+// a DNS name. Valid chars are only 0-9, a-z, and '-'.
 func DNSSanitize(name string) string {
 	r := strings.NewReplacer(
 		"_", "-",
@@ -51,7 +51,7 @@ func DNSSanitize(name string) string {
 		",", "",
 		".", "",
 		"!", "")
-	return r.Replace(name)
+	return strings.ToLower(r.Replace(name))
 }
 
 func K8SSanitize(name string) string {
@@ -61,5 +61,5 @@ func K8SSanitize(name string) string {
 		"&", "",
 		",", "",
 		"!", "")
-	return r.Replace(name)
+	return strings.ToLower(r.Replace(name))
 }


### PR DESCRIPTION
- tweak util. K8SSanitize and DNSSanitize to convert to lower case strings.   kubernetes resources should be lower case and DNS is case insensitive.  
- invoke K8SSanitize within the mex k8s templates to deal with app names with spaces and convert apps and operator names to lower case
- add one return to an error case if the mex agent fails to startup