### PR TITLE
EDGECLOUD-253 - Fix AndroidSDK appVersion.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -264,7 +264,7 @@ public class MatchingEngine {
 
         try {
             pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-            versionName = (appVersion == null) ? pInfo.versionName : appVersion;
+            versionName = (appVersion == null || appVersion.isEmpty()) ? pInfo.versionName : appVersion;
         } catch (PackageManager.NameNotFoundException nfe) {
             nfe.printStackTrace();
             // Hard stop, or continue?


### PR DESCRIPTION
Minor fix for Android MEX SDK. Server reports error.

One can pass in a empty string or null for the appVersion in createRegisterClientRequest().
