### PR TITLE
EDGECLOUD-172 EDGECLOUD-176 EDGECLOUD-177 EDGECLOUD-178 EDGECLOUD-179

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -216,6 +216,11 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 				return objstore.ErrKVStoreKeyExists
 			}
 			in.Errors = nil
+		} else {
+			err := in.Validate(edgeproto.AppInstAllFieldsMap)
+			if err != nil {
+				return err
+			}
 		}
 
 		// cache location of cloudlet in app inst

--- a/controller/cluster_api.go
+++ b/controller/cluster_api.go
@@ -66,6 +66,9 @@ func (s *ClusterApi) DeleteCluster(ctx context.Context, in *edgeproto.Cluster) (
 	if appApi.UsesCluster(&in.Key) {
 		return &edgeproto.Result{}, errors.New("Cluster in use by Application")
 	}
+	if clusterInstApi.UsesCluster(&in.Key) {
+		return &edgeproto.Result{}, errors.New("Cluster in use by ClusterInst")
+	}
 	return s.store.Delete(in, s.sync.syncWait)
 }
 

--- a/controller/gateway.go
+++ b/controller/gateway.go
@@ -40,7 +40,6 @@ func grpcGateway(addr string, tlsCertFile string) (http.Handler, error) {
 		edgeproto.RegisterDeveloperApiHandler,
 		edgeproto.RegisterAppApiHandler,
 		edgeproto.RegisterAppInstApiHandler,
-		edgeproto.RegisterAppInstInfoApiHandler,
 		edgeproto.RegisterOperatorApiHandler,
 		edgeproto.RegisterCloudletApiHandler,
 		edgeproto.RegisterCloudletInfoApiHandler,
@@ -48,7 +47,8 @@ func grpcGateway(addr string, tlsCertFile string) (http.Handler, error) {
 		edgeproto.RegisterClusterFlavorApiHandler,
 		edgeproto.RegisterClusterApiHandler,
 		edgeproto.RegisterClusterInstApiHandler,
-		edgeproto.RegisterClusterInstInfoApiHandler,
+		edgeproto.RegisterControllerApiHandler,
+		edgeproto.RegisterNodeApiHandler,
 	} {
 		if err := f(ctx, mux, conn); err != nil {
 			return nil, err

--- a/edgectl/main.go
+++ b/edgectl/main.go
@@ -115,8 +115,6 @@ func main() {
 	controllerCmd.AddCommand(gencmd.CloudletApiCmds...)
 	controllerCmd.AddCommand(gencmd.AppInstApiCmds...)
 	controllerCmd.AddCommand(gencmd.DebugApiCmds...)
-	controllerCmd.AddCommand(gencmd.AppInstInfoApiCmds...)
-	controllerCmd.AddCommand(gencmd.ClusterInstInfoApiCmds...)
 	controllerCmd.AddCommand(gencmd.CloudletInfoApiCmds...)
 	controllerCmd.AddCommand(gencmd.ControllerApiCmds...)
 	controllerCmd.AddCommand(gencmd.NodeApiCmds...)
@@ -124,8 +122,9 @@ func main() {
 	dmeCmd.AddCommand(gencmd.Match_Engine_ApiCmds...)
 	dmeCmd.AddCommand(gencmd.DebugApiCmds...)
 
-	crmCmd.AddCommand(gencmd.CloudResourceManagerCmds...)
 	crmCmd.AddCommand(gencmd.DebugApiCmds...)
+	crmCmd.AddCommand(gencmd.ClusterInstInfoApiCmds...)
+	crmCmd.AddCommand(gencmd.AppInstInfoApiCmds...)
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -125,7 +125,20 @@ func (key *FlavorKey) Validate() error {
 }
 
 func (s *Flavor) Validate(fields map[string]struct{}) error {
-	return s.GetKey().Validate()
+	err := s.GetKey().Validate()
+	if err != nil {
+		return err
+	}
+	if _, found := fields[FlavorFieldRam]; found && s.Ram == 0 {
+		return errors.New("Ram cannot be 0")
+	}
+	if _, found := fields[FlavorFieldVcpus]; found && s.Vcpus == 0 {
+		return errors.New("Vcpus cannot be 0")
+	}
+	if _, found := fields[FlavorFieldDisk]; found && s.Disk == 0 {
+		return errors.New("Disk cannot be 0")
+	}
+	return nil
 }
 
 func (key *ClusterFlavorKey) Validate() error {
@@ -136,7 +149,26 @@ func (key *ClusterFlavorKey) Validate() error {
 }
 
 func (s *ClusterFlavor) Validate(fields map[string]struct{}) error {
-	return s.GetKey().Validate()
+	err := s.GetKey().Validate()
+	if err != nil {
+		return err
+	}
+	if _, found := fields[ClusterFlavorFieldNodeFlavor]; found && s.NodeFlavor.Name == "" {
+		return errors.New("Invalid empty string for Node Flavor")
+	}
+	if _, found := fields[ClusterFlavorFieldMasterFlavor]; found && s.MasterFlavor.Name == "" {
+		return errors.New("Invalid empty string for Master Flavor")
+	}
+	if _, found := fields[ClusterFlavorFieldNumNodes]; found && s.NumNodes == 0 {
+		return errors.New("Number of nodes cannot be 0")
+	}
+	if _, found := fields[ClusterFlavorFieldMaxNodes]; found && s.MaxNodes == 0 {
+		return errors.New("Number of maximum nodes cannot be 0")
+	}
+	if _, found := fields[ClusterFlavorFieldNumMasters]; found && s.NumMasters == 0 {
+		return errors.New("Number of master nodes cannot be 0")
+	}
+	return nil
 }
 
 func (key *AppKey) Validate() error {

--- a/gencmd/app-client.cmd.go
+++ b/gencmd/app-client.cmd.go
@@ -37,6 +37,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -721,7 +722,12 @@ var FindCloudletCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := Match_Engine_ApiCmd.FindCloudlet(ctx, &Match_Engine_RequestIn)
 		if err != nil {
-			return fmt.Errorf("FindCloudlet failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("FindCloudlet failed: %s", errstr)
 		}
 		Match_Engine_ReplyWriteOutputOne(obj)
 		return nil
@@ -744,7 +750,12 @@ var VerifyLocationCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := Match_Engine_ApiCmd.VerifyLocation(ctx, &Match_Engine_RequestIn)
 		if err != nil {
-			return fmt.Errorf("VerifyLocation failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("VerifyLocation failed: %s", errstr)
 		}
 		Match_Engine_Loc_VerifyWriteOutputOne(obj)
 		return nil
@@ -767,7 +778,12 @@ var GetLocationCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := Match_Engine_ApiCmd.GetLocation(ctx, &Match_Engine_RequestIn)
 		if err != nil {
-			return fmt.Errorf("GetLocation failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("GetLocation failed: %s", errstr)
 		}
 		Match_Engine_LocWriteOutputOne(obj)
 		return nil
@@ -790,7 +806,12 @@ var RegisterClientCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := Match_Engine_ApiCmd.RegisterClient(ctx, &Match_Engine_RequestIn)
 		if err != nil {
-			return fmt.Errorf("RegisterClient failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("RegisterClient failed: %s", errstr)
 		}
 		Match_Engine_StatusWriteOutputOne(obj)
 		return nil
@@ -813,7 +834,12 @@ var AddUserToGroupCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := Match_Engine_ApiCmd.AddUserToGroup(ctx, &DynamicLocGroupAddIn)
 		if err != nil {
-			return fmt.Errorf("AddUserToGroup failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("AddUserToGroup failed: %s", errstr)
 		}
 		Match_Engine_StatusWriteOutputOne(obj)
 		return nil
@@ -836,7 +862,12 @@ var GetCloudletsCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := Match_Engine_ApiCmd.GetCloudlets(ctx, &Match_Engine_RequestIn)
 		if err != nil {
-			return fmt.Errorf("GetCloudlets failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("GetCloudlets failed: %s", errstr)
 		}
 		Match_Engine_Cloudlet_ListWriteOutputOne(obj)
 		return nil

--- a/gencmd/app.cmd.go
+++ b/gencmd/app.cmd.go
@@ -76,6 +76,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -223,7 +224,12 @@ var CreateAppCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := AppApiCmd.CreateApp(ctx, &AppIn)
 		if err != nil {
-			return fmt.Errorf("CreateApp failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("CreateApp failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -246,7 +252,12 @@ var DeleteAppCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := AppApiCmd.DeleteApp(ctx, &AppIn)
 		if err != nil {
-			return fmt.Errorf("DeleteApp failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteApp failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -270,7 +281,12 @@ var UpdateAppCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := AppApiCmd.UpdateApp(ctx, &AppIn)
 		if err != nil {
-			return fmt.Errorf("UpdateApp failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("UpdateApp failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -293,7 +309,12 @@ var ShowAppCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := AppApiCmd.ShowApp(ctx, &AppIn)
 		if err != nil {
-			return fmt.Errorf("ShowApp failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowApp failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.App, 0)
 		for {

--- a/gencmd/app_inst.cmd.go
+++ b/gencmd/app_inst.cmd.go
@@ -16,6 +16,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -392,7 +393,12 @@ var CreateAppInstCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := AppInstApiCmd.CreateAppInst(ctx, &AppInstIn)
 		if err != nil {
-			return fmt.Errorf("CreateAppInst failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("CreateAppInst failed: %s", errstr)
 		}
 		for {
 			obj, err := stream.Recv()
@@ -424,7 +430,12 @@ var DeleteAppInstCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := AppInstApiCmd.DeleteAppInst(ctx, &AppInstIn)
 		if err != nil {
-			return fmt.Errorf("DeleteAppInst failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteAppInst failed: %s", errstr)
 		}
 		for {
 			obj, err := stream.Recv()
@@ -457,7 +468,12 @@ var UpdateAppInstCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := AppInstApiCmd.UpdateAppInst(ctx, &AppInstIn)
 		if err != nil {
-			return fmt.Errorf("UpdateAppInst failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("UpdateAppInst failed: %s", errstr)
 		}
 		for {
 			obj, err := stream.Recv()
@@ -489,7 +505,12 @@ var ShowAppInstCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := AppInstApiCmd.ShowAppInst(ctx, &AppInstIn)
 		if err != nil {
-			return fmt.Errorf("ShowAppInst failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowAppInst failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.AppInst, 0)
 		for {
@@ -534,7 +555,12 @@ var ShowAppInstInfoCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := AppInstInfoApiCmd.ShowAppInstInfo(ctx, &AppInstInfoIn)
 		if err != nil {
-			return fmt.Errorf("ShowAppInstInfo failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowAppInstInfo failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.AppInstInfo, 0)
 		for {
@@ -572,7 +598,12 @@ var ShowAppInstMetricsCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := AppInstMetricsApiCmd.ShowAppInstMetrics(ctx, &AppInstMetricsIn)
 		if err != nil {
-			return fmt.Errorf("ShowAppInstMetrics failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowAppInstMetrics failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.AppInstMetrics, 0)
 		for {

--- a/gencmd/cloud-resource-manager.cmd.go
+++ b/gencmd/cloud-resource-manager.cmd.go
@@ -14,6 +14,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -280,7 +281,12 @@ var ListCloudResourceCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := CloudResourceManagerCmd.ListCloudResource(ctx, &CloudResourceIn)
 		if err != nil {
-			return fmt.Errorf("ListCloudResource failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ListCloudResource failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.CloudResource, 0)
 		for {
@@ -317,7 +323,12 @@ var AddCloudResourceCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := CloudResourceManagerCmd.AddCloudResource(ctx, &CloudResourceIn)
 		if err != nil {
-			return fmt.Errorf("AddCloudResource failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("AddCloudResource failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -340,7 +351,12 @@ var DeleteCloudResourceCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := CloudResourceManagerCmd.DeleteCloudResource(ctx, &CloudResourceIn)
 		if err != nil {
-			return fmt.Errorf("DeleteCloudResource failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteCloudResource failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -359,7 +375,12 @@ var DeployApplicationCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := CloudResourceManagerCmd.DeployApplication(ctx, &EdgeCloudApplicationIn)
 		if err != nil {
-			return fmt.Errorf("DeployApplication failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeployApplication failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -378,7 +399,12 @@ var DeleteApplicationCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := CloudResourceManagerCmd.DeleteApplication(ctx, &EdgeCloudApplicationIn)
 		if err != nil {
-			return fmt.Errorf("DeleteApplication failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteApplication failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil

--- a/gencmd/cloudlet.cmd.go
+++ b/gencmd/cloudlet.cmd.go
@@ -16,6 +16,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -269,7 +270,12 @@ var CreateCloudletCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := CloudletApiCmd.CreateCloudlet(ctx, &CloudletIn)
 		if err != nil {
-			return fmt.Errorf("CreateCloudlet failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("CreateCloudlet failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Result, 0)
 		for {
@@ -306,7 +312,12 @@ var DeleteCloudletCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := CloudletApiCmd.DeleteCloudlet(ctx, &CloudletIn)
 		if err != nil {
-			return fmt.Errorf("DeleteCloudlet failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteCloudlet failed: %s", errstr)
 		}
 		for {
 			obj, err := stream.Recv()
@@ -339,7 +350,12 @@ var UpdateCloudletCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := CloudletApiCmd.UpdateCloudlet(ctx, &CloudletIn)
 		if err != nil {
-			return fmt.Errorf("UpdateCloudlet failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("UpdateCloudlet failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Result, 0)
 		for {
@@ -376,7 +392,12 @@ var ShowCloudletCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := CloudletApiCmd.ShowCloudlet(ctx, &CloudletIn)
 		if err != nil {
-			return fmt.Errorf("ShowCloudlet failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowCloudlet failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Cloudlet, 0)
 		for {
@@ -420,7 +441,12 @@ var ShowCloudletInfoCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := CloudletInfoApiCmd.ShowCloudletInfo(ctx, &CloudletInfoIn)
 		if err != nil {
-			return fmt.Errorf("ShowCloudletInfo failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowCloudletInfo failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.CloudletInfo, 0)
 		for {
@@ -457,7 +483,12 @@ var InjectCloudletInfoCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := CloudletInfoApiCmd.InjectCloudletInfo(ctx, &CloudletInfoIn)
 		if err != nil {
-			return fmt.Errorf("InjectCloudletInfo failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("InjectCloudletInfo failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -480,7 +511,12 @@ var EvictCloudletInfoCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := CloudletInfoApiCmd.EvictCloudletInfo(ctx, &CloudletInfoIn)
 		if err != nil {
-			return fmt.Errorf("EvictCloudletInfo failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("EvictCloudletInfo failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -505,7 +541,12 @@ var ShowCloudletMetricsCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := CloudletMetricsApiCmd.ShowCloudletMetrics(ctx, &CloudletMetricsIn)
 		if err != nil {
-			return fmt.Errorf("ShowCloudletMetrics failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowCloudletMetrics failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.CloudletMetrics, 0)
 		for {

--- a/gencmd/cluster.cmd.go
+++ b/gencmd/cluster.cmd.go
@@ -13,6 +13,7 @@ import "io"
 import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -124,7 +125,12 @@ var CreateClusterCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := ClusterApiCmd.CreateCluster(ctx, &ClusterIn)
 		if err != nil {
-			return fmt.Errorf("CreateCluster failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("CreateCluster failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -143,7 +149,12 @@ var DeleteClusterCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := ClusterApiCmd.DeleteCluster(ctx, &ClusterIn)
 		if err != nil {
-			return fmt.Errorf("DeleteCluster failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteCluster failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -163,7 +174,12 @@ var UpdateClusterCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := ClusterApiCmd.UpdateCluster(ctx, &ClusterIn)
 		if err != nil {
-			return fmt.Errorf("UpdateCluster failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("UpdateCluster failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -182,7 +198,12 @@ var ShowClusterCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := ClusterApiCmd.ShowCluster(ctx, &ClusterIn)
 		if err != nil {
-			return fmt.Errorf("ShowCluster failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowCluster failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Cluster, 0)
 		for {

--- a/gencmd/clusterflavor.cmd.go
+++ b/gencmd/clusterflavor.cmd.go
@@ -13,6 +13,7 @@ import "io"
 import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -130,7 +131,12 @@ var CreateClusterFlavorCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := ClusterFlavorApiCmd.CreateClusterFlavor(ctx, &ClusterFlavorIn)
 		if err != nil {
-			return fmt.Errorf("CreateClusterFlavor failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("CreateClusterFlavor failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -149,7 +155,12 @@ var DeleteClusterFlavorCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := ClusterFlavorApiCmd.DeleteClusterFlavor(ctx, &ClusterFlavorIn)
 		if err != nil {
-			return fmt.Errorf("DeleteClusterFlavor failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteClusterFlavor failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -169,7 +180,12 @@ var UpdateClusterFlavorCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := ClusterFlavorApiCmd.UpdateClusterFlavor(ctx, &ClusterFlavorIn)
 		if err != nil {
-			return fmt.Errorf("UpdateClusterFlavor failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("UpdateClusterFlavor failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -188,7 +204,12 @@ var ShowClusterFlavorCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := ClusterFlavorApiCmd.ShowClusterFlavor(ctx, &ClusterFlavorIn)
 		if err != nil {
-			return fmt.Errorf("ShowClusterFlavor failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowClusterFlavor failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.ClusterFlavor, 0)
 		for {

--- a/gencmd/clusterinst.cmd.go
+++ b/gencmd/clusterinst.cmd.go
@@ -14,6 +14,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -240,7 +241,12 @@ var CreateClusterInstCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := ClusterInstApiCmd.CreateClusterInst(ctx, &ClusterInstIn)
 		if err != nil {
-			return fmt.Errorf("CreateClusterInst failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("CreateClusterInst failed: %s", errstr)
 		}
 		for {
 			obj, err := stream.Recv()
@@ -272,7 +278,12 @@ var DeleteClusterInstCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := ClusterInstApiCmd.DeleteClusterInst(ctx, &ClusterInstIn)
 		if err != nil {
-			return fmt.Errorf("DeleteClusterInst failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteClusterInst failed: %s", errstr)
 		}
 		for {
 			obj, err := stream.Recv()
@@ -305,7 +316,12 @@ var UpdateClusterInstCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := ClusterInstApiCmd.UpdateClusterInst(ctx, &ClusterInstIn)
 		if err != nil {
-			return fmt.Errorf("UpdateClusterInst failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("UpdateClusterInst failed: %s", errstr)
 		}
 		for {
 			obj, err := stream.Recv()
@@ -337,7 +353,12 @@ var ShowClusterInstCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := ClusterInstApiCmd.ShowClusterInst(ctx, &ClusterInstIn)
 		if err != nil {
-			return fmt.Errorf("ShowClusterInst failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowClusterInst failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.ClusterInst, 0)
 		for {
@@ -382,7 +403,12 @@ var ShowClusterInstInfoCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := ClusterInstInfoApiCmd.ShowClusterInstInfo(ctx, &ClusterInstInfoIn)
 		if err != nil {
-			return fmt.Errorf("ShowClusterInstInfo failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowClusterInstInfo failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.ClusterInstInfo, 0)
 		for {

--- a/gencmd/controller.cmd.go
+++ b/gencmd/controller.cmd.go
@@ -12,6 +12,7 @@ import "io"
 import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -119,7 +120,12 @@ var ShowControllerCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := ControllerApiCmd.ShowController(ctx, &ControllerIn)
 		if err != nil {
-			return fmt.Errorf("ShowController failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowController failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Controller, 0)
 		for {

--- a/gencmd/debug.cmd.go
+++ b/gencmd/debug.cmd.go
@@ -23,6 +23,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -141,7 +142,12 @@ var EnableDebugLevelsCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := DebugApiCmd.EnableDebugLevels(ctx, &DebugLevelsIn)
 		if err != nil {
-			return fmt.Errorf("EnableDebugLevels failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("EnableDebugLevels failed: %s", errstr)
 		}
 		DebugResultWriteOutputOne(obj)
 		return nil
@@ -164,7 +170,12 @@ var DisableDebugLevelsCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := DebugApiCmd.DisableDebugLevels(ctx, &DebugLevelsIn)
 		if err != nil {
-			return fmt.Errorf("DisableDebugLevels failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DisableDebugLevels failed: %s", errstr)
 		}
 		DebugResultWriteOutputOne(obj)
 		return nil
@@ -187,7 +198,12 @@ var ShowDebugLevelsCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := DebugApiCmd.ShowDebugLevels(ctx, &DebugLevelsIn)
 		if err != nil {
-			return fmt.Errorf("ShowDebugLevels failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowDebugLevels failed: %s", errstr)
 		}
 		DebugLevelsWriteOutputOne(obj)
 		return nil

--- a/gencmd/developer.cmd.go
+++ b/gencmd/developer.cmd.go
@@ -12,6 +12,7 @@ import "io"
 import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -126,7 +127,12 @@ var CreateDeveloperCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := DeveloperApiCmd.CreateDeveloper(ctx, &DeveloperIn)
 		if err != nil {
-			return fmt.Errorf("CreateDeveloper failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("CreateDeveloper failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -145,7 +151,12 @@ var DeleteDeveloperCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := DeveloperApiCmd.DeleteDeveloper(ctx, &DeveloperIn)
 		if err != nil {
-			return fmt.Errorf("DeleteDeveloper failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteDeveloper failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -165,7 +176,12 @@ var UpdateDeveloperCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := DeveloperApiCmd.UpdateDeveloper(ctx, &DeveloperIn)
 		if err != nil {
-			return fmt.Errorf("UpdateDeveloper failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("UpdateDeveloper failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -184,7 +200,12 @@ var ShowDeveloperCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := DeveloperApiCmd.ShowDeveloper(ctx, &DeveloperIn)
 		if err != nil {
-			return fmt.Errorf("ShowDeveloper failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowDeveloper failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Developer, 0)
 		for {

--- a/gencmd/dynamic-location-group.cmd.go
+++ b/gencmd/dynamic-location-group.cmd.go
@@ -13,6 +13,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -135,7 +136,12 @@ var SendToGroupCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := DynamicLocGroupApiCmd.SendToGroup(ctx, &DlgMessageIn)
 		if err != nil {
-			return fmt.Errorf("SendToGroup failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("SendToGroup failed: %s", errstr)
 		}
 		DlgReplyWriteOutputOne(obj)
 		return nil

--- a/gencmd/flavor.cmd.go
+++ b/gencmd/flavor.cmd.go
@@ -13,6 +13,7 @@ import "io"
 import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -126,7 +127,12 @@ var CreateFlavorCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := FlavorApiCmd.CreateFlavor(ctx, &FlavorIn)
 		if err != nil {
-			return fmt.Errorf("CreateFlavor failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("CreateFlavor failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -145,7 +151,12 @@ var DeleteFlavorCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := FlavorApiCmd.DeleteFlavor(ctx, &FlavorIn)
 		if err != nil {
-			return fmt.Errorf("DeleteFlavor failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteFlavor failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -165,7 +176,12 @@ var UpdateFlavorCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := FlavorApiCmd.UpdateFlavor(ctx, &FlavorIn)
 		if err != nil {
-			return fmt.Errorf("UpdateFlavor failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("UpdateFlavor failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -184,7 +200,12 @@ var ShowFlavorCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := FlavorApiCmd.ShowFlavor(ctx, &FlavorIn)
 		if err != nil {
-			return fmt.Errorf("ShowFlavor failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowFlavor failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Flavor, 0)
 		for {

--- a/gencmd/node.cmd.go
+++ b/gencmd/node.cmd.go
@@ -14,6 +14,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -173,7 +174,12 @@ var ShowNodeLocalCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := NodeApiCmd.ShowNodeLocal(ctx, &NodeIn)
 		if err != nil {
-			return fmt.Errorf("ShowNodeLocal failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowNodeLocal failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Node, 0)
 		for {
@@ -211,7 +217,12 @@ var ShowNodeCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := NodeApiCmd.ShowNode(ctx, &NodeIn)
 		if err != nil {
-			return fmt.Errorf("ShowNode failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowNode failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Node, 0)
 		for {

--- a/gencmd/operator.cmd.go
+++ b/gencmd/operator.cmd.go
@@ -12,6 +12,7 @@ import "io"
 import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -118,7 +119,12 @@ var CreateOperatorCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := OperatorApiCmd.CreateOperator(ctx, &OperatorIn)
 		if err != nil {
-			return fmt.Errorf("CreateOperator failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("CreateOperator failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -137,7 +143,12 @@ var DeleteOperatorCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := OperatorApiCmd.DeleteOperator(ctx, &OperatorIn)
 		if err != nil {
-			return fmt.Errorf("DeleteOperator failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DeleteOperator failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -157,7 +168,12 @@ var UpdateOperatorCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := OperatorApiCmd.UpdateOperator(ctx, &OperatorIn)
 		if err != nil {
-			return fmt.Errorf("UpdateOperator failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("UpdateOperator failed: %s", errstr)
 		}
 		ResultWriteOutputOne(obj)
 		return nil
@@ -176,7 +192,12 @@ var ShowOperatorCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := OperatorApiCmd.ShowOperator(ctx, &OperatorIn)
 		if err != nil {
-			return fmt.Errorf("ShowOperator failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowOperator failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.Operator, 0)
 		for {

--- a/gencmd/refs.cmd.go
+++ b/gencmd/refs.cmd.go
@@ -13,6 +13,7 @@ import "io"
 import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -151,7 +152,12 @@ var ShowCloudletRefsCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := CloudletRefsApiCmd.ShowCloudletRefs(ctx, &CloudletRefsIn)
 		if err != nil {
-			return fmt.Errorf("ShowCloudletRefs failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowCloudletRefs failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.CloudletRefs, 0)
 		for {
@@ -188,7 +194,12 @@ var ShowClusterRefsCmd = &cobra.Command{
 		ctx := context.Background()
 		stream, err := ClusterRefsApiCmd.ShowClusterRefs(ctx, &ClusterRefsIn)
 		if err != nil {
-			return fmt.Errorf("ShowClusterRefs failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowClusterRefs failed: %s", errstr)
 		}
 		objs := make([]*edgeproto.ClusterRefs, 0)
 		for {

--- a/testgen/gencmd/sample.cmd.go
+++ b/testgen/gencmd/sample.cmd.go
@@ -28,6 +28,7 @@ import "text/tabwriter"
 import "github.com/spf13/pflag"
 import "errors"
 import "github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -528,7 +529,12 @@ var RequestCmd = &cobra.Command{
 		ctx := context.Background()
 		obj, err := TestApiCmd.Request(ctx, &TestGenIn)
 		if err != nil {
-			return fmt.Errorf("Request failed: %s", err.Error())
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("Request failed: %s", errstr)
 		}
 		TestGenWriteOutputOne(obj)
 		return nil


### PR DESCRIPTION
Various bug fixes.
172: added check to prevent Cluster delete if in use by ClusterInst
176: added checks to require ram/cpu/disk for create Flavor
177: remove ShowClusterInstInfo/ShowAppInstInfo from edgectl controller (but added to crm for standalone mode)
178: added error message if no default flavor specified during app create if cluster is not specified
179: Validate() functions were not being called for STM-based creates, so added them in
Bonus: cleaned up error message reporting from edgectl. Previously:
```
Error: DeleteCluster failed: rpc error: code = Unknown desc = Cluster in use by ClusterInst
```
Now:
```
Error: DeleteCluster failed: Cluster in use by ClusterInst
```
