### PR TITLE
e2e testfiles for new uri scheme

### DIFF
--- a/setup-env/e2e-tests/data/mextest/appdata_mextest.yml
+++ b/setup-env/e2e-tests/data/mextest/appdata_mextest.yml
@@ -1,0 +1,166 @@
+flavors:
+- key:
+    name: x1.tiny
+  ram: 1024
+  vcpus: 1
+  disk: 1
+- key:
+    name: x1.small
+  ram: 2048
+  vcpus: 2
+  disk: 2
+- key:
+    name: x1.medium
+  ram: 4096
+  vcpus: 4
+  disk: 4
+
+clusterflavors:
+- key:
+    name: x1.medium
+  nodeflavor:
+    name: x1.small
+  masterflavor:
+    name: x1.small
+  numnodes: 3
+  maxnodes: 3
+  nummasters: 1
+
+clusters:
+- key:
+    name: testappcluster
+  defaultflavor:
+    name: x1.medium
+
+clusterinsts:
+- key:
+    clusterkey:
+      name: testappcluster
+    cloudletkey:
+      operatorkey:
+        name: gcp
+      name: centraluscloudlet
+  flavor:
+    name: x1.medium
+  liveness: LivenessStatic
+
+operators:
+- key:
+    name: jlm
+- key: 
+    name: azure
+- key:
+    name: gcp
+
+developers:
+- key:
+    name: MobiledgeX SDK Demo
+  username: bruce
+  passhash: 8136f09c17354891c642b9b9f1722c34
+  address: 000 Nowhere Street, Gainesville, FL 32604
+  email: empty@xxxx.com
+
+cloudlets:
+- key:
+    operatorkey:
+      name: gcp
+    name: centraluscloudlet
+  accessuri: 
+  location:
+    lat: 44.977300
+    long: -93.265469
+  ipsupport: IpSupportDynamic
+  numdynamicips: 254
+
+- key:
+    operatorkey:
+      name: jlm
+    name: bonntestcloudlet
+  accessuri: 
+  location:
+    lat: 50.737
+    long: 7.098
+  ipsupport: IpSupportDynamic
+  numdynamicips: 254
+
+apps:
+- key:
+    developerkey:
+      name: MobiledgeX SDK Demo
+    name: MobiledgeX SDK Demo
+    version: "1.0"
+  imagepath: registry.mobiledgex.net:5000/mobiledgex/simapp 
+  imagetype: ImageTypeDocker
+  defaultflavor:
+    name: x1.small
+  cluster:
+    name: testappcluster
+  config: "simapp -port 7777"
+  apptemplate: "http://35.199.188.102/apps/apptemplate.yaml"
+  accessports: "http:7777"
+  ipaccess: IpAccessDedicated
+
+- key:
+    developerkey:
+      name: MobiledgeX SDK Demo
+    name: MobiledgeX SDK Demo
+    version: "1.1"
+  imagepath: registry.mobiledgex.net:5000/mobiledgex/simapp
+  imagetype: ImageTypeDocker
+  defaultflavor:
+    name: x1.small
+  cluster:
+    name: testappcluster
+  config: "simapp -port 7777"
+  apptemplate: "http://35.199.188.102/apps/apptemplate.yaml"
+  accessports: "tcp:7777"
+  ipaccess: IpAccessShared
+
+appinstances:
+- key:
+    appkey:
+      developerkey:
+        name: MobiledgeX SDK Demo
+      name: MobiledgeX SDK Demo
+      version: "1.0"
+    cloudletkey:
+      operatorkey:
+        name: gcp
+      name: centraluscloudlet
+    id: 5011
+  clusterinstkey:
+    clusterkey:
+      name: testappcluster
+    cloudletkey:
+      operatorkey:
+        name: gcp
+      name: centraluscloudlet
+  liveness: LivenessStatic
+  imagepath: mobiledgex_MobiledgeXSDKDemo/MobiledgeXSDKDemo:1
+  imagetype: ImageTypeDocker
+  flavor:
+    name: x1.small
+
+- key:
+    appkey:
+      developerkey:
+        name: MobiledgeX SDK Demo
+      name: MobiledgeX SDK Demo
+      version: "1.1"
+    cloudletkey:
+      operatorkey:
+        name: jlm
+      name: bonntestcloudlet
+    id: 5011
+  clusterinstkey:
+    clusterkey:
+      name: testappcluster
+    cloudletkey:
+      operatorkey:
+        name: jlm
+      name: bonntestcloudlet
+  liveness: LivenessStatic
+  imagepath: mobiledgex_MobiledgeXSDKDemo/MobiledgeXSDKDemo:1
+  imagetype: ImageTypeDocker
+  flavor:
+    name: x1.small

