### PR TITLE
Added a check for ImageType in CreateApp on the controller side.

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -81,6 +81,10 @@ func (s *AppApi) CreateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 	if in.ImageType == edgeproto.ImageType_ImageTypeUnknown {
 		return &edgeproto.Result{}, errors.New("Please specify Image Type")
 	}
+	_, ok := edgeproto.ImageType_name[int32(in.ImageType)]
+	if !ok {
+		return &edgeproto.Result{}, errors.New("invalid Image Type")
+	}
 	if in.IpAccess == edgeproto.IpAccess_IpAccessUnknown {
 		// default to shared
 		in.IpAccess = edgeproto.IpAccess_IpAccessShared


### PR DESCRIPTION
This addresses a case where a ImageType value in the grpc message is not one controller understands.

edgecloud-192