### PR TITLE
skip getsvcexternalip test

### DIFF
--- a/cloud-resource-manager/crmutil/mexos_test.go
+++ b/cloud-resource-manager/crmutil/mexos_test.go
@@ -327,7 +327,14 @@ func TestFormNginxProxyRequest(t *testing.T) {
 
 func TestGetSvcExternalIP(t *testing.T) {
 	home := os.Getenv("HOME")
-	eip, err := getSvcExternalIP("testapp", home+"/.mobiledgex/aks-testcluster.kubeconfig")
+	path := home + "/.mobiledgex/aks-testcluster.kubeconfig"
+
+	_, err := os.Stat(path)
+	if err != nil {
+		fmt.Println("skip getSvcExternalIP test")
+		return
+	}
+	eip, err := getSvcExternalIP("testapp", path)
 	if err != nil {
 		t.Errorf("error %v", err)
 		return


### PR DESCRIPTION
as requested this test is disabled if aks instance does not exist.