--- a/setup-env/e2e-tests/setups/mextest/cluster-gcloud-gke.yaml
+++ b/setup-env/e2e-tests/setups/mextest/cluster-gcloud-gke.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: cluster
+resource: gcp-us-west1-a-still-entity-201400
+metadata:
+  name: jlmtestcluster
+  tags: jlmtestcluster-tag
+  kind: mex-gke-cluster
+  tenant: jlmtesttenant
+  operator: gcp
+  region: us-west1
+  zone: us-west1-a
+  location: us-west
+  project: still-entity-201400
+  resourcegroup:
+spec:
+  flags:
+  flavor:
+  key: gke-jlmtestcluster
+  dockerregistry: registry.mobiledgex.net:5000
+  rootlb:
+  networkscheme:

--- a/setup-env/e2e-tests/setups/mextest/etcd-operator.yml
+++ b/setup-env/e2e-tests/setups/mextest/etcd-operator.yml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etcd-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: etcd-operator
+    spec:
+      containers:
+      - name: etcd-operator
+        image: quay.io/coreos/etcd-operator:v0.9.2
+        command:
+        - etcd-operator
+        # Uncomment to act for resources in all namespaces. More information in doc/clusterwide.md
+        #- -cluster-wide
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/setup-env/e2e-tests/setups/mextest/gcp_k8s.yml
+++ b/setup-env/e2e-tests/setups/mextest/gcp_k8s.yml
@@ -1,0 +1,86 @@
+cluster:
+    mexmanifest: "{{setupdir}}//cluster-gcloud-gke.yaml"
+
+#we don't actually know the ip until after it is created, so this is updated
+#after and deploy is run a second time.  A better solution TBD
+cloudflare:
+  zone: mobiledgex.net
+  records: 
+  - name: mextest.dme.mobiledgex.net
+    type: A
+    content: 35.233.179.175
+  - name: mextest.tok.mobiledgex.net
+    type: A
+    content: 40.113.219.126
+  - name: mextest.locsim.mobiledgex.net
+    type: A
+    content: 40.113.219.126
+  - name: mextest.ctrl.mobiledgex.net
+    type: A
+    content: 35.233.134.203
+  - name: mobiledgexsdkdemomobiledgexsdkdemo10.centraluscloudlet.gcp.mobiledgex.net
+    type: A
+    content: 35.230.36.164
+
+
+k8s-deployment:
+   - file: rbac.yml
+     description: setup permissions for service account
+
+   - file: mex-secret.yml
+     description: secret used to access private repo
+
+   - file: etcd-operator.yml
+     description: create an operator deployment to manage etcd
+     waitforpods:
+      - podname: etcd-operator
+        podcount: 1
+        maxwait: 180
+ 
+   - file: mex-etcd-cluster.yml
+     description: creates the MEX etcd cluster
+     waitforpods:
+      - podname: mex-etcd-cluster
+        podcount: 3 
+        maxwait: 180
+
+   - file: mex-controller-deploy.yml
+     description: deploys the controllers
+     waitforpods:
+      - podname: controller
+        podcount: 3
+        maxwait: 180
+
+   - file: mex-controller-lb.yml
+     description: create a load balancer for controllers
+
+   - file: mex-dme-deploy.yml
+     description: deploys the dmes
+     waitforpods:
+      - podname: dme
+        podcount: 2
+        maxwait: 180
+
+   - file: mex-dme-lb.yml
+     description: create a load balancer for dmes
+
+controllers:
+- controllerlocal:
+    name: ctrl-pool
+    tls:
+       servercert: "{{tlsoutdir}}/mex-server.crt"
+       clientcert: "{{tlsoutdir}}/mex-client.crt"
+    apiaddr: "0.0.0.0:55001"
+  hostname: "mextest.ctrl.mobiledgex.net"
+
+
+dmes:
+- dmelocal:
+    name: dme-pool
+    carrier: tdg
+    tls:
+       servercert: "{{tlsoutdir}}/mex-server.crt"
+       clientcert: "{{tlsoutdir}}/mex-client.crt"
+    apiaddr: "0.0.0.0:50051"
+  hostname: "mextest.dme.mobiledgex.net"
+

