### PR TITLE
EDGECLOUD-226 allow https (ssl)  connection to controller

### DIFF
--- a/mexui/src/app/appinsts/appinsts.component.ts
+++ b/mexui/src/app/appinsts/appinsts.component.ts
@@ -452,12 +452,14 @@ export class AppinstsComponent implements OnInit {
      (data) => {
          // console.log("Delete called with index = ${index}");
          this.appinsts.splice(index,1);
+         this.ngOnInit();
      },
      error =>  {
        // Temporary solution: need to understand this error better.
        // console.log('oops', error);
        // console.log("Got Error on Delete  with index = " + index);
        this.appinsts.splice(index,1);
+       this.ngOnInit();
      }
    );
  }

--- a/mexui/src/app/devdata.service.ts
+++ b/mexui/src/app/devdata.service.ts
@@ -7,7 +7,8 @@ import { catchError, retry } from 'rxjs/operators';
 import 'rxjs/add/observable/of';
 import { Developer, App, AppInst, Flavor, Oprator, Cloudlet, Cluster } from './app.model';
 
-const ctrlUrl="http://mexdemo.ctrl-http.mobiledgex.net:36001";
+const ctrlUrl="https://mexdemo.ctrl.mobiledgex.net:36001";
+//const ctrlUrl="http://mexdemo.ctrl-http.mobiledgex.net:36001";
 // const ctrlUrl="http://0.0.0.0:36002";
 
 


### PR DESCRIPTION
Allow https connection to the controller.

The browser still has to import the relevant certificate (in case of mexdemo, mex-ca.crt) in the browser and trust it.