### PR TITLE
edgecloud-268 kubernetes is checking preflight conditions very harshl…

### DIFF
--- a/cloud-resource-manager/crmutil/mexos.go
+++ b/cloud-resource-manager/crmutil/mexos.go
@@ -920,8 +920,17 @@ func RunMEXOSAgentService(mf *Manifest, rootLB *MEXRootLB) error {
 	if err != nil {
 		return err
 	}
+	out, err := client.Output("systemctl stop mexosagent.service")
+	if err != nil {
+		log.InfoLog("warning: cannot stop mexosagent.service", "out", out, "err", err)
+	}
+	out, err = client.Output("systemctl disable mexosagent.service")
+	if err != nil {
+		log.InfoLog("warning: cannot disable mexosagent.service", "out", out, "err", err)
+	}
+	log.DebugLog(log.DebugLevelMexos, "stopped mexosagent service")
 	cmd := fmt.Sprintf("scp -o StrictHostKeyChecking=no -i %s bob@registry.mobiledgex.net:files-repo/mobiledgex/mexosagent /usr/local/bin/", mexEnv["MEX_SSH_KEY"])
-	out, err := client.Output(cmd)
+	out, err = client.Output(cmd)
 	if err != nil {
 		log.InfoLog("error: cannot download mexosagent from registry", "error", err, "out", out)
 		return err


### PR DESCRIPTION
…y against docker version. this seems to be a new behavior. all k8s cluster creations failed.  to fix this the base mobiledgex-16.04.2 images were fixed to ignore the preflight errors. in addition, another new error happened after image was updated on bonn, berlin and hamburg. the mexosagent no longer runs as docker container instance since the LB work for L4. the services have to be stopped and started again. this fixes that. after this fix things should be back to normal