--- a/setup-env/e2e-tests/setups/mextest/grafana.yaml
+++ b/setup-env/e2e-tests/setups/mextest/grafana.yaml
@@ -1,0 +1,74 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: monitoring-grafana
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: k8s.gcr.io/heapster-grafana-amd64:v5.0.4
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ca-certificates
+          readOnly: true
+        - mountPath: /var
+          name: grafana-storage
+        env:
+        - name: INFLUXDB_HOST
+          value: monitoring-influxdb
+        - name: GF_SERVER_HTTP_PORT
+          value: "3000"
+          # The following env variables are required to make Grafana accessible via
+          # the kubernetes api-server proxy. On production clusters, we recommend
+          # removing these env variables, setup auth for grafana, and expose the grafana
+          # service using a LoadBalancer or a public IP.
+        - name: GF_AUTH_BASIC_ENABLED
+          value: "true"
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "false"
+        - name: GF_SECURITY_ADMIN_PASSWORD
+          value: mexadmin123
+        - name: GRAFANA_PASSWD
+          value: mexadmin123
+        - name: GF_SERVER_ROOT_URL
+          # If you're only using the API Server proxy, set this value instead:
+          # value: /api/v1/namespaces/default/services/monitoring-grafana/proxy
+          value: /
+      volumes:
+      - name: ca-certificates
+        hostPath:
+          path: /etc/ssl/certs
+      - name: grafana-storage
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are NOT using this as an addon, you should comment out this line.
+    kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: monitoring-grafana
+  name: monitoring-grafana
+  namespace: default
+spec:
+  # In a production setup, we recommend accessing Grafana through an external Loadbalancer
+  # or through a public IP.
+  type: LoadBalancer
+  # You could also use NodePort to expose the service at a randomly-generated port
+  # type: NodePort
+  ports:
+  - port: 80
+    targetPort: 3000
+  selector:
+    k8s-app: grafana

--- a/setup-env/e2e-tests/setups/mextest/influxdb.yaml
+++ b/setup-env/e2e-tests/setups/mextest/influxdb.yaml
@@ -1,0 +1,41 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: monitoring-influxdb
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: influxdb
+    spec:
+      containers:
+      - name: influxdb
+        image: k8s.gcr.io/heapster-influxdb-amd64:v1.5.2
+        volumeMounts:
+        - mountPath: /data
+          name: influxdb-storage
+      volumes:
+      - name: influxdb-storage
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    task: monitoring
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are NOT using this as an addon, you should comment out this line.
+    # kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: monitoring-influxdb
+  name: monitoring-influxdb
+  namespace: default
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8086
+    targetPort: 8086
+  selector:
+    k8s-app: influxdb

