### PR TITLE
edgectl create/delete from yaml file

### DIFF
--- a/edgectl/main.go
+++ b/edgectl/main.go
@@ -119,6 +119,9 @@ func main() {
 	controllerCmd.AddCommand(gencmd.ControllerApiCmds...)
 	controllerCmd.AddCommand(gencmd.NodeApiCmds...)
 
+	controllerCmd.AddCommand(createCmd)
+	controllerCmd.AddCommand(deleteCmd)
+
 	dmeCmd.AddCommand(gencmd.Match_Engine_ApiCmds...)
 	dmeCmd.AddCommand(gencmd.DebugApiCmds...)
 

--- a/gencmd/app-client.cmd.go
+++ b/gencmd/app-client.cmd.go
@@ -711,27 +711,44 @@ var FindCloudletCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if Match_Engine_ApiCmd == nil {
-			return fmt.Errorf("Match_Engine_Api client not initialized")
-		}
-		var err error
-		err = parseMatch_Engine_RequestEnums()
+		err := parseMatch_Engine_RequestEnums()
 		if err != nil {
 			return fmt.Errorf("FindCloudlet failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := Match_Engine_ApiCmd.FindCloudlet(ctx, &Match_Engine_RequestIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("FindCloudlet failed: %s", errstr)
-		}
-		Match_Engine_ReplyWriteOutputOne(obj)
-		return nil
+		return FindCloudlet(&Match_Engine_RequestIn)
 	},
+}
+
+func FindCloudlet(in *distributed_match_engine.Match_Engine_Request) error {
+	if Match_Engine_ApiCmd == nil {
+		return fmt.Errorf("Match_Engine_Api client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := Match_Engine_ApiCmd.FindCloudlet(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("FindCloudlet failed: %s", errstr)
+	}
+	Match_Engine_ReplyWriteOutputOne(obj)
+	return nil
+}
+
+func FindCloudlets(data []distributed_match_engine.Match_Engine_Request, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("FindCloudlet %v\n", data[ii])
+		myerr := FindCloudlet(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var VerifyLocationCmd = &cobra.Command{
@@ -739,27 +756,44 @@ var VerifyLocationCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if Match_Engine_ApiCmd == nil {
-			return fmt.Errorf("Match_Engine_Api client not initialized")
-		}
-		var err error
-		err = parseMatch_Engine_RequestEnums()
+		err := parseMatch_Engine_RequestEnums()
 		if err != nil {
 			return fmt.Errorf("VerifyLocation failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := Match_Engine_ApiCmd.VerifyLocation(ctx, &Match_Engine_RequestIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("VerifyLocation failed: %s", errstr)
-		}
-		Match_Engine_Loc_VerifyWriteOutputOne(obj)
-		return nil
+		return VerifyLocation(&Match_Engine_RequestIn)
 	},
+}
+
+func VerifyLocation(in *distributed_match_engine.Match_Engine_Request) error {
+	if Match_Engine_ApiCmd == nil {
+		return fmt.Errorf("Match_Engine_Api client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := Match_Engine_ApiCmd.VerifyLocation(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("VerifyLocation failed: %s", errstr)
+	}
+	Match_Engine_Loc_VerifyWriteOutputOne(obj)
+	return nil
+}
+
+func VerifyLocations(data []distributed_match_engine.Match_Engine_Request, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("VerifyLocation %v\n", data[ii])
+		myerr := VerifyLocation(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var GetLocationCmd = &cobra.Command{
@@ -767,27 +801,44 @@ var GetLocationCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if Match_Engine_ApiCmd == nil {
-			return fmt.Errorf("Match_Engine_Api client not initialized")
-		}
-		var err error
-		err = parseMatch_Engine_RequestEnums()
+		err := parseMatch_Engine_RequestEnums()
 		if err != nil {
 			return fmt.Errorf("GetLocation failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := Match_Engine_ApiCmd.GetLocation(ctx, &Match_Engine_RequestIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("GetLocation failed: %s", errstr)
-		}
-		Match_Engine_LocWriteOutputOne(obj)
-		return nil
+		return GetLocation(&Match_Engine_RequestIn)
 	},
+}
+
+func GetLocation(in *distributed_match_engine.Match_Engine_Request) error {
+	if Match_Engine_ApiCmd == nil {
+		return fmt.Errorf("Match_Engine_Api client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := Match_Engine_ApiCmd.GetLocation(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("GetLocation failed: %s", errstr)
+	}
+	Match_Engine_LocWriteOutputOne(obj)
+	return nil
+}
+
+func GetLocations(data []distributed_match_engine.Match_Engine_Request, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("GetLocation %v\n", data[ii])
+		myerr := GetLocation(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var RegisterClientCmd = &cobra.Command{
@@ -795,27 +846,44 @@ var RegisterClientCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if Match_Engine_ApiCmd == nil {
-			return fmt.Errorf("Match_Engine_Api client not initialized")
-		}
-		var err error
-		err = parseMatch_Engine_RequestEnums()
+		err := parseMatch_Engine_RequestEnums()
 		if err != nil {
 			return fmt.Errorf("RegisterClient failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := Match_Engine_ApiCmd.RegisterClient(ctx, &Match_Engine_RequestIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("RegisterClient failed: %s", errstr)
-		}
-		Match_Engine_StatusWriteOutputOne(obj)
-		return nil
+		return RegisterClient(&Match_Engine_RequestIn)
 	},
+}
+
+func RegisterClient(in *distributed_match_engine.Match_Engine_Request) error {
+	if Match_Engine_ApiCmd == nil {
+		return fmt.Errorf("Match_Engine_Api client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := Match_Engine_ApiCmd.RegisterClient(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("RegisterClient failed: %s", errstr)
+	}
+	Match_Engine_StatusWriteOutputOne(obj)
+	return nil
+}
+
+func RegisterClients(data []distributed_match_engine.Match_Engine_Request, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("RegisterClient %v\n", data[ii])
+		myerr := RegisterClient(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var AddUserToGroupCmd = &cobra.Command{
@@ -823,27 +891,44 @@ var AddUserToGroupCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if Match_Engine_ApiCmd == nil {
-			return fmt.Errorf("Match_Engine_Api client not initialized")
-		}
-		var err error
-		err = parseDynamicLocGroupAddEnums()
+		err := parseDynamicLocGroupAddEnums()
 		if err != nil {
 			return fmt.Errorf("AddUserToGroup failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := Match_Engine_ApiCmd.AddUserToGroup(ctx, &DynamicLocGroupAddIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("AddUserToGroup failed: %s", errstr)
-		}
-		Match_Engine_StatusWriteOutputOne(obj)
-		return nil
+		return AddUserToGroup(&DynamicLocGroupAddIn)
 	},
+}
+
+func AddUserToGroup(in *distributed_match_engine.DynamicLocGroupAdd) error {
+	if Match_Engine_ApiCmd == nil {
+		return fmt.Errorf("Match_Engine_Api client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := Match_Engine_ApiCmd.AddUserToGroup(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("AddUserToGroup failed: %s", errstr)
+	}
+	Match_Engine_StatusWriteOutputOne(obj)
+	return nil
+}
+
+func AddUserToGroups(data []distributed_match_engine.DynamicLocGroupAdd, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("AddUserToGroup %v\n", data[ii])
+		myerr := AddUserToGroup(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var GetCloudletsCmd = &cobra.Command{
@@ -851,27 +936,44 @@ var GetCloudletsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if Match_Engine_ApiCmd == nil {
-			return fmt.Errorf("Match_Engine_Api client not initialized")
-		}
-		var err error
-		err = parseMatch_Engine_RequestEnums()
+		err := parseMatch_Engine_RequestEnums()
 		if err != nil {
 			return fmt.Errorf("GetCloudlets failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := Match_Engine_ApiCmd.GetCloudlets(ctx, &Match_Engine_RequestIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("GetCloudlets failed: %s", errstr)
-		}
-		Match_Engine_Cloudlet_ListWriteOutputOne(obj)
-		return nil
+		return GetCloudlets(&Match_Engine_RequestIn)
 	},
+}
+
+func GetCloudlets(in *distributed_match_engine.Match_Engine_Request) error {
+	if Match_Engine_ApiCmd == nil {
+		return fmt.Errorf("Match_Engine_Api client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := Match_Engine_ApiCmd.GetCloudlets(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("GetCloudlets failed: %s", errstr)
+	}
+	Match_Engine_Cloudlet_ListWriteOutputOne(obj)
+	return nil
+}
+
+func GetCloudletss(data []distributed_match_engine.Match_Engine_Request, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("GetCloudlets %v\n", data[ii])
+		myerr := GetCloudlets(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var Match_Engine_ApiCmds = []*cobra.Command{

--- a/gencmd/app.cmd.go
+++ b/gencmd/app.cmd.go
@@ -213,27 +213,44 @@ var CreateAppCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppApiCmd == nil {
-			return fmt.Errorf("AppApi client not initialized")
-		}
-		var err error
-		err = parseAppEnums()
+		err := parseAppEnums()
 		if err != nil {
 			return fmt.Errorf("CreateApp failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := AppApiCmd.CreateApp(ctx, &AppIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("CreateApp failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return CreateApp(&AppIn)
 	},
+}
+
+func CreateApp(in *edgeproto.App) error {
+	if AppApiCmd == nil {
+		return fmt.Errorf("AppApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := AppApiCmd.CreateApp(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("CreateApp failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func CreateApps(data []edgeproto.App, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("CreateApp %v\n", data[ii])
+		myerr := CreateApp(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteAppCmd = &cobra.Command{
@@ -241,27 +258,44 @@ var DeleteAppCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppApiCmd == nil {
-			return fmt.Errorf("AppApi client not initialized")
-		}
-		var err error
-		err = parseAppEnums()
+		err := parseAppEnums()
 		if err != nil {
 			return fmt.Errorf("DeleteApp failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := AppApiCmd.DeleteApp(ctx, &AppIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteApp failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return DeleteApp(&AppIn)
 	},
+}
+
+func DeleteApp(in *edgeproto.App) error {
+	if AppApiCmd == nil {
+		return fmt.Errorf("AppApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := AppApiCmd.DeleteApp(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteApp failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func DeleteApps(data []edgeproto.App, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteApp %v\n", data[ii])
+		myerr := DeleteApp(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var UpdateAppCmd = &cobra.Command{
@@ -269,28 +303,45 @@ var UpdateAppCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppApiCmd == nil {
-			return fmt.Errorf("AppApi client not initialized")
-		}
-		var err error
-		err = parseAppEnums()
+		err := parseAppEnums()
 		if err != nil {
 			return fmt.Errorf("UpdateApp failed: %s", err.Error())
 		}
 		AppSetFields()
-		ctx := context.Background()
-		obj, err := AppApiCmd.UpdateApp(ctx, &AppIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("UpdateApp failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return UpdateApp(&AppIn)
 	},
+}
+
+func UpdateApp(in *edgeproto.App) error {
+	if AppApiCmd == nil {
+		return fmt.Errorf("AppApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := AppApiCmd.UpdateApp(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("UpdateApp failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func UpdateApps(data []edgeproto.App, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("UpdateApp %v\n", data[ii])
+		myerr := UpdateApp(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowAppCmd = &cobra.Command{
@@ -298,41 +349,58 @@ var ShowAppCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppApiCmd == nil {
-			return fmt.Errorf("AppApi client not initialized")
-		}
-		var err error
-		err = parseAppEnums()
+		err := parseAppEnums()
 		if err != nil {
 			return fmt.Errorf("ShowApp failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := AppApiCmd.ShowApp(ctx, &AppIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowApp failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.App, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowApp recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		AppWriteOutputArray(objs)
-		return nil
+		return ShowApp(&AppIn)
 	},
+}
+
+func ShowApp(in *edgeproto.App) error {
+	if AppApiCmd == nil {
+		return fmt.Errorf("AppApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := AppApiCmd.ShowApp(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowApp failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.App, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowApp recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	AppWriteOutputArray(objs)
+	return nil
+}
+
+func ShowApps(data []edgeproto.App, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowApp %v\n", data[ii])
+		myerr := ShowApp(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var AppApiCmds = []*cobra.Command{

--- a/gencmd/app_inst.cmd.go
+++ b/gencmd/app_inst.cmd.go
@@ -382,36 +382,53 @@ var CreateAppInstCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppInstApiCmd == nil {
-			return fmt.Errorf("AppInstApi client not initialized")
-		}
-		var err error
-		err = parseAppInstEnums()
+		err := parseAppInstEnums()
 		if err != nil {
 			return fmt.Errorf("CreateAppInst failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := AppInstApiCmd.CreateAppInst(ctx, &AppInstIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("CreateAppInst failed: %s", errstr)
-		}
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("CreateAppInst recv failed: %s", err.Error())
-			}
-			ResultWriteOutputOne(obj)
-		}
-		return nil
+		return CreateAppInst(&AppInstIn)
 	},
+}
+
+func CreateAppInst(in *edgeproto.AppInst) error {
+	if AppInstApiCmd == nil {
+		return fmt.Errorf("AppInstApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := AppInstApiCmd.CreateAppInst(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("CreateAppInst failed: %s", errstr)
+	}
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("CreateAppInst recv failed: %s", err.Error())
+		}
+		ResultWriteOutputOne(obj)
+	}
+	return nil
+}
+
+func CreateAppInsts(data []edgeproto.AppInst, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("CreateAppInst %v\n", data[ii])
+		myerr := CreateAppInst(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteAppInstCmd = &cobra.Command{
@@ -419,36 +436,53 @@ var DeleteAppInstCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppInstApiCmd == nil {
-			return fmt.Errorf("AppInstApi client not initialized")
-		}
-		var err error
-		err = parseAppInstEnums()
+		err := parseAppInstEnums()
 		if err != nil {
 			return fmt.Errorf("DeleteAppInst failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := AppInstApiCmd.DeleteAppInst(ctx, &AppInstIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteAppInst failed: %s", errstr)
-		}
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("DeleteAppInst recv failed: %s", err.Error())
-			}
-			ResultWriteOutputOne(obj)
-		}
-		return nil
+		return DeleteAppInst(&AppInstIn)
 	},
+}
+
+func DeleteAppInst(in *edgeproto.AppInst) error {
+	if AppInstApiCmd == nil {
+		return fmt.Errorf("AppInstApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := AppInstApiCmd.DeleteAppInst(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteAppInst failed: %s", errstr)
+	}
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("DeleteAppInst recv failed: %s", err.Error())
+		}
+		ResultWriteOutputOne(obj)
+	}
+	return nil
+}
+
+func DeleteAppInsts(data []edgeproto.AppInst, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteAppInst %v\n", data[ii])
+		myerr := DeleteAppInst(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var UpdateAppInstCmd = &cobra.Command{
@@ -456,37 +490,54 @@ var UpdateAppInstCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppInstApiCmd == nil {
-			return fmt.Errorf("AppInstApi client not initialized")
-		}
-		var err error
-		err = parseAppInstEnums()
+		err := parseAppInstEnums()
 		if err != nil {
 			return fmt.Errorf("UpdateAppInst failed: %s", err.Error())
 		}
 		AppInstSetFields()
-		ctx := context.Background()
-		stream, err := AppInstApiCmd.UpdateAppInst(ctx, &AppInstIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("UpdateAppInst failed: %s", errstr)
-		}
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("UpdateAppInst recv failed: %s", err.Error())
-			}
-			ResultWriteOutputOne(obj)
-		}
-		return nil
+		return UpdateAppInst(&AppInstIn)
 	},
+}
+
+func UpdateAppInst(in *edgeproto.AppInst) error {
+	if AppInstApiCmd == nil {
+		return fmt.Errorf("AppInstApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := AppInstApiCmd.UpdateAppInst(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("UpdateAppInst failed: %s", errstr)
+	}
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("UpdateAppInst recv failed: %s", err.Error())
+		}
+		ResultWriteOutputOne(obj)
+	}
+	return nil
+}
+
+func UpdateAppInsts(data []edgeproto.AppInst, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("UpdateAppInst %v\n", data[ii])
+		myerr := UpdateAppInst(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowAppInstCmd = &cobra.Command{
@@ -494,42 +545,59 @@ var ShowAppInstCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppInstApiCmd == nil {
-			return fmt.Errorf("AppInstApi client not initialized")
-		}
-		var err error
-		err = parseAppInstEnums()
+		err := parseAppInstEnums()
 		if err != nil {
 			return fmt.Errorf("ShowAppInst failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := AppInstApiCmd.ShowAppInst(ctx, &AppInstIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowAppInst failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.AppInst, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowAppInst recv failed: %s", err.Error())
-			}
-			AppInstHideTags(obj)
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		AppInstWriteOutputArray(objs)
-		return nil
+		return ShowAppInst(&AppInstIn)
 	},
+}
+
+func ShowAppInst(in *edgeproto.AppInst) error {
+	if AppInstApiCmd == nil {
+		return fmt.Errorf("AppInstApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := AppInstApiCmd.ShowAppInst(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowAppInst failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.AppInst, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowAppInst recv failed: %s", err.Error())
+		}
+		AppInstHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	AppInstWriteOutputArray(objs)
+	return nil
+}
+
+func ShowAppInsts(data []edgeproto.AppInst, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowAppInst %v\n", data[ii])
+		myerr := ShowAppInst(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var AppInstApiCmds = []*cobra.Command{
@@ -544,42 +612,59 @@ var ShowAppInstInfoCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppInstInfoApiCmd == nil {
-			return fmt.Errorf("AppInstInfoApi client not initialized")
-		}
-		var err error
-		err = parseAppInstInfoEnums()
+		err := parseAppInstInfoEnums()
 		if err != nil {
 			return fmt.Errorf("ShowAppInstInfo failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := AppInstInfoApiCmd.ShowAppInstInfo(ctx, &AppInstInfoIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowAppInstInfo failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.AppInstInfo, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowAppInstInfo recv failed: %s", err.Error())
-			}
-			AppInstInfoHideTags(obj)
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		AppInstInfoWriteOutputArray(objs)
-		return nil
+		return ShowAppInstInfo(&AppInstInfoIn)
 	},
+}
+
+func ShowAppInstInfo(in *edgeproto.AppInstInfo) error {
+	if AppInstInfoApiCmd == nil {
+		return fmt.Errorf("AppInstInfoApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := AppInstInfoApiCmd.ShowAppInstInfo(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowAppInstInfo failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.AppInstInfo, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowAppInstInfo recv failed: %s", err.Error())
+		}
+		AppInstInfoHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	AppInstInfoWriteOutputArray(objs)
+	return nil
+}
+
+func ShowAppInstInfos(data []edgeproto.AppInstInfo, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowAppInstInfo %v\n", data[ii])
+		myerr := ShowAppInstInfo(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var AppInstInfoApiCmds = []*cobra.Command{
@@ -591,37 +676,54 @@ var ShowAppInstMetricsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if AppInstMetricsApiCmd == nil {
-			return fmt.Errorf("AppInstMetricsApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		stream, err := AppInstMetricsApiCmd.ShowAppInstMetrics(ctx, &AppInstMetricsIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowAppInstMetrics failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.AppInstMetrics, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowAppInstMetrics recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		AppInstMetricsWriteOutputArray(objs)
-		return nil
+		return ShowAppInstMetrics(&AppInstMetricsIn)
 	},
+}
+
+func ShowAppInstMetrics(in *edgeproto.AppInstMetrics) error {
+	if AppInstMetricsApiCmd == nil {
+		return fmt.Errorf("AppInstMetricsApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := AppInstMetricsApiCmd.ShowAppInstMetrics(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowAppInstMetrics failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.AppInstMetrics, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowAppInstMetrics recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	AppInstMetricsWriteOutputArray(objs)
+	return nil
+}
+
+func ShowAppInstMetricss(data []edgeproto.AppInstMetrics, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowAppInstMetrics %v\n", data[ii])
+		myerr := ShowAppInstMetrics(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var AppInstMetricsApiCmds = []*cobra.Command{

--- a/gencmd/cloud-resource-manager.cmd.go
+++ b/gencmd/cloud-resource-manager.cmd.go
@@ -270,41 +270,58 @@ var ListCloudResourceCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudResourceManagerCmd == nil {
-			return fmt.Errorf("CloudResourceManager client not initialized")
-		}
-		var err error
-		err = parseCloudResourceEnums()
+		err := parseCloudResourceEnums()
 		if err != nil {
 			return fmt.Errorf("ListCloudResource failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := CloudResourceManagerCmd.ListCloudResource(ctx, &CloudResourceIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ListCloudResource failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.CloudResource, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ListCloudResource recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		CloudResourceWriteOutputArray(objs)
-		return nil
+		return ListCloudResource(&CloudResourceIn)
 	},
+}
+
+func ListCloudResource(in *edgeproto.CloudResource) error {
+	if CloudResourceManagerCmd == nil {
+		return fmt.Errorf("CloudResourceManager client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := CloudResourceManagerCmd.ListCloudResource(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ListCloudResource failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.CloudResource, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ListCloudResource recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	CloudResourceWriteOutputArray(objs)
+	return nil
+}
+
+func ListCloudResources(data []edgeproto.CloudResource, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ListCloudResource %v\n", data[ii])
+		myerr := ListCloudResource(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var AddCloudResourceCmd = &cobra.Command{
@@ -312,27 +329,44 @@ var AddCloudResourceCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudResourceManagerCmd == nil {
-			return fmt.Errorf("CloudResourceManager client not initialized")
-		}
-		var err error
-		err = parseCloudResourceEnums()
+		err := parseCloudResourceEnums()
 		if err != nil {
 			return fmt.Errorf("AddCloudResource failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := CloudResourceManagerCmd.AddCloudResource(ctx, &CloudResourceIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("AddCloudResource failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return AddCloudResource(&CloudResourceIn)
 	},
+}
+
+func AddCloudResource(in *edgeproto.CloudResource) error {
+	if CloudResourceManagerCmd == nil {
+		return fmt.Errorf("CloudResourceManager client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := CloudResourceManagerCmd.AddCloudResource(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("AddCloudResource failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func AddCloudResources(data []edgeproto.CloudResource, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("AddCloudResource %v\n", data[ii])
+		myerr := AddCloudResource(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteCloudResourceCmd = &cobra.Command{
@@ -340,27 +374,44 @@ var DeleteCloudResourceCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudResourceManagerCmd == nil {
-			return fmt.Errorf("CloudResourceManager client not initialized")
-		}
-		var err error
-		err = parseCloudResourceEnums()
+		err := parseCloudResourceEnums()
 		if err != nil {
 			return fmt.Errorf("DeleteCloudResource failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := CloudResourceManagerCmd.DeleteCloudResource(ctx, &CloudResourceIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteCloudResource failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return DeleteCloudResource(&CloudResourceIn)
 	},
+}
+
+func DeleteCloudResource(in *edgeproto.CloudResource) error {
+	if CloudResourceManagerCmd == nil {
+		return fmt.Errorf("CloudResourceManager client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := CloudResourceManagerCmd.DeleteCloudResource(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteCloudResource failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func DeleteCloudResources(data []edgeproto.CloudResource, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteCloudResource %v\n", data[ii])
+		myerr := DeleteCloudResource(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeployApplicationCmd = &cobra.Command{
@@ -368,23 +419,40 @@ var DeployApplicationCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudResourceManagerCmd == nil {
-			return fmt.Errorf("CloudResourceManager client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := CloudResourceManagerCmd.DeployApplication(ctx, &EdgeCloudApplicationIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeployApplication failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return DeployApplication(&EdgeCloudApplicationIn)
 	},
+}
+
+func DeployApplication(in *edgeproto.EdgeCloudApplication) error {
+	if CloudResourceManagerCmd == nil {
+		return fmt.Errorf("CloudResourceManager client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := CloudResourceManagerCmd.DeployApplication(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeployApplication failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func DeployApplications(data []edgeproto.EdgeCloudApplication, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeployApplication %v\n", data[ii])
+		myerr := DeployApplication(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteApplicationCmd = &cobra.Command{
@@ -392,23 +460,40 @@ var DeleteApplicationCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudResourceManagerCmd == nil {
-			return fmt.Errorf("CloudResourceManager client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := CloudResourceManagerCmd.DeleteApplication(ctx, &EdgeCloudApplicationIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteApplication failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return DeleteApplication(&EdgeCloudApplicationIn)
 	},
+}
+
+func DeleteApplication(in *edgeproto.EdgeCloudApplication) error {
+	if CloudResourceManagerCmd == nil {
+		return fmt.Errorf("CloudResourceManager client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := CloudResourceManagerCmd.DeleteApplication(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteApplication failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func DeleteApplications(data []edgeproto.EdgeCloudApplication, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteApplication %v\n", data[ii])
+		myerr := DeleteApplication(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var CloudResourceManagerCmds = []*cobra.Command{

--- a/gencmd/cloudlet.cmd.go
+++ b/gencmd/cloudlet.cmd.go
@@ -259,41 +259,58 @@ var CreateCloudletCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudletApiCmd == nil {
-			return fmt.Errorf("CloudletApi client not initialized")
-		}
-		var err error
-		err = parseCloudletEnums()
+		err := parseCloudletEnums()
 		if err != nil {
 			return fmt.Errorf("CreateCloudlet failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := CloudletApiCmd.CreateCloudlet(ctx, &CloudletIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("CreateCloudlet failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.Result, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("CreateCloudlet recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		ResultWriteOutputArray(objs)
-		return nil
+		return CreateCloudlet(&CloudletIn)
 	},
+}
+
+func CreateCloudlet(in *edgeproto.Cloudlet) error {
+	if CloudletApiCmd == nil {
+		return fmt.Errorf("CloudletApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := CloudletApiCmd.CreateCloudlet(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("CreateCloudlet failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.Result, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("CreateCloudlet recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	ResultWriteOutputArray(objs)
+	return nil
+}
+
+func CreateCloudlets(data []edgeproto.Cloudlet, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("CreateCloudlet %v\n", data[ii])
+		myerr := CreateCloudlet(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteCloudletCmd = &cobra.Command{
@@ -301,36 +318,53 @@ var DeleteCloudletCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudletApiCmd == nil {
-			return fmt.Errorf("CloudletApi client not initialized")
-		}
-		var err error
-		err = parseCloudletEnums()
+		err := parseCloudletEnums()
 		if err != nil {
 			return fmt.Errorf("DeleteCloudlet failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := CloudletApiCmd.DeleteCloudlet(ctx, &CloudletIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteCloudlet failed: %s", errstr)
-		}
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("DeleteCloudlet recv failed: %s", err.Error())
-			}
-			ResultWriteOutputOne(obj)
-		}
-		return nil
+		return DeleteCloudlet(&CloudletIn)
 	},
+}
+
+func DeleteCloudlet(in *edgeproto.Cloudlet) error {
+	if CloudletApiCmd == nil {
+		return fmt.Errorf("CloudletApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := CloudletApiCmd.DeleteCloudlet(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteCloudlet failed: %s", errstr)
+	}
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("DeleteCloudlet recv failed: %s", err.Error())
+		}
+		ResultWriteOutputOne(obj)
+	}
+	return nil
+}
+
+func DeleteCloudlets(data []edgeproto.Cloudlet, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteCloudlet %v\n", data[ii])
+		myerr := DeleteCloudlet(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var UpdateCloudletCmd = &cobra.Command{
@@ -338,42 +372,59 @@ var UpdateCloudletCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudletApiCmd == nil {
-			return fmt.Errorf("CloudletApi client not initialized")
-		}
-		var err error
-		err = parseCloudletEnums()
+		err := parseCloudletEnums()
 		if err != nil {
 			return fmt.Errorf("UpdateCloudlet failed: %s", err.Error())
 		}
 		CloudletSetFields()
-		ctx := context.Background()
-		stream, err := CloudletApiCmd.UpdateCloudlet(ctx, &CloudletIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("UpdateCloudlet failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.Result, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("UpdateCloudlet recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		ResultWriteOutputArray(objs)
-		return nil
+		return UpdateCloudlet(&CloudletIn)
 	},
+}
+
+func UpdateCloudlet(in *edgeproto.Cloudlet) error {
+	if CloudletApiCmd == nil {
+		return fmt.Errorf("CloudletApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := CloudletApiCmd.UpdateCloudlet(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("UpdateCloudlet failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.Result, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("UpdateCloudlet recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	ResultWriteOutputArray(objs)
+	return nil
+}
+
+func UpdateCloudlets(data []edgeproto.Cloudlet, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("UpdateCloudlet %v\n", data[ii])
+		myerr := UpdateCloudlet(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowCloudletCmd = &cobra.Command{
@@ -381,41 +432,58 @@ var ShowCloudletCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudletApiCmd == nil {
-			return fmt.Errorf("CloudletApi client not initialized")
-		}
-		var err error
-		err = parseCloudletEnums()
+		err := parseCloudletEnums()
 		if err != nil {
 			return fmt.Errorf("ShowCloudlet failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := CloudletApiCmd.ShowCloudlet(ctx, &CloudletIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowCloudlet failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.Cloudlet, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowCloudlet recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		CloudletWriteOutputArray(objs)
-		return nil
+		return ShowCloudlet(&CloudletIn)
 	},
+}
+
+func ShowCloudlet(in *edgeproto.Cloudlet) error {
+	if CloudletApiCmd == nil {
+		return fmt.Errorf("CloudletApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := CloudletApiCmd.ShowCloudlet(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowCloudlet failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.Cloudlet, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowCloudlet recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	CloudletWriteOutputArray(objs)
+	return nil
+}
+
+func ShowCloudlets(data []edgeproto.Cloudlet, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowCloudlet %v\n", data[ii])
+		myerr := ShowCloudlet(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var CloudletApiCmds = []*cobra.Command{
@@ -430,41 +498,58 @@ var ShowCloudletInfoCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudletInfoApiCmd == nil {
-			return fmt.Errorf("CloudletInfoApi client not initialized")
-		}
-		var err error
-		err = parseCloudletInfoEnums()
+		err := parseCloudletInfoEnums()
 		if err != nil {
 			return fmt.Errorf("ShowCloudletInfo failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := CloudletInfoApiCmd.ShowCloudletInfo(ctx, &CloudletInfoIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowCloudletInfo failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.CloudletInfo, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowCloudletInfo recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		CloudletInfoWriteOutputArray(objs)
-		return nil
+		return ShowCloudletInfo(&CloudletInfoIn)
 	},
+}
+
+func ShowCloudletInfo(in *edgeproto.CloudletInfo) error {
+	if CloudletInfoApiCmd == nil {
+		return fmt.Errorf("CloudletInfoApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := CloudletInfoApiCmd.ShowCloudletInfo(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowCloudletInfo failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.CloudletInfo, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowCloudletInfo recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	CloudletInfoWriteOutputArray(objs)
+	return nil
+}
+
+func ShowCloudletInfos(data []edgeproto.CloudletInfo, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowCloudletInfo %v\n", data[ii])
+		myerr := ShowCloudletInfo(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var InjectCloudletInfoCmd = &cobra.Command{
@@ -472,27 +557,44 @@ var InjectCloudletInfoCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudletInfoApiCmd == nil {
-			return fmt.Errorf("CloudletInfoApi client not initialized")
-		}
-		var err error
-		err = parseCloudletInfoEnums()
+		err := parseCloudletInfoEnums()
 		if err != nil {
 			return fmt.Errorf("InjectCloudletInfo failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := CloudletInfoApiCmd.InjectCloudletInfo(ctx, &CloudletInfoIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("InjectCloudletInfo failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return InjectCloudletInfo(&CloudletInfoIn)
 	},
+}
+
+func InjectCloudletInfo(in *edgeproto.CloudletInfo) error {
+	if CloudletInfoApiCmd == nil {
+		return fmt.Errorf("CloudletInfoApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := CloudletInfoApiCmd.InjectCloudletInfo(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("InjectCloudletInfo failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func InjectCloudletInfos(data []edgeproto.CloudletInfo, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("InjectCloudletInfo %v\n", data[ii])
+		myerr := InjectCloudletInfo(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var EvictCloudletInfoCmd = &cobra.Command{
@@ -500,27 +602,44 @@ var EvictCloudletInfoCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudletInfoApiCmd == nil {
-			return fmt.Errorf("CloudletInfoApi client not initialized")
-		}
-		var err error
-		err = parseCloudletInfoEnums()
+		err := parseCloudletInfoEnums()
 		if err != nil {
 			return fmt.Errorf("EvictCloudletInfo failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := CloudletInfoApiCmd.EvictCloudletInfo(ctx, &CloudletInfoIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("EvictCloudletInfo failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return EvictCloudletInfo(&CloudletInfoIn)
 	},
+}
+
+func EvictCloudletInfo(in *edgeproto.CloudletInfo) error {
+	if CloudletInfoApiCmd == nil {
+		return fmt.Errorf("CloudletInfoApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := CloudletInfoApiCmd.EvictCloudletInfo(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("EvictCloudletInfo failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func EvictCloudletInfos(data []edgeproto.CloudletInfo, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("EvictCloudletInfo %v\n", data[ii])
+		myerr := EvictCloudletInfo(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var CloudletInfoApiCmds = []*cobra.Command{
@@ -534,37 +653,54 @@ var ShowCloudletMetricsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudletMetricsApiCmd == nil {
-			return fmt.Errorf("CloudletMetricsApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		stream, err := CloudletMetricsApiCmd.ShowCloudletMetrics(ctx, &CloudletMetricsIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowCloudletMetrics failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.CloudletMetrics, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowCloudletMetrics recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		CloudletMetricsWriteOutputArray(objs)
-		return nil
+		return ShowCloudletMetrics(&CloudletMetricsIn)
 	},
+}
+
+func ShowCloudletMetrics(in *edgeproto.CloudletMetrics) error {
+	if CloudletMetricsApiCmd == nil {
+		return fmt.Errorf("CloudletMetricsApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := CloudletMetricsApiCmd.ShowCloudletMetrics(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowCloudletMetrics failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.CloudletMetrics, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowCloudletMetrics recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	CloudletMetricsWriteOutputArray(objs)
+	return nil
+}
+
+func ShowCloudletMetricss(data []edgeproto.CloudletMetrics, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowCloudletMetrics %v\n", data[ii])
+		myerr := ShowCloudletMetrics(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var CloudletMetricsApiCmds = []*cobra.Command{

--- a/gencmd/cluster.cmd.go
+++ b/gencmd/cluster.cmd.go
@@ -118,23 +118,40 @@ var CreateClusterCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterApiCmd == nil {
-			return fmt.Errorf("ClusterApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := ClusterApiCmd.CreateCluster(ctx, &ClusterIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("CreateCluster failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return CreateCluster(&ClusterIn)
 	},
+}
+
+func CreateCluster(in *edgeproto.Cluster) error {
+	if ClusterApiCmd == nil {
+		return fmt.Errorf("ClusterApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := ClusterApiCmd.CreateCluster(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("CreateCluster failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func CreateClusters(data []edgeproto.Cluster, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("CreateCluster %v\n", data[ii])
+		myerr := CreateCluster(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteClusterCmd = &cobra.Command{
@@ -142,23 +159,40 @@ var DeleteClusterCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterApiCmd == nil {
-			return fmt.Errorf("ClusterApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := ClusterApiCmd.DeleteCluster(ctx, &ClusterIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteCluster failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return DeleteCluster(&ClusterIn)
 	},
+}
+
+func DeleteCluster(in *edgeproto.Cluster) error {
+	if ClusterApiCmd == nil {
+		return fmt.Errorf("ClusterApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := ClusterApiCmd.DeleteCluster(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteCluster failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func DeleteClusters(data []edgeproto.Cluster, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteCluster %v\n", data[ii])
+		myerr := DeleteCluster(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var UpdateClusterCmd = &cobra.Command{
@@ -166,24 +200,41 @@ var UpdateClusterCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterApiCmd == nil {
-			return fmt.Errorf("ClusterApi client not initialized")
-		}
-		var err error
 		ClusterSetFields()
-		ctx := context.Background()
-		obj, err := ClusterApiCmd.UpdateCluster(ctx, &ClusterIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("UpdateCluster failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return UpdateCluster(&ClusterIn)
 	},
+}
+
+func UpdateCluster(in *edgeproto.Cluster) error {
+	if ClusterApiCmd == nil {
+		return fmt.Errorf("ClusterApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := ClusterApiCmd.UpdateCluster(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("UpdateCluster failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func UpdateClusters(data []edgeproto.Cluster, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("UpdateCluster %v\n", data[ii])
+		myerr := UpdateCluster(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowClusterCmd = &cobra.Command{
@@ -191,37 +242,54 @@ var ShowClusterCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterApiCmd == nil {
-			return fmt.Errorf("ClusterApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		stream, err := ClusterApiCmd.ShowCluster(ctx, &ClusterIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowCluster failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.Cluster, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowCluster recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		ClusterWriteOutputArray(objs)
-		return nil
+		return ShowCluster(&ClusterIn)
 	},
+}
+
+func ShowCluster(in *edgeproto.Cluster) error {
+	if ClusterApiCmd == nil {
+		return fmt.Errorf("ClusterApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := ClusterApiCmd.ShowCluster(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowCluster failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.Cluster, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowCluster recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	ClusterWriteOutputArray(objs)
+	return nil
+}
+
+func ShowClusters(data []edgeproto.Cluster, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowCluster %v\n", data[ii])
+		myerr := ShowCluster(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ClusterApiCmds = []*cobra.Command{

--- a/gencmd/clusterflavor.cmd.go
+++ b/gencmd/clusterflavor.cmd.go
@@ -124,23 +124,40 @@ var CreateClusterFlavorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterFlavorApiCmd == nil {
-			return fmt.Errorf("ClusterFlavorApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := ClusterFlavorApiCmd.CreateClusterFlavor(ctx, &ClusterFlavorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("CreateClusterFlavor failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return CreateClusterFlavor(&ClusterFlavorIn)
 	},
+}
+
+func CreateClusterFlavor(in *edgeproto.ClusterFlavor) error {
+	if ClusterFlavorApiCmd == nil {
+		return fmt.Errorf("ClusterFlavorApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := ClusterFlavorApiCmd.CreateClusterFlavor(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("CreateClusterFlavor failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func CreateClusterFlavors(data []edgeproto.ClusterFlavor, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("CreateClusterFlavor %v\n", data[ii])
+		myerr := CreateClusterFlavor(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteClusterFlavorCmd = &cobra.Command{
@@ -148,23 +165,40 @@ var DeleteClusterFlavorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterFlavorApiCmd == nil {
-			return fmt.Errorf("ClusterFlavorApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := ClusterFlavorApiCmd.DeleteClusterFlavor(ctx, &ClusterFlavorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteClusterFlavor failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return DeleteClusterFlavor(&ClusterFlavorIn)
 	},
+}
+
+func DeleteClusterFlavor(in *edgeproto.ClusterFlavor) error {
+	if ClusterFlavorApiCmd == nil {
+		return fmt.Errorf("ClusterFlavorApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := ClusterFlavorApiCmd.DeleteClusterFlavor(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteClusterFlavor failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func DeleteClusterFlavors(data []edgeproto.ClusterFlavor, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteClusterFlavor %v\n", data[ii])
+		myerr := DeleteClusterFlavor(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var UpdateClusterFlavorCmd = &cobra.Command{
@@ -172,24 +206,41 @@ var UpdateClusterFlavorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterFlavorApiCmd == nil {
-			return fmt.Errorf("ClusterFlavorApi client not initialized")
-		}
-		var err error
 		ClusterFlavorSetFields()
-		ctx := context.Background()
-		obj, err := ClusterFlavorApiCmd.UpdateClusterFlavor(ctx, &ClusterFlavorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("UpdateClusterFlavor failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return UpdateClusterFlavor(&ClusterFlavorIn)
 	},
+}
+
+func UpdateClusterFlavor(in *edgeproto.ClusterFlavor) error {
+	if ClusterFlavorApiCmd == nil {
+		return fmt.Errorf("ClusterFlavorApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := ClusterFlavorApiCmd.UpdateClusterFlavor(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("UpdateClusterFlavor failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func UpdateClusterFlavors(data []edgeproto.ClusterFlavor, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("UpdateClusterFlavor %v\n", data[ii])
+		myerr := UpdateClusterFlavor(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowClusterFlavorCmd = &cobra.Command{
@@ -197,37 +248,54 @@ var ShowClusterFlavorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterFlavorApiCmd == nil {
-			return fmt.Errorf("ClusterFlavorApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		stream, err := ClusterFlavorApiCmd.ShowClusterFlavor(ctx, &ClusterFlavorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowClusterFlavor failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.ClusterFlavor, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowClusterFlavor recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		ClusterFlavorWriteOutputArray(objs)
-		return nil
+		return ShowClusterFlavor(&ClusterFlavorIn)
 	},
+}
+
+func ShowClusterFlavor(in *edgeproto.ClusterFlavor) error {
+	if ClusterFlavorApiCmd == nil {
+		return fmt.Errorf("ClusterFlavorApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := ClusterFlavorApiCmd.ShowClusterFlavor(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowClusterFlavor failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.ClusterFlavor, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowClusterFlavor recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	ClusterFlavorWriteOutputArray(objs)
+	return nil
+}
+
+func ShowClusterFlavors(data []edgeproto.ClusterFlavor, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowClusterFlavor %v\n", data[ii])
+		myerr := ShowClusterFlavor(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ClusterFlavorApiCmds = []*cobra.Command{

--- a/gencmd/clusterinst.cmd.go
+++ b/gencmd/clusterinst.cmd.go
@@ -230,36 +230,53 @@ var CreateClusterInstCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterInstApiCmd == nil {
-			return fmt.Errorf("ClusterInstApi client not initialized")
-		}
-		var err error
-		err = parseClusterInstEnums()
+		err := parseClusterInstEnums()
 		if err != nil {
 			return fmt.Errorf("CreateClusterInst failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := ClusterInstApiCmd.CreateClusterInst(ctx, &ClusterInstIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("CreateClusterInst failed: %s", errstr)
-		}
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("CreateClusterInst recv failed: %s", err.Error())
-			}
-			ResultWriteOutputOne(obj)
-		}
-		return nil
+		return CreateClusterInst(&ClusterInstIn)
 	},
+}
+
+func CreateClusterInst(in *edgeproto.ClusterInst) error {
+	if ClusterInstApiCmd == nil {
+		return fmt.Errorf("ClusterInstApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := ClusterInstApiCmd.CreateClusterInst(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("CreateClusterInst failed: %s", errstr)
+	}
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("CreateClusterInst recv failed: %s", err.Error())
+		}
+		ResultWriteOutputOne(obj)
+	}
+	return nil
+}
+
+func CreateClusterInsts(data []edgeproto.ClusterInst, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("CreateClusterInst %v\n", data[ii])
+		myerr := CreateClusterInst(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteClusterInstCmd = &cobra.Command{
@@ -267,36 +284,53 @@ var DeleteClusterInstCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterInstApiCmd == nil {
-			return fmt.Errorf("ClusterInstApi client not initialized")
-		}
-		var err error
-		err = parseClusterInstEnums()
+		err := parseClusterInstEnums()
 		if err != nil {
 			return fmt.Errorf("DeleteClusterInst failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := ClusterInstApiCmd.DeleteClusterInst(ctx, &ClusterInstIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteClusterInst failed: %s", errstr)
-		}
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("DeleteClusterInst recv failed: %s", err.Error())
-			}
-			ResultWriteOutputOne(obj)
-		}
-		return nil
+		return DeleteClusterInst(&ClusterInstIn)
 	},
+}
+
+func DeleteClusterInst(in *edgeproto.ClusterInst) error {
+	if ClusterInstApiCmd == nil {
+		return fmt.Errorf("ClusterInstApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := ClusterInstApiCmd.DeleteClusterInst(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteClusterInst failed: %s", errstr)
+	}
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("DeleteClusterInst recv failed: %s", err.Error())
+		}
+		ResultWriteOutputOne(obj)
+	}
+	return nil
+}
+
+func DeleteClusterInsts(data []edgeproto.ClusterInst, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteClusterInst %v\n", data[ii])
+		myerr := DeleteClusterInst(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var UpdateClusterInstCmd = &cobra.Command{
@@ -304,37 +338,54 @@ var UpdateClusterInstCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterInstApiCmd == nil {
-			return fmt.Errorf("ClusterInstApi client not initialized")
-		}
-		var err error
-		err = parseClusterInstEnums()
+		err := parseClusterInstEnums()
 		if err != nil {
 			return fmt.Errorf("UpdateClusterInst failed: %s", err.Error())
 		}
 		ClusterInstSetFields()
-		ctx := context.Background()
-		stream, err := ClusterInstApiCmd.UpdateClusterInst(ctx, &ClusterInstIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("UpdateClusterInst failed: %s", errstr)
-		}
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("UpdateClusterInst recv failed: %s", err.Error())
-			}
-			ResultWriteOutputOne(obj)
-		}
-		return nil
+		return UpdateClusterInst(&ClusterInstIn)
 	},
+}
+
+func UpdateClusterInst(in *edgeproto.ClusterInst) error {
+	if ClusterInstApiCmd == nil {
+		return fmt.Errorf("ClusterInstApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := ClusterInstApiCmd.UpdateClusterInst(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("UpdateClusterInst failed: %s", errstr)
+	}
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("UpdateClusterInst recv failed: %s", err.Error())
+		}
+		ResultWriteOutputOne(obj)
+	}
+	return nil
+}
+
+func UpdateClusterInsts(data []edgeproto.ClusterInst, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("UpdateClusterInst %v\n", data[ii])
+		myerr := UpdateClusterInst(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowClusterInstCmd = &cobra.Command{
@@ -342,42 +393,59 @@ var ShowClusterInstCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterInstApiCmd == nil {
-			return fmt.Errorf("ClusterInstApi client not initialized")
-		}
-		var err error
-		err = parseClusterInstEnums()
+		err := parseClusterInstEnums()
 		if err != nil {
 			return fmt.Errorf("ShowClusterInst failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := ClusterInstApiCmd.ShowClusterInst(ctx, &ClusterInstIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowClusterInst failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.ClusterInst, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowClusterInst recv failed: %s", err.Error())
-			}
-			ClusterInstHideTags(obj)
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		ClusterInstWriteOutputArray(objs)
-		return nil
+		return ShowClusterInst(&ClusterInstIn)
 	},
+}
+
+func ShowClusterInst(in *edgeproto.ClusterInst) error {
+	if ClusterInstApiCmd == nil {
+		return fmt.Errorf("ClusterInstApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := ClusterInstApiCmd.ShowClusterInst(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowClusterInst failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.ClusterInst, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowClusterInst recv failed: %s", err.Error())
+		}
+		ClusterInstHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	ClusterInstWriteOutputArray(objs)
+	return nil
+}
+
+func ShowClusterInsts(data []edgeproto.ClusterInst, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowClusterInst %v\n", data[ii])
+		myerr := ShowClusterInst(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ClusterInstApiCmds = []*cobra.Command{
@@ -392,42 +460,59 @@ var ShowClusterInstInfoCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterInstInfoApiCmd == nil {
-			return fmt.Errorf("ClusterInstInfoApi client not initialized")
-		}
-		var err error
-		err = parseClusterInstInfoEnums()
+		err := parseClusterInstInfoEnums()
 		if err != nil {
 			return fmt.Errorf("ShowClusterInstInfo failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := ClusterInstInfoApiCmd.ShowClusterInstInfo(ctx, &ClusterInstInfoIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowClusterInstInfo failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.ClusterInstInfo, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowClusterInstInfo recv failed: %s", err.Error())
-			}
-			ClusterInstInfoHideTags(obj)
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		ClusterInstInfoWriteOutputArray(objs)
-		return nil
+		return ShowClusterInstInfo(&ClusterInstInfoIn)
 	},
+}
+
+func ShowClusterInstInfo(in *edgeproto.ClusterInstInfo) error {
+	if ClusterInstInfoApiCmd == nil {
+		return fmt.Errorf("ClusterInstInfoApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := ClusterInstInfoApiCmd.ShowClusterInstInfo(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowClusterInstInfo failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.ClusterInstInfo, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowClusterInstInfo recv failed: %s", err.Error())
+		}
+		ClusterInstInfoHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	ClusterInstInfoWriteOutputArray(objs)
+	return nil
+}
+
+func ShowClusterInstInfos(data []edgeproto.ClusterInstInfo, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowClusterInstInfo %v\n", data[ii])
+		myerr := ShowClusterInstInfo(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ClusterInstInfoApiCmds = []*cobra.Command{

--- a/gencmd/debug.cmd.go
+++ b/gencmd/debug.cmd.go
@@ -131,27 +131,44 @@ var EnableDebugLevelsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if DebugApiCmd == nil {
-			return fmt.Errorf("DebugApi client not initialized")
-		}
-		var err error
-		err = parseDebugLevelsEnums()
+		err := parseDebugLevelsEnums()
 		if err != nil {
 			return fmt.Errorf("EnableDebugLevels failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := DebugApiCmd.EnableDebugLevels(ctx, &DebugLevelsIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("EnableDebugLevels failed: %s", errstr)
-		}
-		DebugResultWriteOutputOne(obj)
-		return nil
+		return EnableDebugLevels(&DebugLevelsIn)
 	},
+}
+
+func EnableDebugLevels(in *log.DebugLevels) error {
+	if DebugApiCmd == nil {
+		return fmt.Errorf("DebugApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := DebugApiCmd.EnableDebugLevels(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("EnableDebugLevels failed: %s", errstr)
+	}
+	DebugResultWriteOutputOne(obj)
+	return nil
+}
+
+func EnableDebugLevelss(data []log.DebugLevels, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("EnableDebugLevels %v\n", data[ii])
+		myerr := EnableDebugLevels(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DisableDebugLevelsCmd = &cobra.Command{
@@ -159,27 +176,44 @@ var DisableDebugLevelsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if DebugApiCmd == nil {
-			return fmt.Errorf("DebugApi client not initialized")
-		}
-		var err error
-		err = parseDebugLevelsEnums()
+		err := parseDebugLevelsEnums()
 		if err != nil {
 			return fmt.Errorf("DisableDebugLevels failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := DebugApiCmd.DisableDebugLevels(ctx, &DebugLevelsIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DisableDebugLevels failed: %s", errstr)
-		}
-		DebugResultWriteOutputOne(obj)
-		return nil
+		return DisableDebugLevels(&DebugLevelsIn)
 	},
+}
+
+func DisableDebugLevels(in *log.DebugLevels) error {
+	if DebugApiCmd == nil {
+		return fmt.Errorf("DebugApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := DebugApiCmd.DisableDebugLevels(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DisableDebugLevels failed: %s", errstr)
+	}
+	DebugResultWriteOutputOne(obj)
+	return nil
+}
+
+func DisableDebugLevelss(data []log.DebugLevels, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DisableDebugLevels %v\n", data[ii])
+		myerr := DisableDebugLevels(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowDebugLevelsCmd = &cobra.Command{
@@ -187,27 +221,44 @@ var ShowDebugLevelsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if DebugApiCmd == nil {
-			return fmt.Errorf("DebugApi client not initialized")
-		}
-		var err error
-		err = parseDebugLevelsEnums()
+		err := parseDebugLevelsEnums()
 		if err != nil {
 			return fmt.Errorf("ShowDebugLevels failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		obj, err := DebugApiCmd.ShowDebugLevels(ctx, &DebugLevelsIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowDebugLevels failed: %s", errstr)
-		}
-		DebugLevelsWriteOutputOne(obj)
-		return nil
+		return ShowDebugLevels(&DebugLevelsIn)
 	},
+}
+
+func ShowDebugLevels(in *log.DebugLevels) error {
+	if DebugApiCmd == nil {
+		return fmt.Errorf("DebugApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := DebugApiCmd.ShowDebugLevels(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowDebugLevels failed: %s", errstr)
+	}
+	DebugLevelsWriteOutputOne(obj)
+	return nil
+}
+
+func ShowDebugLevelss(data []log.DebugLevels, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowDebugLevels %v\n", data[ii])
+		myerr := ShowDebugLevels(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DebugApiCmds = []*cobra.Command{

--- a/gencmd/developer.cmd.go
+++ b/gencmd/developer.cmd.go
@@ -120,23 +120,40 @@ var CreateDeveloperCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if DeveloperApiCmd == nil {
-			return fmt.Errorf("DeveloperApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := DeveloperApiCmd.CreateDeveloper(ctx, &DeveloperIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("CreateDeveloper failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return CreateDeveloper(&DeveloperIn)
 	},
+}
+
+func CreateDeveloper(in *edgeproto.Developer) error {
+	if DeveloperApiCmd == nil {
+		return fmt.Errorf("DeveloperApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := DeveloperApiCmd.CreateDeveloper(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("CreateDeveloper failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func CreateDevelopers(data []edgeproto.Developer, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("CreateDeveloper %v\n", data[ii])
+		myerr := CreateDeveloper(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteDeveloperCmd = &cobra.Command{
@@ -144,23 +161,40 @@ var DeleteDeveloperCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if DeveloperApiCmd == nil {
-			return fmt.Errorf("DeveloperApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := DeveloperApiCmd.DeleteDeveloper(ctx, &DeveloperIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteDeveloper failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return DeleteDeveloper(&DeveloperIn)
 	},
+}
+
+func DeleteDeveloper(in *edgeproto.Developer) error {
+	if DeveloperApiCmd == nil {
+		return fmt.Errorf("DeveloperApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := DeveloperApiCmd.DeleteDeveloper(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteDeveloper failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func DeleteDevelopers(data []edgeproto.Developer, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteDeveloper %v\n", data[ii])
+		myerr := DeleteDeveloper(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var UpdateDeveloperCmd = &cobra.Command{
@@ -168,24 +202,41 @@ var UpdateDeveloperCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if DeveloperApiCmd == nil {
-			return fmt.Errorf("DeveloperApi client not initialized")
-		}
-		var err error
 		DeveloperSetFields()
-		ctx := context.Background()
-		obj, err := DeveloperApiCmd.UpdateDeveloper(ctx, &DeveloperIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("UpdateDeveloper failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return UpdateDeveloper(&DeveloperIn)
 	},
+}
+
+func UpdateDeveloper(in *edgeproto.Developer) error {
+	if DeveloperApiCmd == nil {
+		return fmt.Errorf("DeveloperApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := DeveloperApiCmd.UpdateDeveloper(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("UpdateDeveloper failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func UpdateDevelopers(data []edgeproto.Developer, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("UpdateDeveloper %v\n", data[ii])
+		myerr := UpdateDeveloper(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowDeveloperCmd = &cobra.Command{
@@ -193,37 +244,54 @@ var ShowDeveloperCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if DeveloperApiCmd == nil {
-			return fmt.Errorf("DeveloperApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		stream, err := DeveloperApiCmd.ShowDeveloper(ctx, &DeveloperIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowDeveloper failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.Developer, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowDeveloper recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		DeveloperWriteOutputArray(objs)
-		return nil
+		return ShowDeveloper(&DeveloperIn)
 	},
+}
+
+func ShowDeveloper(in *edgeproto.Developer) error {
+	if DeveloperApiCmd == nil {
+		return fmt.Errorf("DeveloperApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := DeveloperApiCmd.ShowDeveloper(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowDeveloper failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.Developer, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowDeveloper recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	DeveloperWriteOutputArray(objs)
+	return nil
+}
+
+func ShowDevelopers(data []edgeproto.Developer, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowDeveloper %v\n", data[ii])
+		myerr := ShowDeveloper(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeveloperApiCmds = []*cobra.Command{

--- a/gencmd/flavor.cmd.go
+++ b/gencmd/flavor.cmd.go
@@ -120,23 +120,40 @@ var CreateFlavorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if FlavorApiCmd == nil {
-			return fmt.Errorf("FlavorApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := FlavorApiCmd.CreateFlavor(ctx, &FlavorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("CreateFlavor failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return CreateFlavor(&FlavorIn)
 	},
+}
+
+func CreateFlavor(in *edgeproto.Flavor) error {
+	if FlavorApiCmd == nil {
+		return fmt.Errorf("FlavorApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := FlavorApiCmd.CreateFlavor(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("CreateFlavor failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func CreateFlavors(data []edgeproto.Flavor, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("CreateFlavor %v\n", data[ii])
+		myerr := CreateFlavor(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteFlavorCmd = &cobra.Command{
@@ -144,23 +161,40 @@ var DeleteFlavorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if FlavorApiCmd == nil {
-			return fmt.Errorf("FlavorApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := FlavorApiCmd.DeleteFlavor(ctx, &FlavorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteFlavor failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return DeleteFlavor(&FlavorIn)
 	},
+}
+
+func DeleteFlavor(in *edgeproto.Flavor) error {
+	if FlavorApiCmd == nil {
+		return fmt.Errorf("FlavorApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := FlavorApiCmd.DeleteFlavor(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteFlavor failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func DeleteFlavors(data []edgeproto.Flavor, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteFlavor %v\n", data[ii])
+		myerr := DeleteFlavor(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var UpdateFlavorCmd = &cobra.Command{
@@ -168,24 +202,41 @@ var UpdateFlavorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if FlavorApiCmd == nil {
-			return fmt.Errorf("FlavorApi client not initialized")
-		}
-		var err error
 		FlavorSetFields()
-		ctx := context.Background()
-		obj, err := FlavorApiCmd.UpdateFlavor(ctx, &FlavorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("UpdateFlavor failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return UpdateFlavor(&FlavorIn)
 	},
+}
+
+func UpdateFlavor(in *edgeproto.Flavor) error {
+	if FlavorApiCmd == nil {
+		return fmt.Errorf("FlavorApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := FlavorApiCmd.UpdateFlavor(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("UpdateFlavor failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func UpdateFlavors(data []edgeproto.Flavor, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("UpdateFlavor %v\n", data[ii])
+		myerr := UpdateFlavor(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowFlavorCmd = &cobra.Command{
@@ -193,37 +244,54 @@ var ShowFlavorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if FlavorApiCmd == nil {
-			return fmt.Errorf("FlavorApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		stream, err := FlavorApiCmd.ShowFlavor(ctx, &FlavorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowFlavor failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.Flavor, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowFlavor recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		FlavorWriteOutputArray(objs)
-		return nil
+		return ShowFlavor(&FlavorIn)
 	},
+}
+
+func ShowFlavor(in *edgeproto.Flavor) error {
+	if FlavorApiCmd == nil {
+		return fmt.Errorf("FlavorApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := FlavorApiCmd.ShowFlavor(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowFlavor failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.Flavor, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowFlavor recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	FlavorWriteOutputArray(objs)
+	return nil
+}
+
+func ShowFlavors(data []edgeproto.Flavor, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowFlavor %v\n", data[ii])
+		myerr := ShowFlavor(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var FlavorApiCmds = []*cobra.Command{

--- a/gencmd/node.cmd.go
+++ b/gencmd/node.cmd.go
@@ -163,42 +163,59 @@ var ShowNodeLocalCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if NodeApiCmd == nil {
-			return fmt.Errorf("NodeApi client not initialized")
-		}
-		var err error
-		err = parseNodeEnums()
+		err := parseNodeEnums()
 		if err != nil {
 			return fmt.Errorf("ShowNodeLocal failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := NodeApiCmd.ShowNodeLocal(ctx, &NodeIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowNodeLocal failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.Node, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowNodeLocal recv failed: %s", err.Error())
-			}
-			NodeHideTags(obj)
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		NodeWriteOutputArray(objs)
-		return nil
+		return ShowNodeLocal(&NodeIn)
 	},
+}
+
+func ShowNodeLocal(in *edgeproto.Node) error {
+	if NodeApiCmd == nil {
+		return fmt.Errorf("NodeApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := NodeApiCmd.ShowNodeLocal(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowNodeLocal failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.Node, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowNodeLocal recv failed: %s", err.Error())
+		}
+		NodeHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	NodeWriteOutputArray(objs)
+	return nil
+}
+
+func ShowNodeLocals(data []edgeproto.Node, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowNodeLocal %v\n", data[ii])
+		myerr := ShowNodeLocal(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowNodeCmd = &cobra.Command{
@@ -206,42 +223,59 @@ var ShowNodeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if NodeApiCmd == nil {
-			return fmt.Errorf("NodeApi client not initialized")
-		}
-		var err error
-		err = parseNodeEnums()
+		err := parseNodeEnums()
 		if err != nil {
 			return fmt.Errorf("ShowNode failed: %s", err.Error())
 		}
-		ctx := context.Background()
-		stream, err := NodeApiCmd.ShowNode(ctx, &NodeIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowNode failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.Node, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowNode recv failed: %s", err.Error())
-			}
-			NodeHideTags(obj)
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		NodeWriteOutputArray(objs)
-		return nil
+		return ShowNode(&NodeIn)
 	},
+}
+
+func ShowNode(in *edgeproto.Node) error {
+	if NodeApiCmd == nil {
+		return fmt.Errorf("NodeApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := NodeApiCmd.ShowNode(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowNode failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.Node, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowNode recv failed: %s", err.Error())
+		}
+		NodeHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	NodeWriteOutputArray(objs)
+	return nil
+}
+
+func ShowNodes(data []edgeproto.Node, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowNode %v\n", data[ii])
+		myerr := ShowNode(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var NodeApiCmds = []*cobra.Command{

--- a/gencmd/operator.cmd.go
+++ b/gencmd/operator.cmd.go
@@ -112,23 +112,40 @@ var CreateOperatorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if OperatorApiCmd == nil {
-			return fmt.Errorf("OperatorApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := OperatorApiCmd.CreateOperator(ctx, &OperatorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("CreateOperator failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return CreateOperator(&OperatorIn)
 	},
+}
+
+func CreateOperator(in *edgeproto.Operator) error {
+	if OperatorApiCmd == nil {
+		return fmt.Errorf("OperatorApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := OperatorApiCmd.CreateOperator(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("CreateOperator failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func CreateOperators(data []edgeproto.Operator, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("CreateOperator %v\n", data[ii])
+		myerr := CreateOperator(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var DeleteOperatorCmd = &cobra.Command{
@@ -136,23 +153,40 @@ var DeleteOperatorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if OperatorApiCmd == nil {
-			return fmt.Errorf("OperatorApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		obj, err := OperatorApiCmd.DeleteOperator(ctx, &OperatorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("DeleteOperator failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return DeleteOperator(&OperatorIn)
 	},
+}
+
+func DeleteOperator(in *edgeproto.Operator) error {
+	if OperatorApiCmd == nil {
+		return fmt.Errorf("OperatorApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := OperatorApiCmd.DeleteOperator(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DeleteOperator failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func DeleteOperators(data []edgeproto.Operator, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DeleteOperator %v\n", data[ii])
+		myerr := DeleteOperator(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var UpdateOperatorCmd = &cobra.Command{
@@ -160,24 +194,41 @@ var UpdateOperatorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if OperatorApiCmd == nil {
-			return fmt.Errorf("OperatorApi client not initialized")
-		}
-		var err error
 		OperatorSetFields()
-		ctx := context.Background()
-		obj, err := OperatorApiCmd.UpdateOperator(ctx, &OperatorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("UpdateOperator failed: %s", errstr)
-		}
-		ResultWriteOutputOne(obj)
-		return nil
+		return UpdateOperator(&OperatorIn)
 	},
+}
+
+func UpdateOperator(in *edgeproto.Operator) error {
+	if OperatorApiCmd == nil {
+		return fmt.Errorf("OperatorApi client not initialized")
+	}
+	ctx := context.Background()
+	obj, err := OperatorApiCmd.UpdateOperator(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("UpdateOperator failed: %s", errstr)
+	}
+	ResultWriteOutputOne(obj)
+	return nil
+}
+
+func UpdateOperators(data []edgeproto.Operator, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("UpdateOperator %v\n", data[ii])
+		myerr := UpdateOperator(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ShowOperatorCmd = &cobra.Command{
@@ -185,37 +236,54 @@ var ShowOperatorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if OperatorApiCmd == nil {
-			return fmt.Errorf("OperatorApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		stream, err := OperatorApiCmd.ShowOperator(ctx, &OperatorIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowOperator failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.Operator, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowOperator recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		OperatorWriteOutputArray(objs)
-		return nil
+		return ShowOperator(&OperatorIn)
 	},
+}
+
+func ShowOperator(in *edgeproto.Operator) error {
+	if OperatorApiCmd == nil {
+		return fmt.Errorf("OperatorApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := OperatorApiCmd.ShowOperator(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowOperator failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.Operator, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowOperator recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	OperatorWriteOutputArray(objs)
+	return nil
+}
+
+func ShowOperators(data []edgeproto.Operator, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowOperator %v\n", data[ii])
+		myerr := ShowOperator(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var OperatorApiCmds = []*cobra.Command{

--- a/gencmd/refs.cmd.go
+++ b/gencmd/refs.cmd.go
@@ -145,37 +145,54 @@ var ShowCloudletRefsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if CloudletRefsApiCmd == nil {
-			return fmt.Errorf("CloudletRefsApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		stream, err := CloudletRefsApiCmd.ShowCloudletRefs(ctx, &CloudletRefsIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowCloudletRefs failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.CloudletRefs, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowCloudletRefs recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		CloudletRefsWriteOutputArray(objs)
-		return nil
+		return ShowCloudletRefs(&CloudletRefsIn)
 	},
+}
+
+func ShowCloudletRefs(in *edgeproto.CloudletRefs) error {
+	if CloudletRefsApiCmd == nil {
+		return fmt.Errorf("CloudletRefsApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := CloudletRefsApiCmd.ShowCloudletRefs(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowCloudletRefs failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.CloudletRefs, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowCloudletRefs recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	CloudletRefsWriteOutputArray(objs)
+	return nil
+}
+
+func ShowCloudletRefss(data []edgeproto.CloudletRefs, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowCloudletRefs %v\n", data[ii])
+		myerr := ShowCloudletRefs(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var CloudletRefsApiCmds = []*cobra.Command{
@@ -187,37 +204,54 @@ var ShowClusterRefsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if we got this far, usage has been met.
 		cmd.SilenceUsage = true
-		if ClusterRefsApiCmd == nil {
-			return fmt.Errorf("ClusterRefsApi client not initialized")
-		}
-		var err error
-		ctx := context.Background()
-		stream, err := ClusterRefsApiCmd.ShowClusterRefs(ctx, &ClusterRefsIn)
-		if err != nil {
-			errstr := err.Error()
-			st, ok := status.FromError(err)
-			if ok {
-				errstr = st.Message()
-			}
-			return fmt.Errorf("ShowClusterRefs failed: %s", errstr)
-		}
-		objs := make([]*edgeproto.ClusterRefs, 0)
-		for {
-			obj, err := stream.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return fmt.Errorf("ShowClusterRefs recv failed: %s", err.Error())
-			}
-			objs = append(objs, obj)
-		}
-		if len(objs) == 0 {
-			return nil
-		}
-		ClusterRefsWriteOutputArray(objs)
-		return nil
+		return ShowClusterRefs(&ClusterRefsIn)
 	},
+}
+
+func ShowClusterRefs(in *edgeproto.ClusterRefs) error {
+	if ClusterRefsApiCmd == nil {
+		return fmt.Errorf("ClusterRefsApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := ClusterRefsApiCmd.ShowClusterRefs(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowClusterRefs failed: %s", errstr)
+	}
+	objs := make([]*edgeproto.ClusterRefs, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ShowClusterRefs recv failed: %s", err.Error())
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	ClusterRefsWriteOutputArray(objs)
+	return nil
+}
+
+func ShowClusterRefss(data []edgeproto.ClusterRefs, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowClusterRefs %v\n", data[ii])
+		myerr := ShowClusterRefs(&data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
 }
 
 var ClusterRefsApiCmds = []*cobra.Command{

--- a/setup-env/e2e-tests/testfiles/regression_group.yml
+++ b/setup-env/e2e-tests/testfiles/regression_group.yml
@@ -4,6 +4,8 @@ tests:
   - includefile: check_nodes.yml
   - includefile: add_delete.yml
     loops: 2
+  - includefile: add_delete_cli.yml
+    loops: 2
   - includefile: add_delete_2apps.yml
     loops: 2
   - includefile: get_cloudlets.yml

--- a/setup-env/test-mex/test-mex.go
+++ b/setup-env/test-mex/test-mex.go
@@ -63,6 +63,7 @@ var actionChoices = map[string]string{
 	"stop":          "procname",
 	"status":        "procname",
 	"ctrlapi":       "procname",
+	"ctrlcli":       "procname",
 	"ctrlinfo":      "procname",
 	"dmeapi":        "procname",
 	"deploy":        "",
@@ -284,6 +285,16 @@ func main() {
 					log.Printf("Unable to run api for %s\n", action)
 					errorsFound++
 					errors = append(errors, "controller api failed")
+				}
+			}
+		case "ctrlcli":
+			if !setupmex.UpdateAPIAddrs() {
+				errorsFound++
+			} else {
+				if !apis.RunControllerCLI(actionSubtype, actionParam, *apiFile, *outputDir) {
+					log.Printf("Unable to run edgectl for %s\n", action)
+					errorsFound++
+					errors = append(errors, "controller cli failed")
 				}
 			}
 		case "dmeapi":

--- a/setup-env/util/util.go
+++ b/setup-env/util/util.go
@@ -494,3 +494,13 @@ func CompareYamlFiles(firstYamlFile string, secondYamlFile string, fileType stri
 	log.Println("Comparison success")
 	return true
 }
+
+func ControllerCLI(ctrl *ControllerProcess, args ...string) ([]byte, error) {
+	cmdargs := []string{"--addr", ctrl.ApiAddr, "controller"}
+	if ctrl.TLS.ClientCert != "" {
+		cmdargs = append(cmdargs, "--tls", ctrl.TLS.ClientCert)
+	}
+	cmdargs = append(cmdargs, args...)
+	cmd := exec.Command("edgectl", cmdargs...)
+	return cmd.CombinedOutput()
+}


### PR DESCRIPTION
This adds the ability to pass a yaml file to edgectl to Create/Delete multiple objects. This is similar to kubectl create -f <filename>.
```edgectl controller Create|Delete -f <filename.yaml>```
YAML file format is the same format as the data files we already use for the e2e tests. I've added an e2e regression test that uses the same data files.

Example output from e2e tests:
```
      --- running action: ctrlcli-create
2018/09/20 11:16:27 Applying data via CLI for /Users/gainsley/go/src/github.com/mobiledgex/edge-cloud/setup-env/e2e-tests/data/appdata.yml
2018/09/20 11:16:27 Using controller ctrl1 at address 0.0.0.0:55001
2018/09/20 11:16:27 CreateFlavor {[] {x1.tiny} 1024 1 1}
{}
CreateFlavor {[] {x1.small} 2048 2 2}
{}
CreateFlavor {[] {x1.medium} 4096 4 4}
{}
CreateClusterFlavor {[] {c1.tiny} {x1.tiny} {x1.tiny} 2 2 1}
{}
CreateClusterFlavor {[] {c1.small} {x1.small} {x1.small} 3 3 1}
{}
CreateClusterFlavor {[] {c1.medium} {x1.medium} {x1.medium} 3 4 1}
{}
CreateOperator {[] {ATT}}
{}
CreateOperator {[] {tmus}}
{}
CreateDeveloper {[] {AcmeAppCo} acmeapp 8136f09c17354891c642b9b9f1722c34 123 Maple Street, Gainesville, FL 32604 acmeapp@xxxx.com}
{}
CreateDeveloper {[] {AcmeAppCo1} acmeapp 8136f09c17354891c642b9b9f1722c34 123 Maple Street, Gainesville, FL 32604 acmeapp@xxxx.com}
{}
CreateCloudlet {[] {{tmus} tmocloud-1} cloud1.tmo {31 -91 0 0 0 0 0 (timestamp: nil Timestamp)} IpSupportDynamic  254}
CreateCloudlet {[] {{tmus} tmocloud-2} cloud2.tmo {35 -95 0 0 0 0 0 (timestamp: nil Timestamp)} IpSupportDynamic  254}
CreateCluster {[] {SmallCluster} {c1.small} false}
{}
CreateApp {[] {{AcmeAppCo} someapplication 1.0} mobiledgex_AcmeAppCo/someapplication:1.0 ImageTypeDocker AccessLayerL7   {x1.small} {SmallCluster}}
{}
CreateClusterInst {[] {{SmallCluster} {{tmus} tmocloud-1}} {c1.small} LivenessStatic false TrackedStateUnknown [] NoOverride}
message: Creating
message: Ready
message: Created successfully
CreateClusterInst {[] {{SmallCluster} {{tmus} tmocloud-2}} {c1.small} LivenessStatic false TrackedStateUnknown [] NoOverride}
message: Creating
message: Ready
message: Created successfully
CreateAppInst {[] {{{AcmeAppCo} someapplication 1.0} {{tmus} tmocloud-1} 123} {31 -91 0 0 0 0 0 (timestamp: nil Timestamp)}  {{SmallCluster} {{tmus} tmocloud-1}} LivenessStatic mobiledgex_AcmeAppCo/someapplication:1.0 ImageTypeDocker [] someapplication  {x1.small} AccessLayerL7 TrackedStateUnknown [] NoOverride}
message: Creating
message: Ready
message: Created successfully
CreateAppInst {[] {{{AcmeAppCo} someapplication 1.0} {{tmus} tmocloud-2} 123} {35 -95 0 0 0 0 0 (timestamp: nil Timestamp)}  {{SmallCluster} {{tmus} tmocloud-2}} LivenessStatic mobiledgex_AcmeAppCo/someapplication:1.0 ImageTypeDocker [] someapplication  {x1.small} AccessLayerL7 TrackedStateUnknown [] NoOverride}
message: Creating
message: Ready
message: Created successfully
```