### PR TITLE
EDGECLOUD-228 - App creation with invalid ipaccess value

### DIFF
--- a/controller/influxq_test.go
+++ b/controller/influxq_test.go
@@ -39,6 +39,10 @@ func TestInfluxQ(t *testing.T) {
 	connected := q.WaitConnected()
 	assert.True(t, connected, "connected")
 
+	// clear test metrics
+	_, err = q.QueryDB(`DROP SERIES FROM "test-metric"`)
+	require.Nil(t, err, "clear test metrics")
+
 	count := 0
 	iilimit := 10
 

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -192,17 +192,19 @@ func (s *App) Validate(fields map[string]struct{}) error {
 	if err = s.GetKey().Validate(); err != nil {
 		return err
 	}
-	if s.ImageType == ImageType_ImageTypeUnknown {
+	if _, found := fields[AppFieldImageType]; found && s.ImageType == ImageType_ImageTypeUnknown {
 		return errors.New("Please specify Image Type")
 	}
 	if err = s.ValidateEnums(); err != nil {
 		return err
 	}
-	if s.AccessPorts == "" {
-		return errors.New("Please specify access ports")
-	}
-	if _, err = ParseAppPorts(s.AccessPorts); err != nil {
-		return err
+	if _, found := fields[AppFieldAccessPorts]; found {
+		if s.AccessPorts == "" {
+			return errors.New("Please specify access ports")
+		}
+		if _, err = ParseAppPorts(s.AccessPorts); found && err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/integration/controller_test.go
+++ b/integration/controller_test.go
@@ -45,14 +45,16 @@ func testControllerSync(t *testing.T, setup *process.ProcessSetup) {
 	}
 
 	// restart a controller and make sure it resyncs
+	restartInterval := 1 * time.Second
 	ctrlApis[0].Close()
 	setup.Controllers[0].Stop()
 	setup.Controllers[0].Start("", process.WithDebug("etcd,api,notify"))
+	// we need to wait for the ctrlr connection to be ready
 	ctrlApis[0], err = setup.Controllers[0].ConnectAPI(connectTimeout)
 	assert.Nil(t, err, "reconnect to controller 0")
 	devApis[0] = edgeproto.NewDeveloperApiClient(ctrlApis[0])
 	for _, dev := range testutil.DevData {
-		testutil.WaitAssertFoundDeveloper(t, devApis[0], &dev, retries, interval)
+		testutil.WaitAssertFoundDeveloper(t, devApis[0], &dev, retries, restartInterval)
 	}
 
 	// update a developer and make sure it syncs


### PR DESCRIPTION
Change broke UpdateApp api - fixed it.
Also fixed other go test failures to get a clean run.
   - integration test - restart of a controller needs to wait a bit longer
   - influx test - need to clear the metrics