--- a/setup-env/e2e-tests/setups/mextest/mex-controller-deploy.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-controller-deploy.yml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  labels:
+    app: controller
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: controller
+  template:
+    metadata:
+      labels:
+        app: controller
+    spec:
+      containers:
+      - name: controller
+        image: registry.mobiledgex.net:5000/mobiledgex/edge-cloud:jlm1016
+        imagePullPolicy: Always
+        command:
+         - "controller"
+         - "--apiAddr"
+         - "0.0.0.0:55001"
+         - "--httpAddr"
+         - "0.0.0.0:36001"
+         - "--notifyAddr"
+         - "0.0.0.0:37001"
+         - "--etcdUrls"  
+         - "mex-etcd-cluster:2379"
+#         - "--influxAddr"
+#         - "monitoring-influxdb:8086"
+         - "--tls"
+         - "/root/tls/mex-server.crt"
+         - "--d" 
+         - "etcd,api,notify"
+
+      imagePullSecrets:
+       - name: mexreg-secret 
+

--- a/setup-env/e2e-tests/setups/mextest/mex-controller-http-lb.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-controller-http-lb.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+  name: controller-http
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+   - port: 36001
+     protocol: TCP
+     targetPort: 36001
+  selector:
+    app: controller
+  sessionAffinity: None
+  type: LoadBalancer

--- a/setup-env/e2e-tests/setups/mextest/mex-controller-lb.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-controller-lb.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+  name: controller
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+   - port: 55001
+     name: api
+     protocol: TCP
+     targetPort: 55001
+   - port: 36001
+     name: http
+     protocol: TCP
+     targetPort: 36001
+   - port: 37001
+     name: notify
+     protocol: TCP
+     targetPort: 37001
+  selector:
+    app: controller
+  sessionAffinity: None
+  type: LoadBalancer

--- a/setup-env/e2e-tests/setups/mextest/mex-controller-notify-lb.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-controller-notify-lb.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+  name: controller-notify
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+   - port: 37001 
+     protocol: TCP
+     targetPort: 37001
+  selector:
+    app: controller
+  sessionAffinity: None
+  type: LoadBalancer

--- a/setup-env/e2e-tests/setups/mextest/mex-controller-notify-svc.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-controller-notify-svc.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+  name: controller-notify
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - name: controller-notify
+    port: 37001
+    protocol: TCP
+  selector:
+    app: controller
+  sessionAffinity: None
+  type: NodePort

--- a/setup-env/e2e-tests/setups/mextest/mex-crm-deploy-bonn.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-crm-deploy-bonn.yml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crmbonn
+  labels:
+    app: crmbonn
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crmbonn
+  template:
+    metadata:
+      labels:
+        app: crmbonn
+    spec:
+      hostAliases:
+       - ip: "37.50.143.121"
+         hostnames:
+         - "fmbncisrs101.tacn.detemobil.de"
+      containers:
+      - name: crmbonn
+        image: registry.mobiledgex.net:5000/mobiledgex/edge-cloud:jlm1016
+        imagePullPolicy: Always
+        env:
+         - name: MEX_CF_USER
+           value: bob.bae@gmail.com
+         - name: MEX_CF_KEY
+           value: e6aefae8a9825d40dbf7eadb9a49967373847
+         - name: MEX_SSH_KEY
+           value: id_rsa_mobiledgex
+         - name: MEX_DOCKER_REG_PASS
+           value: sandhill
+         - name: MEX_DIR
+           value: /root/.mobiledgex
+         - name: OS_AUTH_URL
+           value: https://fmbncisrs101.tacn.detemobil.de:5000/v2.0
+         - name: OS_CACERT
+           value: /root/.mobiledgex/bonnedgecloudtelekomde.crt
+         - name: OS_USERNAME
+           value: mexadmin
+         - name: OS_PASSWORD
+           value: MEX$Admin12345 
+         - name: OS_REGION_NAME
+           value: RegionOne
+         - name: OS_TENANT_NAME
+           value: mex
+        command:
+         - crmserver
+        args:
+         - "--apiAddr"
+         - "0.0.0.0:55091"
+         - "--cloudletKey"
+         - "{\"operator_key\":{\"name\":\"jlm\"},\"name\":\"bonntestcloudlet\"}"
+         - "--notifyAddrs"
+         - "controller:37001"
+         - "--tls"
+         - "/root/tls/mex-server.crt"
+         - "--d"
+         - "mexos"
+
+      imagePullSecrets:
+       - name: mexreg-secret
+

