### PR TITLE
exit with exitcode=1 on testcase failure

### DIFF
--- a/setup-env/e2e-tests/e2e-tests.go
+++ b/setup-env/e2e-tests/e2e-tests.go
@@ -233,6 +233,7 @@ func main() {
 				fmt.Printf("  %s: failures %d\n", t, f)
 			}
 			fmt.Printf("Logs in %s\n", *outputDir)
+                        os.Exit(1)
 		}
 	}
 


### PR DESCRIPTION
Exit with exit value of 1 (non zero) on test case failure. This will allow "make test" to return a non-zero exit value if a test case fails. "make test" was returning a 0 exit value on both testcase pass and failure

	modified:   e2e-tests.go

