### PR TITLE
Basic audit logging

### DIFF
--- a/cloudcommon/grpc.go
+++ b/cloudcommon/grpc.go
@@ -1,0 +1,14 @@
+package cloudcommon
+
+import "strings"
+
+func ParseGrpcMethod(method string) (path string, cmd string) {
+	if i := strings.LastIndexByte(method, '/'); i > 0 {
+		path = method[:i]
+		cmd = method[i+1:]
+	} else {
+		path = ""
+		cmd = method
+	}
+	return path, cmd
+}

--- a/controller/audit.go
+++ b/controller/audit.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
+	"github.com/mobiledgex/edge-cloud/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/peer"
+)
+
+var AuditId uint64
+
+func AuditUnaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	_, cmd := cloudcommon.ParseGrpcMethod(info.FullMethod)
+	if strings.HasPrefix(cmd, "Show") {
+		return handler(ctx, req)
+	}
+
+	id := atomic.AddUint64(&AuditId, 1)
+	pr, ok := peer.FromContext(ctx)
+	client := "unknown"
+	if ok {
+		client = pr.Addr.String()
+	}
+
+	log.AuditLogStart(id, cmd, client, "notyet", "req", req)
+	resp, err := handler(ctx, req)
+	log.AuditLogEnd(id, err)
+
+	return resp, err
+}
+
+func AuditStreamInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	_, cmd := cloudcommon.ParseGrpcMethod(info.FullMethod)
+	if strings.HasPrefix(cmd, "Show") {
+		return handler(srv, stream)
+	}
+
+	id := atomic.AddUint64(&AuditId, 1)
+	pr, ok := peer.FromContext(stream.Context())
+	client := "unknown"
+	if ok {
+		client = pr.Addr.String()
+	}
+
+	if info.IsClientStream {
+		log.AuditLogStart(id, cmd, client, "notyet")
+	} else {
+		// client API is not actually declared as streaming, but client
+		// API argument is passed in via the stream.
+		// Defer audit log until we can capture the client's argument.
+		stream = NewAuditRecvOne(stream, id, cmd, client, "notyet")
+	}
+	err := handler(srv, stream)
+	log.AuditLogEnd(id, err)
+
+	return err
+}
+
+type AuditRecvOne struct {
+	grpc.ServerStream
+	id     uint64
+	client string
+	cmd    string
+	user   string
+}
+
+func NewAuditRecvOne(stream grpc.ServerStream, id uint64, cmd, client, user string) *AuditRecvOne {
+	s := AuditRecvOne{
+		ServerStream: stream,
+		id:           id,
+		cmd:          cmd,
+		client:       client,
+		user:         user,
+	}
+	return &s
+}
+
+func (s *AuditRecvOne) RecvMsg(m interface{}) error {
+	// grpc handler will call RecvMsg once and only once,
+	// to get the object to pass as the argument to our
+	// implemented function. We log once the object has been
+	// read from the stream. This way the audit log can capture
+	// the API argument sent by the client.
+	err := s.ServerStream.RecvMsg(m)
+	log.AuditLogStart(s.id, s.cmd, s.client, s.user, "req", m)
+	return err
+}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -109,7 +109,9 @@ func main() {
 	if err != nil {
 		log.FatalLog("get TLS Credentials", "error", err)
 	}
-	server := grpc.NewServer(grpc.Creds(creds))
+	server := grpc.NewServer(grpc.Creds(creds),
+		grpc.UnaryInterceptor(AuditUnaryInterceptor),
+		grpc.StreamInterceptor(AuditStreamInterceptor))
 	edgeproto.RegisterDeveloperApiServer(server, &developerApi)
 	edgeproto.RegisterAppApiServer(server, &appApi)
 	edgeproto.RegisterOperatorApiServer(server, &operatorApi)

--- a/d-match-engine/dme-server/dme-stats.go
+++ b/d-match-engine/dme-server/dme-stats.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/cespare/xxhash"
 	"github.com/gogo/protobuf/types"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	grpcstats "github.com/mobiledgex/edge-cloud/metrics/grpc"
@@ -175,11 +175,8 @@ func (s *DmeStats) UnaryStatsInterceptor(ctx context.Context, req interface{}, i
 	resp, err := handler(ctx, req)
 
 	call := ApiStatCall{}
-	if i := strings.LastIndexByte(info.FullMethod, '/'); i > 0 {
-		call.key.method = info.FullMethod[i+1:]
-	} else {
-		call.key.method = info.FullMethod
-	}
+	_, call.key.method = cloudcommon.ParseGrpcMethod(info.FullMethod)
+
 	switch typ := req.(type) {
 	case *dme.Match_Engine_Request:
 		call.key.AppKey.DeveloperKey.Name = typ.DevName

--- a/log/logger.go
+++ b/log/logger.go
@@ -39,6 +39,30 @@ func FatalLog(msg string, keysAndValues ...interface{}) {
 	slogger.Fatalw(msg, keysAndValues...)
 }
 
+func AuditLogStart(id uint64, cmd, client, user string, keysAndValues ...interface{}) {
+	args := make([]interface{}, 0)
+	args = append(args, "id")
+	args = append(args, id)
+	args = append(args, "cmd")
+	args = append(args, cmd)
+	args = append(args, "client")
+	args = append(args, client)
+	args = append(args, "user")
+	args = append(args, user)
+	args = append(args, keysAndValues...)
+	slogger.Infow("Audit start", args...)
+}
+
+func AuditLogEnd(id uint64, err error) {
+	res := "success"
+	msg := ""
+	if err != nil {
+		res = "failure"
+		msg = err.Error()
+	}
+	slogger.Infow("Audit end", "id", id, "result", res, "msg", msg)
+}
+
 func enumToBit(in DebugLevel) uint64 {
 	return uint64(1) << uint(in)
 }


### PR DESCRIPTION
This adds basic audit logging for Controller API calls. Information about the API call, and the caller, are logged. Show commands are not logged. We don't have users yet, so they're logged as "notyet". Example output:
```
2018-09-14T16:52:52.065-0700	INFO	controller/audit.go:29	Audit start	{"id": 1, "cmd": "CreateOperator", "client": "127.0.0.1:49185", "user": "notyet", "req": "key:<name:\"Op\" > "}
2018-09-14T16:52:52.065-0700	INFO	controller/sync.go:100	Sync cb	{"action": "update", "key": "1/Operator/{\"name\":\"Op\"}", "value": "{\"key\":{\"name\":\"Op\"}}", "rev": 4}
2018-09-14T16:52:52.066-0700	INFO	edgeproto/operator.pb.go:665	SyncUpdate Operator	{"obj": "key:<name:\"Op\" > ", "rev": 4}
2018-09-14T16:52:52.066-0700	INFO	controller/sync.go:142	syncWait	{"cur-rev": 4, "wait-rev": 4}
2018-09-14T16:52:52.066-0700	INFO	controller/audit.go:31	Audit end	{"id": 1, "result": "success", "msg": ""}
2018-09-14T16:52:55.945-0700	INFO	controller/audit.go:29	Audit start	{"id": 2, "cmd": "CreateOperator", "client": "127.0.0.1:49188", "user": "notyet", "req": "key:<name:\"Op\" > "}
2018-09-14T16:52:55.945-0700	INFO	controller/audit.go:31	Audit end	{"id": 2, "result": "failure", "msg": "Key already exists"}
```
Because commands can have a fair amount of time disparity between start and finish, and because bad things (like crashes) could possibly happen before the command finishes, I log start and end separately. A unique id is used to identify the start and end logs of the same command.

There is some trickiness with logging a command like ```CreateClusterInst(ClusterInst) returns (stream Result)``` whose input is unary, but output is streaming. Internally grpc treats both input and output as streams, so I had to override the stream object in order to capture and log the input argument.