--- a/setup-env/e2e-tests/setups/mextest/mex-crm-deploy-centralgcp.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-crm-deploy-centralgcp.yml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crmcentralgcp
+  labels:
+    app: crmcentralgcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crmcentralgcp
+  template:
+    metadata:
+      labels:
+        app: crmcentralgcp
+    spec:
+      containers:
+      - name: crmcentralgcp
+        image: registry.mobiledgex.net:5000/mobiledgex/edge-cloud:jlm1016
+        imagePullPolicy: Always
+        env:
+         - name: PATH
+           value: /tmp/google-cloud-sdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/bin
+         - name: MEX_CF_USER
+           value: bob.bae@gmail.com
+         - name: MEX_CF_KEY
+           value: e6aefae8a9825d40dbf7eadb9a49967373847
+         - name: MEX_SSH_KEY
+           value: id_rsa_mobiledgex
+         - name: MEX_DOCKER_REG_PASS
+           value: sandhill
+         - name: MEX_DIR
+           value: /root/.mobiledgex
+         - name: OS_AUTH_URL
+           value: NOTHING
+         - name: OS_CACERT
+           value: NOTHING
+         - name: OS_USERNAME
+           value: mexadmin
+         - name: OS_PASSWORD
+           value: NOTHING
+         - name: OS_REGION_NAME
+           value: RegionOne
+         - name: OS_TENANT_NAME
+           value: mex
+        command:
+         - crmserver
+        args:
+         - "--apiAddr"
+         - "0.0.0.0:55091"
+         - "--cloudletKey"
+         - "{\"operator_key\":{\"name\":\"gcp\"},\"name\":\"centraluscloudlet\"}"
+         - "--notifyAddrs"
+         - "controller:37001"
+         - "--tls"
+         - "/root/tls/mex-server.crt"
+         - "--d"
+         - "mexos"
+
+      imagePullSecrets:
+       - name: mexreg-secret
+

--- a/setup-env/e2e-tests/setups/mextest/mex-crm-lb.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-crm-lb.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: crm
+  name: crm
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+   - port: 55091
+     protocol: TCP
+     targetPort: 55091
+  selector:
+    app: crm
+  sessionAffinity: None
+  type: LoadBalancer

--- a/setup-env/e2e-tests/setups/mextest/mex-dme-deploy.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-dme-deploy.yml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dme
+  labels:
+    app: dme
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dme
+  template:
+    metadata:
+      labels:
+        app: dme
+    spec:
+      containers:
+      - name: dme
+        image: registry.mobiledgex.net:5000/mobiledgex/edge-cloud:jlm1016
+        imagePullPolicy: Always
+        command:
+         - "dme-server"
+         - "--apiAddr"
+         - "0.0.0.0:50051"
+         - "--notifyAddrs"
+         - "controller:37001"
+         - "--locverurl"
+         - "http://mextest.locsim.mobiledgex.net:8888/verifyLocation"
+         - "--carrier"
+         - "TDG"
+         - "--d"
+         - "locapi,dmedb,dmereq"
+         - "--toksrvurl"
+         - "http://mextest.tok.mobiledgex.net:9999/its?followURL=https://dme.mobiledgex.net/verifyLoc" 
+         - "--tls"
+         - "/root/tls/mex-server.crt"
+         - "--cloudletKey"
+         - "{\"operator_key\":{\"name\":\"TDG\"},\"name\":\"centraluscloudlet\"}"
+        env:
+         - name: LOCAPI_USER
+           value: mexserver
+         - name: LOCAPI_PASSWD
+           value: seC2835!
+         
+      imagePullSecrets:
+       - name: mexreg-secret 
+

