### PR TITLE
EDGECLOUD-274 EDGECLOUD-251 EDGECLOUD-248 EDGECLOUD-242 EDGECLOUD-240

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,16 @@ test-debug:
 test-python:
 	bash ./setup-env/e2e-tests/python/tools/run_all_tests.sh
 
+# start/restart local processes to run individual python or other tests against
+test-start:
+	e2e-tests -testfile ./setup-env/e2e-tests/testfiles/deploy_start_create.yml -setupfile ./setup-env/e2e-tests/setups/local_multi.yml -stop -notimestamp
+
+# restart process, clean data
+test-reset:
+	e2e-tests -testfile ./setup-env/e2e-tests/testfiles/deploy_reset_create.yml -setupfile ./setup-env/e2e-tests/setups/local_multi.yml -stop -notimestamp
+
+test-stop:
+	e2e-tests -testfile ./setup-env/e2e-tests/testfiles/stop_cleanup.yml -setupfile ./setup-env/e2e-tests/setups/local_multi.yml -stop -notimestamp
+
 clean:
 	go clean ./...

--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -266,29 +266,29 @@ func (s *AppApi) ShowApp(in *edgeproto.App, cb edgeproto.AppApi_ShowAppServer) e
 // GetClusterFlavorForFlavor finds the smallest cluster flavor whose
 // node flavor matches the passed in flavor.
 func GetClusterFlavorForFlavor(flavorKey *edgeproto.FlavorKey) (*edgeproto.ClusterFlavorKey, error) {
-	matchingFlavors := make([]*edgeproto.ClusterFlavor, 0)
+	matching := make([]*edgeproto.ClusterFlavor, 0)
 
 	clusterFlavorApi.cache.Mux.Lock()
 	defer clusterFlavorApi.cache.Mux.Unlock()
 	for _, val := range clusterFlavorApi.cache.Objs {
 		if val.NodeFlavor.Matches(flavorKey) {
-			matchingFlavors = append(matchingFlavors, val)
+			matching = append(matching, val)
 		}
 	}
-	if len(matchingFlavors) == 0 {
-		return nil, fmt.Errorf("No cluster flavors matching flavor %s found", flavorKey.Name)
+	if len(matching) == 0 {
+		return nil, fmt.Errorf("No cluster flavors with node flavor %s found", flavorKey.Name)
 	}
-	sort.Slice(matchingFlavors, func(i, j int) bool {
-		if matchingFlavors[i].MaxNodes < matchingFlavors[j].MaxNodes {
-			return true
+	sort.Slice(matching, func(i, j int) bool {
+		if matching[i].MaxNodes != matching[j].MaxNodes {
+			return matching[i].MaxNodes < matching[j].MaxNodes
 		}
-		if matchingFlavors[i].NumNodes < matchingFlavors[j].NumNodes {
-			return true
+		if matching[i].NumNodes != matching[j].NumNodes {
+			return matching[i].NumNodes < matching[j].NumNodes
 		}
-		if matchingFlavors[i].NumMasters < matchingFlavors[j].NumMasters {
-			return true
+		if matching[i].NumMasters != matching[j].NumMasters {
+			return matching[i].NumMasters < matching[j].NumMasters
 		}
-		return false
+		return matching[i].Key.Name < matching[j].Key.Name
 	})
-	return &matchingFlavors[0].Key, nil
+	return &matching[0].Key, nil
 }

--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -66,6 +66,10 @@ func (s *CloudletApi) CreateCloudlet(in *edgeproto.Cloudlet, cb edgeproto.Cloudl
 			return errors.New("Must specify at least one dynamic public IP available")
 		}
 	}
+	if in.Location.Lat == 0 && in.Location.Long == 0 {
+		// user forgot to specify location
+		return errors.New("location is missing; 0,0 is not a valid location")
+	}
 	_, err := s.store.Create(in, s.sync.syncWait)
 	return err
 }

--- a/controller/cluster_api.go
+++ b/controller/cluster_api.go
@@ -17,7 +17,7 @@ type ClusterApi struct {
 
 var clusterApi = ClusterApi{}
 
-const ClusterAutoPrefix = "AutoCluster"
+const ClusterAutoPrefix = "autocluster"
 
 var ClusterAutoPrefixErr = fmt.Sprintf("Cluster name prefix \"%s\" is reserved",
 	ClusterAutoPrefix)
@@ -51,6 +51,9 @@ func (s *ClusterApi) Get(key *edgeproto.ClusterKey, buf *edgeproto.Cluster) bool
 func (s *ClusterApi) CreateCluster(ctx context.Context, in *edgeproto.Cluster) (*edgeproto.Result, error) {
 	if strings.HasPrefix(in.Key.Name, ClusterAutoPrefix) {
 		return &edgeproto.Result{}, errors.New(ClusterAutoPrefixErr)
+	}
+	if in.DefaultFlavor.Name != "" && !clusterFlavorApi.HasClusterFlavor(&in.DefaultFlavor) {
+		return &edgeproto.Result{}, fmt.Errorf("default flavor %s not found", in.DefaultFlavor.Name)
 	}
 	in.Auto = false
 	return s.store.Create(in, s.sync.syncWait)

--- a/controller/cluster_api_test.go
+++ b/controller/cluster_api_test.go
@@ -20,6 +20,10 @@ func TestClusterApi(t *testing.T) {
 	sync.Start()
 	defer sync.Done()
 
+	// create support data
+	testutil.InternalFlavorCreate(t, &flavorApi, testutil.FlavorData)
+	testutil.InternalClusterFlavorCreate(t, &clusterFlavorApi, testutil.ClusterFlavorData)
+
 	testutil.InternalClusterTest(t, "cud", &clusterApi, testutil.ClusterData)
 
 	dummy.Stop()

--- a/controller/developer_api.go
+++ b/controller/developer_api.go
@@ -22,10 +22,6 @@ func InitDeveloperApi(sync *Sync) {
 	sync.RegisterCache(&developerApi.cache)
 }
 
-func (s *DeveloperApi) HasDeveloper(key *edgeproto.DeveloperKey) bool {
-	return s.cache.HasKey(key)
-}
-
 func (s *DeveloperApi) CreateDeveloper(ctx context.Context, in *edgeproto.Developer) (*edgeproto.Result, error) {
 	return s.store.Create(in, s.sync.syncWait)
 }

--- a/setup-env/e2e-tests/data/appdata_default_appinst_withdeps.yml
+++ b/setup-env/e2e-tests/data/appdata_default_appinst_withdeps.yml
@@ -15,13 +15,22 @@ flavors:
   vcpus: 4
   disk: 4
 
+clusterflavors:
+- key:
+    name: c1.small
+  nodeflavor:
+    name: x1.small
+  masterflavor:
+    name: x1.small
+  numnodes: 3
+  maxnodes: 3
+  nummasters: 1
 
 clusters:
 - key:
     name: SmallCluster
   defaultflavor:
     name: c1.small
-
 
 developers:
 - key:

--- a/setup-env/e2e-tests/testfiles/deploy_reset_create.yml
+++ b/setup-env/e2e-tests/testfiles/deploy_reset_create.yml
@@ -1,0 +1,7 @@
+##
+##
+description: Stops and cleans up any existing process data, restarts processes
+
+tests:
+ - includefile: stop_cleanup.yml
+ - includefile: deploy_start_create.yml

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/util"
 )
@@ -237,6 +238,10 @@ var CloudletData = []edgeproto.Cloudlet{
 		AccessUri:     "10.100.0.1",
 		IpSupport:     edgeproto.IpSupport_IpSupportDynamic,
 		NumDynamicIps: 100,
+		Location: dme.Loc{
+			Lat:  37.338207,
+			Long: -121.886330,
+		},
 	},
 	edgeproto.Cloudlet{
 		Key: edgeproto.CloudletKey{
@@ -246,6 +251,10 @@ var CloudletData = []edgeproto.Cloudlet{
 		AccessUri:     "ff.f8::1",
 		IpSupport:     edgeproto.IpSupport_IpSupportDynamic,
 		NumDynamicIps: 100,
+		Location: dme.Loc{
+			Lat:  40.712776,
+			Long: -74.005974,
+		},
 	},
 	edgeproto.Cloudlet{
 		Key: edgeproto.CloudletKey{
@@ -255,6 +264,10 @@ var CloudletData = []edgeproto.Cloudlet{
 		AccessUri:     "172.24.0.1",
 		IpSupport:     edgeproto.IpSupport_IpSupportDynamic,
 		NumDynamicIps: 100,
+		Location: dme.Loc{
+			Lat:  37.774929,
+			Long: -122.419418,
+		},
 	},
 	edgeproto.Cloudlet{
 		Key: edgeproto.CloudletKey{
@@ -264,6 +277,10 @@ var CloudletData = []edgeproto.Cloudlet{
 		AccessUri:     "hi76.verizon.com",
 		IpSupport:     edgeproto.IpSupport_IpSupportDynamic,
 		NumDynamicIps: 10,
+		Location: dme.Loc{
+			Lat:  21.306944,
+			Long: -157.858337,
+		},
 	},
 }
 var ClusterInstData = []edgeproto.ClusterInst{


### PR DESCRIPTION
This addresses a bunch of bug fixes:
274: Unfortunately there is no way to distinguish between user not specifying a location on CreateCloudlet vs specifying 0,0, so I assume 0,0 means user forgot to specify a location (0,0 ends up in the middle of an ocean).
251: check that default-flavor exists if specified during CreateCluster
248: remove unreachable code
242: see bug for details, rather than change the behavior I've added more messages to clarify behavior.
240: fix cluster flavor sorting algorithm