### PR TITLE
fix ansible start playbook for location api simulator in docker

### DIFF
--- a/d-match-engine/dme-server/dme-location.go
+++ b/d-match-engine/dme-server/dme-location.go
@@ -29,6 +29,7 @@ func VerifyClientLoc(mreq *dme.VerifyLocationRequest, mreply *dme.VerifyLocation
 		"appName", key.Name,
 		"appVersion", key.Version,
 		"devName", key.DeveloperKey.Name,
+		"VerifyLocToken", mreq.VerifyLocToken,
 		"GpsLocation", mreq.GpsLocation)
 
 	if mreq.GpsLocation == nil || (mreq.GpsLocation.Lat == 0 && mreq.GpsLocation.Long == 0) {

--- a/setup-env/ansible/playbooks/mex_start.yml
+++ b/setup-env/ansible/playbooks/mex_start.yml
@@ -184,7 +184,7 @@
        pull: yes
        image: "{{ item.dockerimage }}"
        name: "{{ item.locapisimlocal.name }}"
-       command: "loc-api-sim --port {{ item.locapisimlocal.port }} --file {{ locsim_remote_data_file }}  --geofile {{ item.locapisimlocal.geofile }} --country {{ item.locapisimlocal.country }}"
+       command: "loc-api-sim --port {{ item.locapisimlocal.port }} --file {{ locsim_remote_data_file }}  --geo {{ locsim_remote_data_dir }}/geocode.dat --country {{ item.locapisimlocal.country }}"
        network_mode: host
        volumes:
          - /var/tmp:/var/tmp
@@ -255,6 +255,7 @@
        name: "{{ item.sampleapplocal.name }}"
        entrypoint: "{{ item.command }}" 
        network_mode: host
+       restart_policy: unless-stopped
        volumes: "{{ item.volumemounts }}"
     when: item.hostname == inventory_hostname and item.dockerimage != "" and item.command != ""
     with_items:
@@ -266,6 +267,7 @@
        image: "{{ item.dockerimage }}"
        name: "{{ item.sampleapplocal.name }}"
        network_mode: host
+       restart_policy: unless-stopped
        volumes: "{{ item.volumemounts }}"
     when: item.hostname == inventory_hostname and item.dockerimage != "" and item.command == ""
     with_items:


### PR DESCRIPTION
Fix problem with location simulator docker deployment in ansible playbook in that it was not picking up the right geo database file. Also add log for token in Verify location dme call.