### PR TITLE
remove auth key from appinst structure of DME.  

### DIFF
--- a/d-match-engine/dme-server/match-engine.go
+++ b/d-match-engine/dme-server/match-engine.go
@@ -24,8 +24,7 @@ type dmeAppInst struct {
 	location dme.Loc
 	id       uint64
 	// Ports and L7 Paths
-	ports         []dme.AppPort
-	authPublicKey string
+	ports []dme.AppPort
 }
 
 type dmeAppInsts struct {
@@ -107,7 +106,6 @@ func addApp(appInst *edgeproto.AppInst) {
 		cNew.location = appInst.CloudletLoc
 		cNew.id = appInst.Key.Id
 		cNew.ports = appInst.MappedPorts
-		cNew.authPublicKey = appInst.AuthPublicKey
 		app.carriers[carrierName].insts[cNew.cloudletKey] = cNew
 		log.DebugLog(log.DebugLevelDmedb, "Adding app inst",
 			"appName", app.appKey.Name,


### PR DESCRIPTION
authPublicKey is not needed in the dmeAppInsts struct and is a waste of memory.  The key is only needed in the dmeApp.