### PR TITLE
add unit tests for edgecloud-186

### DIFF
--- a/gensupport/support.go
+++ b/gensupport/support.go
@@ -259,6 +259,34 @@ func IsRepeated(field *descriptor.FieldDescriptorProto) bool {
 	return *field.Label == descriptor.FieldDescriptorProto_LABEL_REPEATED
 }
 
+func HasGrpcFields(message *descriptor.DescriptorProto) bool {
+	if message.Field != nil && len(message.Field) > 0 && *message.Field[0].Name == "fields" && *message.Field[0].Type == descriptor.FieldDescriptorProto_TYPE_STRING {
+		return true
+	}
+	return false
+}
+
+func GetMessageKey(message *descriptor.DescriptorProto) *descriptor.FieldDescriptorProto {
+	if message.Field == nil {
+		return nil
+	}
+	if len(message.Field) > 0 && *message.Field[0].Name == "key" {
+		return message.Field[0]
+	}
+	if len(message.Field) > 1 && HasGrpcFields(message) && *message.Field[1].Name == "key" {
+		return message.Field[1]
+	}
+	return nil
+}
+
+func (s *PluginSupport) GetMessageKeyName(g *generator.Generator, message *descriptor.DescriptorProto) (string, error) {
+	field := GetMessageKey(message)
+	if field == nil {
+		return "", fmt.Errorf("No Key field for %s", *message.Name)
+	}
+	return s.GoType(g, field), nil
+}
+
 type MapType struct {
 	KeyField     *descriptor.FieldDescriptorProto
 	ValField     *descriptor.FieldDescriptorProto

--- a/protoc-gen-gomex/mexgen/mex.go
+++ b/protoc-gen-gomex/mexgen/mex.go
@@ -1113,7 +1113,7 @@ func (m *mex) generateMessage(file *generator.FileDescriptor, desc *generator.De
 		m.P("}")
 		m.P("")
 	}
-	if HasGrpcFields(message) {
+	if gensupport.HasGrpcFields(message) {
 		m.generateFields([]string{*message.Name + "Field"}, []string{}, desc)
 		m.P("")
 		m.P("var ", *message.Name, "AllFields = []string{")
@@ -1135,15 +1135,15 @@ func (m *mex) generateMessage(file *generator.FileDescriptor, desc *generator.De
 
 	msgtyp := m.gen.TypeName(desc)
 	m.P("func (m *", msgtyp, ") CopyInFields(src *", msgtyp, ") {")
-	if HasGrpcFields(message) {
+	if gensupport.HasGrpcFields(message) {
 		m.P("fmap := MakeFieldMap(src.Fields)")
 	}
-	m.generateCopyIn(make([]string, 0), make([]string, 0), desc, make([]*generator.Descriptor, 0), HasGrpcFields(message))
+	m.generateCopyIn(make([]string, 0), make([]string, 0), desc, make([]*generator.Descriptor, 0), gensupport.HasGrpcFields(message))
 	m.P("}")
 	m.P("")
 
 	if GetGenerateCud(message) {
-		keyField := GetMessageKey(message)
+		keyField := gensupport.GetMessageKey(message)
 		if keyField == nil {
 			m.gen.Fail("message", *message.Name, "needs a unique key field named key of type", *message.Name+"Key", "for option generate_cud")
 		}
@@ -1151,12 +1151,12 @@ func (m *mex) generateMessage(file *generator.FileDescriptor, desc *generator.De
 			Name:      *message.Name,
 			CudName:   *message.Name + "Cud",
 			KeyType:   m.support.GoType(m.gen, keyField),
-			HasFields: HasGrpcFields(message),
+			HasFields: gensupport.HasGrpcFields(message),
 		}
 		m.cudTemplate.Execute(m.gen.Buffer, args)
 	}
 	if GetGenerateCache(message) {
-		keyField := GetMessageKey(message)
+		keyField := gensupport.GetMessageKey(message)
 		if keyField == nil {
 			m.gen.Fail("message", *message.Name, "needs a unique key field named key of type", *message.Name+"Key", "for option generate_cud")
 		}
@@ -1193,7 +1193,7 @@ func (m *mex) generateMessage(file *generator.FileDescriptor, desc *generator.De
 		m.P("")
 		m.importUtil = true
 	}
-	if field := GetMessageKey(message); field != nil {
+	if field := gensupport.GetMessageKey(message); field != nil {
 		//m.P("func (m *", message.Name, ") GetKey() *", m.support.GoType(m.gen, field), " {")
 		m.P("func (m *", message.Name, ") GetKey() objstore.ObjKey {")
 		m.P("return &m.Key")
@@ -1212,26 +1212,6 @@ func (m *mex) generateService(file *generator.FileDescriptor, service *descripto
 
 func (m *mex) generateMethod(file *generator.FileDescriptor, service *descriptor.ServiceDescriptorProto, method *descriptor.MethodDescriptorProto) {
 
-}
-
-func HasGrpcFields(message *descriptor.DescriptorProto) bool {
-	if message.Field != nil && len(message.Field) > 0 && *message.Field[0].Name == "fields" && *message.Field[0].Type == descriptor.FieldDescriptorProto_TYPE_STRING {
-		return true
-	}
-	return false
-}
-
-func GetMessageKey(message *descriptor.DescriptorProto) *descriptor.FieldDescriptorProto {
-	if message.Field == nil {
-		return nil
-	}
-	if len(message.Field) > 0 && *message.Field[0].Name == "key" {
-		return message.Field[0]
-	}
-	if len(message.Field) > 1 && HasGrpcFields(message) && *message.Field[1].Name == "key" {
-		return message.Field[1]
-	}
-	return nil
 }
 
 func GetGenerateMatches(message *descriptor.DescriptorProto) bool {

--- a/testutil/app_inst_testutil.go
+++ b/testutil/app_inst_testutil.go
@@ -236,6 +236,24 @@ func basicAppInstShowTest(t *testing.T, api *AppInstCommonApi, testData []edgepr
 		show.AssertFound(t, &obj)
 	}
 }
+
+func GetAppInst(t *testing.T, api *AppInstCommonApi, key *edgeproto.AppInstKey, out *edgeproto.AppInst) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowAppInst{}
+	show.Init()
+	filter := edgeproto.AppInst{}
+	filter.Key = *key
+	err = api.ShowAppInst(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 func basicAppInstCudTest(t *testing.T, api *AppInstCommonApi, testData []edgeproto.AppInst) {
 	var err error
 	ctx := context.TODO()
@@ -439,4 +457,21 @@ func basicAppInstInfoShowTest(t *testing.T, api *AppInstInfoCommonApi, testData 
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
+}
+
+func GetAppInstInfo(t *testing.T, api *AppInstInfoCommonApi, key *edgeproto.AppInstKey, out *edgeproto.AppInstInfo) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowAppInstInfo{}
+	show.Init()
+	filter := edgeproto.AppInstInfo{}
+	filter.Key = *key
+	err = api.ShowAppInstInfo(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
 }

--- a/testutil/app_testutil.go
+++ b/testutil/app_testutil.go
@@ -257,6 +257,24 @@ func basicAppShowTest(t *testing.T, api *AppCommonApi, testData []edgeproto.App)
 		show.AssertFound(t, &obj)
 	}
 }
+
+func GetApp(t *testing.T, api *AppCommonApi, key *edgeproto.AppKey, out *edgeproto.App) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowApp{}
+	show.Init()
+	filter := edgeproto.App{}
+	filter.Key = *key
+	err = api.ShowApp(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 func basicAppCudTest(t *testing.T, api *AppCommonApi, testData []edgeproto.App) {
 	var err error
 	ctx := context.TODO()

--- a/testutil/cloudlet_testutil.go
+++ b/testutil/cloudlet_testutil.go
@@ -236,6 +236,24 @@ func basicCloudletShowTest(t *testing.T, api *CloudletCommonApi, testData []edge
 		show.AssertFound(t, &obj)
 	}
 }
+
+func GetCloudlet(t *testing.T, api *CloudletCommonApi, key *edgeproto.CloudletKey, out *edgeproto.Cloudlet) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowCloudlet{}
+	show.Init()
+	filter := edgeproto.Cloudlet{}
+	filter.Key = *key
+	err = api.ShowCloudlet(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 func basicCloudletCudTest(t *testing.T, api *CloudletCommonApi, testData []edgeproto.Cloudlet) {
 	var err error
 	ctx := context.TODO()
@@ -459,4 +477,21 @@ func basicCloudletInfoShowTest(t *testing.T, api *CloudletInfoCommonApi, testDat
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
+}
+
+func GetCloudletInfo(t *testing.T, api *CloudletInfoCommonApi, key *edgeproto.CloudletKey, out *edgeproto.CloudletInfo) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowCloudletInfo{}
+	show.Init()
+	filter := edgeproto.CloudletInfo{}
+	filter.Key = *key
+	err = api.ShowCloudletInfo(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
 }

--- a/testutil/cluster_testutil.go
+++ b/testutil/cluster_testutil.go
@@ -194,6 +194,24 @@ func basicClusterShowTest(t *testing.T, api *ClusterCommonApi, testData []edgepr
 		show.AssertFound(t, &obj)
 	}
 }
+
+func GetCluster(t *testing.T, api *ClusterCommonApi, key *edgeproto.ClusterKey, out *edgeproto.Cluster) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowCluster{}
+	show.Init()
+	filter := edgeproto.Cluster{}
+	filter.Key = *key
+	err = api.ShowCluster(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 func basicClusterCudTest(t *testing.T, api *ClusterCommonApi, testData []edgeproto.Cluster) {
 	var err error
 	ctx := context.TODO()

--- a/testutil/clusterflavor_testutil.go
+++ b/testutil/clusterflavor_testutil.go
@@ -194,6 +194,24 @@ func basicClusterFlavorShowTest(t *testing.T, api *ClusterFlavorCommonApi, testD
 		show.AssertFound(t, &obj)
 	}
 }
+
+func GetClusterFlavor(t *testing.T, api *ClusterFlavorCommonApi, key *edgeproto.ClusterFlavorKey, out *edgeproto.ClusterFlavor) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowClusterFlavor{}
+	show.Init()
+	filter := edgeproto.ClusterFlavor{}
+	filter.Key = *key
+	err = api.ShowClusterFlavor(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 func basicClusterFlavorCudTest(t *testing.T, api *ClusterFlavorCommonApi, testData []edgeproto.ClusterFlavor) {
 	var err error
 	ctx := context.TODO()

--- a/testutil/clusterinst_testutil.go
+++ b/testutil/clusterinst_testutil.go
@@ -235,6 +235,24 @@ func basicClusterInstShowTest(t *testing.T, api *ClusterInstCommonApi, testData 
 		show.AssertFound(t, &obj)
 	}
 }
+
+func GetClusterInst(t *testing.T, api *ClusterInstCommonApi, key *edgeproto.ClusterInstKey, out *edgeproto.ClusterInst) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowClusterInst{}
+	show.Init()
+	filter := edgeproto.ClusterInst{}
+	filter.Key = *key
+	err = api.ShowClusterInst(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 func basicClusterInstCudTest(t *testing.T, api *ClusterInstCommonApi, testData []edgeproto.ClusterInst) {
 	var err error
 	ctx := context.TODO()
@@ -438,4 +456,21 @@ func basicClusterInstInfoShowTest(t *testing.T, api *ClusterInstInfoCommonApi, t
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
+}
+
+func GetClusterInstInfo(t *testing.T, api *ClusterInstInfoCommonApi, key *edgeproto.ClusterInstKey, out *edgeproto.ClusterInstInfo) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowClusterInstInfo{}
+	show.Init()
+	filter := edgeproto.ClusterInstInfo{}
+	filter.Key = *key
+	err = api.ShowClusterInstInfo(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
 }

--- a/testutil/developer_testutil.go
+++ b/testutil/developer_testutil.go
@@ -193,6 +193,24 @@ func basicDeveloperShowTest(t *testing.T, api *DeveloperCommonApi, testData []ed
 		show.AssertFound(t, &obj)
 	}
 }
+
+func GetDeveloper(t *testing.T, api *DeveloperCommonApi, key *edgeproto.DeveloperKey, out *edgeproto.Developer) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowDeveloper{}
+	show.Init()
+	filter := edgeproto.Developer{}
+	filter.Key = *key
+	err = api.ShowDeveloper(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 func basicDeveloperCudTest(t *testing.T, api *DeveloperCommonApi, testData []edgeproto.Developer) {
 	var err error
 	ctx := context.TODO()

--- a/testutil/flavor_testutil.go
+++ b/testutil/flavor_testutil.go
@@ -194,6 +194,24 @@ func basicFlavorShowTest(t *testing.T, api *FlavorCommonApi, testData []edgeprot
 		show.AssertFound(t, &obj)
 	}
 }
+
+func GetFlavor(t *testing.T, api *FlavorCommonApi, key *edgeproto.FlavorKey, out *edgeproto.Flavor) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowFlavor{}
+	show.Init()
+	filter := edgeproto.Flavor{}
+	filter.Key = *key
+	err = api.ShowFlavor(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 func basicFlavorCudTest(t *testing.T, api *FlavorCommonApi, testData []edgeproto.Flavor) {
 	var err error
 	ctx := context.TODO()

--- a/testutil/operator_testutil.go
+++ b/testutil/operator_testutil.go
@@ -193,6 +193,24 @@ func basicOperatorShowTest(t *testing.T, api *OperatorCommonApi, testData []edge
 		show.AssertFound(t, &obj)
 	}
 }
+
+func GetOperator(t *testing.T, api *OperatorCommonApi, key *edgeproto.OperatorKey, out *edgeproto.Operator) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowOperator{}
+	show.Init()
+	filter := edgeproto.Operator{}
+	filter.Key = *key
+	err = api.ShowOperator(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 func basicOperatorCudTest(t *testing.T, api *OperatorCommonApi, testData []edgeproto.Operator) {
 	var err error
 	ctx := context.TODO()

--- a/testutil/refs_testutil.go
+++ b/testutil/refs_testutil.go
@@ -167,6 +167,23 @@ func basicCloudletRefsShowTest(t *testing.T, api *CloudletRefsCommonApi, testDat
 	}
 }
 
+func GetCloudletRefs(t *testing.T, api *CloudletRefsCommonApi, key *edgeproto.CloudletKey, out *edgeproto.CloudletRefs) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowCloudletRefs{}
+	show.Init()
+	filter := edgeproto.CloudletRefs{}
+	filter.Key = *key
+	err = api.ShowCloudletRefs(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
+}
+
 // Auto-generated code: DO NOT EDIT
 
 type ShowClusterRefs struct {
@@ -309,4 +326,21 @@ func basicClusterRefsShowTest(t *testing.T, api *ClusterRefsCommonApi, testData 
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
+}
+
+func GetClusterRefs(t *testing.T, api *ClusterRefsCommonApi, key *edgeproto.ClusterInstKey, out *edgeproto.ClusterRefs) bool {
+	var err error
+	ctx := context.TODO()
+
+	show := ShowClusterRefs{}
+	show.Init()
+	filter := edgeproto.ClusterRefs{}
+	filter.Key = *key
+	err = api.ShowClusterRefs(ctx, &filter, &show)
+	assert.Nil(t, err, "show data")
+	obj, found := show.Data[key.GetKeyString()]
+	if found {
+		*out = obj
+	}
+	return found
 }


### PR DESCRIPTION
This adds some unit tests for Create/Delete ClusterInst/AppInst CRM delete failures, unsticking error states, and CRM override options. These tests cover bugs were fixed in edgecloud-186. Refactoring some test code was needed.