### PR TITLE
EDGECLOUD-186 fix crm-override option bugs

### DIFF
--- a/controller/callcontext.go
+++ b/controller/callcontext.go
@@ -4,11 +4,13 @@ import "github.com/mobiledgex/edge-cloud/edgeproto"
 
 // Generic caller context
 
-var DefCallContext = &CallContext{}
-
 type CallContext struct {
 	Undo     bool
 	Override edgeproto.CRMOverride
+}
+
+func DefCallContext() *CallContext {
+	return &CallContext{}
 }
 
 func (c *CallContext) WithUndo() *CallContext {

--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -100,7 +100,7 @@ func (s *CloudletApi) DeleteCloudlet(in *edgeproto.Cloudlet, cb edgeproto.Cloudl
 		// delete dynamic instances
 		for key, _ := range dynInsts {
 			appInst := edgeproto.AppInst{Key: key}
-			derr := appInstApi.deleteAppInstInternal(DefCallContext, &appInst, cb)
+			derr := appInstApi.deleteAppInstInternal(DefCallContext(), &appInst, cb)
 			if derr != nil {
 				log.DebugLog(log.DebugLevelApi,
 					"Failed to delete dynamic app inst",
@@ -111,7 +111,7 @@ func (s *CloudletApi) DeleteCloudlet(in *edgeproto.Cloudlet, cb edgeproto.Cloudl
 	if len(clDynInsts) > 0 {
 		for key, _ := range clDynInsts {
 			clInst := edgeproto.ClusterInst{Key: key}
-			derr := clusterInstApi.deleteClusterInstInternal(DefCallContext, &clInst, cb)
+			derr := clusterInstApi.deleteClusterInstInternal(DefCallContext(), &clInst, cb)
 			if derr != nil {
 				log.DebugLog(log.DebugLevelApi,
 					"Failed to delete dynamic cluster inst",
@@ -173,7 +173,7 @@ func (s *CloudletApi) UpdateAppInstLocations(in *edgeproto.Cloudlet) {
 			first = false
 		}
 
-		err := appInstApi.updateAppInstInternal(DefCallContext, &inst, nil)
+		err := appInstApi.updateAppInstInternal(DefCallContext(), &inst, nil)
 		if err != nil {
 			log.DebugLog(log.DebugLevelApi, "Update AppInst Location",
 				"inst", inst, "err", err)

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -105,7 +105,7 @@ func (s *ClusterInstApi) GetClusterInstsForCloudlets(cloudlets map[edgeproto.Clo
 func (s *ClusterInstApi) CreateClusterInst(in *edgeproto.ClusterInst, cb edgeproto.ClusterInstApi_CreateClusterInstServer) error {
 	in.Liveness = edgeproto.Liveness_LivenessStatic
 	in.Auto = false
-	return s.createClusterInstInternal(DefCallContext, in, cb)
+	return s.createClusterInstInternal(DefCallContext(), in, cb)
 }
 
 // createClusterInstInternal is used to create dynamic cluster insts internally,
@@ -231,7 +231,7 @@ func (s *ClusterInstApi) UpdateClusterInst(in *edgeproto.ClusterInst, cb edgepro
 }
 
 func (s *ClusterInstApi) DeleteClusterInst(in *edgeproto.ClusterInst, cb edgeproto.ClusterInstApi_DeleteClusterInstServer) error {
-	return s.deleteClusterInstInternal(DefCallContext, in, cb)
+	return s.deleteClusterInstInternal(DefCallContext(), in, cb)
 }
 
 func (s *ClusterInstApi) deleteClusterInstInternal(cctx *CallContext, in *edgeproto.ClusterInst, cb edgeproto.ClusterInstApi_DeleteClusterInstServer) error {

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -216,9 +216,6 @@ func (key *AppInstKey) Validate() error {
 	if err := key.CloudletKey.Validate(); err != nil {
 		return err
 	}
-	if key.Id == 0 {
-		return errors.New("AppInst Id cannot be zero")
-	}
 	return nil
 }
 


### PR DESCRIPTION
This fixes two issues that Jim found with the new crm-override option. The first is that the new crm-override option was being modified on a global default call-context which was then being used for subsequent API calls. I made it so we allocate a new call-context each time. The second issue was I forgot to add error-state checks to AppInst Create, although I had added them to ClusterInst Create/Delete and AppInst Delete. So I added those in.