--- a/setup-env/e2e-tests/setups/mextest/mex-dme-lb.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-dme-lb.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: dme
+  name: dme
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+   - port: 50051
+     protocol: TCP
+     targetPort: 50051
+  selector:
+    app: dme
+  sessionAffinity: None
+  type: LoadBalancer

--- a/setup-env/e2e-tests/setups/mextest/mex-etcd-cluster.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-etcd-cluster.yml
@@ -1,0 +1,11 @@
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: "mex-etcd-cluster"
+  ## Adding this annotation make this cluster managed by clusterwide operators
+  ## namespaced operators ignore it
+  # annotations:
+  #   etcd.database.coreos.com/scope: clusterwide
+spec:
+  size: 3
+  version: "3.2.13"

--- a/setup-env/e2e-tests/setups/mextest/mex-locsim-svc.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-locsim-svc.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: locsim
+  name: locsim
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - name: locsim
+    port: 8888
+    protocol: TCP
+  selector:
+    app: locsim
+  sessionAffinity: None
+  type: NodePort

--- a/setup-env/e2e-tests/setups/mextest/mex-secret.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-secret.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5tb2JpbGVkZ2V4Lm5ldDo1MDAwL3YyLyI6eyJ1c2VybmFtZSI6Im1vYmlsZWRnZXgiLCJwYXNzd29yZCI6InNhbmRoaWxsIiwiZW1haWwiOiJqaW0ubW9ycmlzQG1vYmlsZWRnZXguY29tIiwiYXV0aCI6ImJXOWlhV3hsWkdkbGVEcHpZVzVrYUdsc2JBPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: 2018-07-24T03:15:09Z
+  name: mexreg-secret
+  namespace: default
+  resourceVersion: "752572"
+  selfLink: /api/v1/namespaces/default/secrets/mexreg-secret
+  uid: c5786ba6-8eef-11e8-8e6d-42010a0a000a
+type: kubernetes.io/dockerconfigjson

--- a/setup-env/e2e-tests/setups/mextest/mex-toksrv-lb.yml
+++ b/setup-env/e2e-tests/setups/mextest/mex-toksrv-lb.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: toksrv
+  name: toksrv
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+   - port: 9999
+     protocol: TCP
+     targetPort: 9999
+  selector:
+    app: toksrv
+  sessionAffinity: None
+  type: LoadBalancer

--- a/setup-env/e2e-tests/setups/mextest/rbac.yml
+++ b/setup-env/e2e-tests/setups/mextest/rbac.yml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: fabric8-rbac
+subjects:
+  - kind: ServiceAccount
+    # Reference to upper's `metadata.name`
+    name: default
+    # Reference to upper's `metadata.namespace`
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+

--- a/setup-env/e2e-tests/testfiles/mextest/create_mextest.yml
+++ b/setup-env/e2e-tests/testfiles/mextest/create_mextest.yml
@@ -1,0 +1,8 @@
+##
+##
+
+tests:
+
+- name: create provisioning
+  apifile: "{{datadir}}/mextest/appdata_mextest.yml"
+  actions: [ctrlapi-create]

--- a/setup-env/e2e-tests/testfiles/mextest/delete_mextest.yml
+++ b/setup-env/e2e-tests/testfiles/mextest/delete_mextest.yml
@@ -1,0 +1,8 @@
+##
+##
+
+tests:
+
+- name: delete provisioning
+  apifile: "{{datadir}}/mextest/appdata_mextest.yml"
+  actions: [ctrlapi-delete]


### PR DESCRIPTION
E2E files for a second test system (mextest rather than mexdemo) to test current code so the demo setup can be left at a stable release but we can have new functionality tested as well.  

This setup has one k8s public cloud cloudlet on gcs and one bonn based openstack cloudlet.  

No code changes just a lot of configs in new directories.