### PR TITLE
EDGECLOUD-283 allocate external port same as internal port if possible

### DIFF
--- a/edgeproto/doc/README.md
+++ b/edgeproto/doc/README.md
@@ -1,5 +1,5 @@
 # Protocol Documentation
-<a name="top"></a>
+<a name="top"/>
 
 ## Table of Contents
 
@@ -179,14 +179,14 @@
 
 
 
-<a name="app.proto"></a>
+<a name="app.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## app.proto
 
 
 
-<a name="edgeproto.App"></a>
+<a name="edgeproto.App"/>
 
 ### App
 Apps are applications that may be instantiated on Cloudlets, providing a back-end service to an application client (using the mobiledgex SDK) running on a user device such as a cell phone, wearable, drone, etc. Applications belong to Developers, and must specify their image and accessibility. Applications are analagous to Pods in Kubernetes, and similarly are tied to a Cluster.
@@ -218,7 +218,7 @@ An application in itself is not tied to a Cloudlet, but provides a definition th
 
 
 
-<a name="edgeproto.AppKey"></a>
+<a name="edgeproto.AppKey"/>
 
 ### AppKey
 AppKey uniquely identifies an Application.
@@ -237,7 +237,7 @@ AppKey uniquely identifies an Application.
  
 
 
-<a name="edgeproto.ImageType"></a>
+<a name="edgeproto.ImageType"/>
 
 ### ImageType
 ImageType specifies the image type of the application.
@@ -254,30 +254,30 @@ ImageType specifies the image type of the application.
  
 
 
-<a name="edgeproto.AppApi"></a>
+<a name="edgeproto.AppApi"/>
 
 ### AppApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateApp | [App](#edgeproto.App) | [Result](#edgeproto.Result) | Create an application |
-| DeleteApp | [App](#edgeproto.App) | [Result](#edgeproto.Result) | Delete an application |
-| UpdateApp | [App](#edgeproto.App) | [Result](#edgeproto.Result) | Update an application |
-| ShowApp | [App](#edgeproto.App) | [App](#edgeproto.App) stream | Show applications. Any fields specified will be used to filter results. |
+| CreateApp | [App](#edgeproto.App) | [Result](#edgeproto.App) | Create an application |
+| DeleteApp | [App](#edgeproto.App) | [Result](#edgeproto.App) | Delete an application |
+| UpdateApp | [App](#edgeproto.App) | [Result](#edgeproto.App) | Update an application |
+| ShowApp | [App](#edgeproto.App) | [App](#edgeproto.App) | Show applications. Any fields specified will be used to filter results. |
 
  
 
 
 
-<a name="app_inst.proto"></a>
+<a name="app_inst.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## app_inst.proto
 
 
 
-<a name="edgeproto.AppInst"></a>
+<a name="edgeproto.AppInst"/>
 
 ### AppInst
 AppInst is an instance of an App (application) on a Cloudlet. It is defined by an App plus a Cloudlet key. This separation of the definition of the App versus its instantiation is unique to Mobiledgex, and allows the Developer to provide the App defintion, while either the Developer may statically define the instances, or the Mobiledgex platform may dynamically create and destroy instances in response to demand.
@@ -306,7 +306,7 @@ Many of the fields here are inherited from the App definition. Some are derived,
 
 
 
-<a name="edgeproto.AppInstInfo"></a>
+<a name="edgeproto.AppInstInfo"/>
 
 ### AppInstInfo
 AppInstInfo provides information from the Cloudlet Resource Manager about the state of the AppInst on the Cloudlet. Whereas the AppInst defines the intent of instantiating an App on a Cloudlet, the AppInstInfo defines the current state of trying to apply that intent on the physical resources of the Cloudlet.
@@ -325,7 +325,7 @@ AppInstInfo provides information from the Cloudlet Resource Manager about the st
 
 
 
-<a name="edgeproto.AppInstKey"></a>
+<a name="edgeproto.AppInstKey"/>
 
 ### AppInstKey
 AppInstKey uniquely identifies an Application Instance (AppInst) or Application Instance state (AppInstInfo).
@@ -342,7 +342,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.AppInstMetrics"></a>
+<a name="edgeproto.AppInstMetrics"/>
 
 ### AppInstMetrics
 (TODO) AppInstMetrics provide metrics collected about the application instance on the Cloudlet. They are sent to a metrics collector for analytics. They are not stored in the persistent distributed database, but are stored as a time series in some other database or files.
@@ -363,50 +363,50 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
  
 
 
-<a name="edgeproto.AppInstApi"></a>
+<a name="edgeproto.AppInstApi"/>
 
 ### AppInstApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.Result) stream | Create an application instance |
-| DeleteAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.Result) stream | Delete an application instance |
-| UpdateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.Result) stream | Update an application instance |
-| ShowAppInst | [AppInst](#edgeproto.AppInst) | [AppInst](#edgeproto.AppInst) stream | Show application instances. Any fields specified will be used to filter results. |
+| CreateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.AppInst) | Create an application instance |
+| DeleteAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.AppInst) | Delete an application instance |
+| UpdateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.AppInst) | Update an application instance |
+| ShowAppInst | [AppInst](#edgeproto.AppInst) | [AppInst](#edgeproto.AppInst) | Show application instances. Any fields specified will be used to filter results. |
 
 
-<a name="edgeproto.AppInstInfoApi"></a>
+<a name="edgeproto.AppInstInfoApi"/>
 
 ### AppInstInfoApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowAppInstInfo | [AppInstInfo](#edgeproto.AppInstInfo) | [AppInstInfo](#edgeproto.AppInstInfo) stream | Show application instances state. |
+| ShowAppInstInfo | [AppInstInfo](#edgeproto.AppInstInfo) | [AppInstInfo](#edgeproto.AppInstInfo) | Show application instances state. |
 
 
-<a name="edgeproto.AppInstMetricsApi"></a>
+<a name="edgeproto.AppInstMetricsApi"/>
 
 ### AppInstMetricsApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowAppInstMetrics | [AppInstMetrics](#edgeproto.AppInstMetrics) | [AppInstMetrics](#edgeproto.AppInstMetrics) stream | Show application instance metrics. |
+| ShowAppInstMetrics | [AppInstMetrics](#edgeproto.AppInstMetrics) | [AppInstMetrics](#edgeproto.AppInstMetrics) | Show application instance metrics. |
 
  
 
 
 
-<a name="cloud-resource-manager.proto"></a>
+<a name="cloud-resource-manager.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## cloud-resource-manager.proto
 
 
 
-<a name="edgeproto.CloudResource"></a>
+<a name="edgeproto.CloudResource"/>
 
 ### CloudResource
 
@@ -426,7 +426,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.EdgeCloudApp"></a>
+<a name="edgeproto.EdgeCloudApp"/>
 
 ### EdgeCloudApp
 
@@ -454,7 +454,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.EdgeCloudApplication"></a>
+<a name="edgeproto.EdgeCloudApplication"/>
 
 ### EdgeCloudApplication
 
@@ -473,7 +473,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
  
 
 
-<a name="edgeproto.CloudResourceCategory"></a>
+<a name="edgeproto.CloudResourceCategory"/>
 
 ### CloudResourceCategory
 
@@ -501,31 +501,31 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
  
 
 
-<a name="edgeproto.CloudResourceManager"></a>
+<a name="edgeproto.CloudResourceManager"/>
 
 ### CloudResourceManager
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListCloudResource | [CloudResource](#edgeproto.CloudResource) | [CloudResource](#edgeproto.CloudResource) stream |  |
-| AddCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.Result) |  |
-| DeleteCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.Result) |  |
-| DeployApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.Result) |  |
-| DeleteApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.Result) |  |
+| ListCloudResource | [CloudResource](#edgeproto.CloudResource) | [CloudResource](#edgeproto.CloudResource) |  |
+| AddCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.CloudResource) |  |
+| DeleteCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.CloudResource) |  |
+| DeployApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.EdgeCloudApplication) |  |
+| DeleteApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.EdgeCloudApplication) |  |
 
  
 
 
 
-<a name="cloudlet.proto"></a>
+<a name="cloudlet.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## cloudlet.proto
 
 
 
-<a name="edgeproto.Cloudlet"></a>
+<a name="edgeproto.Cloudlet"/>
 
 ### Cloudlet
 A Cloudlet is a set of compute resources at a particular location, typically an Operator&#39;s regional data center, or a cell tower. The Cloudlet is managed by a Cloudlet Resource Manager, which communicates with the Mobiledgex Controller and allows AppInsts (application instances) to be instantiated on the Cloudlet.
@@ -549,7 +549,7 @@ Certs for accessing cloudlet site |
 
 
 
-<a name="edgeproto.CloudletInfo"></a>
+<a name="edgeproto.CloudletInfo"/>
 
 ### CloudletInfo
 CloudletInfo provides information from the Cloudlet Resource Manager about the state of the Cloudlet.
@@ -572,7 +572,7 @@ CloudletInfo provides information from the Cloudlet Resource Manager about the s
 
 
 
-<a name="edgeproto.CloudletKey"></a>
+<a name="edgeproto.CloudletKey"/>
 
 ### CloudletKey
 CloudletKey uniquely identifies a Cloudlet.
@@ -588,7 +588,7 @@ CloudletKey uniquely identifies a Cloudlet.
 
 
 
-<a name="edgeproto.CloudletMetrics"></a>
+<a name="edgeproto.CloudletMetrics"/>
 
 ### CloudletMetrics
 (TODO) CloudletMetrics provide metrics collected about the Cloudlet. They are sent to a metrics collector for analytics. They are not stored in the persistent distributed database, but are stored as a time series in some other database or files.
@@ -605,7 +605,7 @@ CloudletKey uniquely identifies a Cloudlet.
  
 
 
-<a name="edgeproto.CloudletState"></a>
+<a name="edgeproto.CloudletState"/>
 
 ### CloudletState
 CloudletState is the state of the Cloudlet.
@@ -624,52 +624,52 @@ CloudletState is the state of the Cloudlet.
  
 
 
-<a name="edgeproto.CloudletApi"></a>
+<a name="edgeproto.CloudletApi"/>
 
 ### CloudletApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Result) stream | Create a Cloudlet |
-| DeleteCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Result) stream | Delete a Cloudlet |
-| UpdateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Result) stream | Update a Cloudlet |
-| ShowCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Cloudlet](#edgeproto.Cloudlet) stream | Show Cloudlets |
+| CreateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Cloudlet) | Create a Cloudlet |
+| DeleteCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Cloudlet) | Delete a Cloudlet |
+| UpdateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Cloudlet) | Update a Cloudlet |
+| ShowCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Cloudlet](#edgeproto.Cloudlet) | Show Cloudlets |
 
 
-<a name="edgeproto.CloudletInfoApi"></a>
+<a name="edgeproto.CloudletInfoApi"/>
 
 ### CloudletInfoApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [CloudletInfo](#edgeproto.CloudletInfo) stream | Show CloudletInfos |
-| InjectCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.Result) | Inject (create) a CloudletInfo for regression testing |
-| EvictCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.Result) | Evict (delete) a CloudletInfo for regression testing |
+| ShowCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [CloudletInfo](#edgeproto.CloudletInfo) | Show CloudletInfos |
+| InjectCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.CloudletInfo) | Inject (create) a CloudletInfo for regression testing |
+| EvictCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.CloudletInfo) | Evict (delete) a CloudletInfo for regression testing |
 
 
-<a name="edgeproto.CloudletMetricsApi"></a>
+<a name="edgeproto.CloudletMetricsApi"/>
 
 ### CloudletMetricsApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowCloudletMetrics | [CloudletMetrics](#edgeproto.CloudletMetrics) | [CloudletMetrics](#edgeproto.CloudletMetrics) stream | Show Cloudlet metrics |
+| ShowCloudletMetrics | [CloudletMetrics](#edgeproto.CloudletMetrics) | [CloudletMetrics](#edgeproto.CloudletMetrics) | Show Cloudlet metrics |
 
  
 
 
 
-<a name="cluster.proto"></a>
+<a name="cluster.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## cluster.proto
 
 
 
-<a name="edgeproto.Cluster"></a>
+<a name="edgeproto.Cluster"/>
 
 ### Cluster
 Clusters define a set of resources that are provided to one or more Apps tied to the cluster. The set of resources is defined by the Cluster flavor. The Cluster definition here is analogous to a Kubernetes cluster.
@@ -689,7 +689,7 @@ In comparison to ClusterFlavors which are fairly static and controller by admini
 
 
 
-<a name="edgeproto.ClusterKey"></a>
+<a name="edgeproto.ClusterKey"/>
 
 ### ClusterKey
 ClusterKey uniquely identifies a Cluster.
@@ -710,30 +710,30 @@ ClusterKey uniquely identifies a Cluster.
  
 
 
-<a name="edgeproto.ClusterApi"></a>
+<a name="edgeproto.ClusterApi"/>
 
 ### ClusterApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Result) | Create a Cluster |
-| DeleteCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Result) | Delete a Cluster |
-| UpdateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Result) | Update a Cluster |
-| ShowCluster | [Cluster](#edgeproto.Cluster) | [Cluster](#edgeproto.Cluster) stream | Show Clusters |
+| CreateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Cluster) | Create a Cluster |
+| DeleteCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Cluster) | Delete a Cluster |
+| UpdateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Cluster) | Update a Cluster |
+| ShowCluster | [Cluster](#edgeproto.Cluster) | [Cluster](#edgeproto.Cluster) | Show Clusters |
 
  
 
 
 
-<a name="clusterflavor.proto"></a>
+<a name="clusterflavor.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## clusterflavor.proto
 
 
 
-<a name="edgeproto.ClusterFlavor"></a>
+<a name="edgeproto.ClusterFlavor"/>
 
 ### ClusterFlavor
 ClusterFlavor defines a set of resources for a Cluster. ClusterFlavors should be fairly static objects that are almost never changed, and are only modified by Mobiledgex administrators.
@@ -754,7 +754,7 @@ ClusterFlavor defines a set of resources for a Cluster. ClusterFlavors should be
 
 
 
-<a name="edgeproto.ClusterFlavorKey"></a>
+<a name="edgeproto.ClusterFlavorKey"/>
 
 ### ClusterFlavorKey
 ClusterFlavorKey uniquely identifies a Cluster Flavor.
@@ -775,30 +775,30 @@ ClusterFlavorKey uniquely identifies a Cluster Flavor.
  
 
 
-<a name="edgeproto.ClusterFlavorApi"></a>
+<a name="edgeproto.ClusterFlavorApi"/>
 
 ### ClusterFlavorApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.Result) | Create a ClusterFlavor |
-| DeleteClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.Result) | Delete a ClusterFlavor |
-| UpdateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.Result) | Update a ClusterFlavor |
-| ShowClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [ClusterFlavor](#edgeproto.ClusterFlavor) stream | Show ClusterFlavors |
+| CreateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.ClusterFlavor) | Create a ClusterFlavor |
+| DeleteClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.ClusterFlavor) | Delete a ClusterFlavor |
+| UpdateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.ClusterFlavor) | Update a ClusterFlavor |
+| ShowClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [ClusterFlavor](#edgeproto.ClusterFlavor) | Show ClusterFlavors |
 
  
 
 
 
-<a name="clusterinst.proto"></a>
+<a name="clusterinst.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## clusterinst.proto
 
 
 
-<a name="edgeproto.ClusterInst"></a>
+<a name="edgeproto.ClusterInst"/>
 
 ### ClusterInst
 ClusterInst is an instance of a Cluster on a Cloudlet. It is defined by a Cluster plus a Cloudlet key. This separation of the definition of the Cluster versus its instance is unique to Mobiledgex, and allows the Developer to provide the Cluster definition, while either the Developer may statically define the instances, or the Mobiledgex platform may dynamically create and destroy instances in response to demand.
@@ -821,7 +821,7 @@ When a Cluster is instantiated on a Cloudlet, the user may override the default 
 
 
 
-<a name="edgeproto.ClusterInstInfo"></a>
+<a name="edgeproto.ClusterInstInfo"/>
 
 ### ClusterInstInfo
 ClusterInstInfo provides information from the Cloudlet Resource Manager about the state of the ClusterInst on the Cloudlet. Whereas the ClusterInst defines the intent of instantiating a Cluster on a Cloudlet, the ClusterInstInfo defines the current state of trying to apply that intent on the physical resources of the Cloudlet.
@@ -840,7 +840,7 @@ ClusterInstInfo provides information from the Cloudlet Resource Manager about th
 
 
 
-<a name="edgeproto.ClusterInstKey"></a>
+<a name="edgeproto.ClusterInstKey"/>
 
 ### ClusterInstKey
 ClusterInstKey uniquely identifies a Cluster Instance (ClusterInst) or Cluster Instance state (ClusterInstInfo).
@@ -862,33 +862,33 @@ ClusterInstKey uniquely identifies a Cluster Instance (ClusterInst) or Cluster I
  
 
 
-<a name="edgeproto.ClusterInstApi"></a>
+<a name="edgeproto.ClusterInstApi"/>
 
 ### ClusterInstApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.Result) stream | Create a Cluster instance |
-| DeleteClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.Result) stream | Delete a Cluster instance |
-| UpdateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.Result) stream | Update a Cluster instance |
-| ShowClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [ClusterInst](#edgeproto.ClusterInst) stream | Show Cluster instances |
+| CreateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.ClusterInst) | Create a Cluster instance |
+| DeleteClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.ClusterInst) | Delete a Cluster instance |
+| UpdateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.ClusterInst) | Update a Cluster instance |
+| ShowClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [ClusterInst](#edgeproto.ClusterInst) | Show Cluster instances |
 
 
-<a name="edgeproto.ClusterInstInfoApi"></a>
+<a name="edgeproto.ClusterInstInfoApi"/>
 
 ### ClusterInstInfoApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowClusterInstInfo | [ClusterInstInfo](#edgeproto.ClusterInstInfo) | [ClusterInstInfo](#edgeproto.ClusterInstInfo) stream | Show Cluster instances state. |
+| ShowClusterInstInfo | [ClusterInstInfo](#edgeproto.ClusterInstInfo) | [ClusterInstInfo](#edgeproto.ClusterInstInfo) | Show Cluster instances state. |
 
  
 
 
 
-<a name="common.proto"></a>
+<a name="common.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## common.proto
@@ -897,7 +897,7 @@ ClusterInstKey uniquely identifies a Cluster Instance (ClusterInst) or Cluster I
  
 
 
-<a name="edgeproto.CRMOverride"></a>
+<a name="edgeproto.CRMOverride"/>
 
 ### CRMOverride
 CRMOverride can be applied to commands that issue requests to the CRM.
@@ -916,7 +916,7 @@ Controller to ignore errors from the CRM, or ignore the CRM completely
 
 
 
-<a name="edgeproto.IpAccess"></a>
+<a name="edgeproto.IpAccess"/>
 
 ### IpAccess
 
@@ -930,7 +930,7 @@ Controller to ignore errors from the CRM, or ignore the CRM completely
 
 
 
-<a name="edgeproto.IpSupport"></a>
+<a name="edgeproto.IpSupport"/>
 
 ### IpSupport
 IpSupport indicates the type of public IP support provided by the Cloudlet. Static IP support indicates a set of static public IPs are available for use, and managed by the Controller. Dynamic indicates the Cloudlet uses a DHCP server to provide public IP addresses, and the controller has no control over which IPs are assigned.
@@ -943,7 +943,7 @@ IpSupport indicates the type of public IP support provided by the Cloudlet. Stat
 
 
 
-<a name="edgeproto.Liveness"></a>
+<a name="edgeproto.Liveness"/>
 
 ### Liveness
 Liveness indicates if an object was created statically via an external API call, or dynamically via an internal algorithm.
@@ -956,7 +956,7 @@ Liveness indicates if an object was created statically via an external API call,
 
 
 
-<a name="edgeproto.TrackedState"></a>
+<a name="edgeproto.TrackedState"/>
 
 ### TrackedState
 TrackedState is used to track the state of an object on a remote node,
@@ -986,14 +986,14 @@ i.e. track the state of a ClusterInst object on the CRM (Cloudlet).
 
 
 
-<a name="controller.proto"></a>
+<a name="controller.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## controller.proto
 
 
 
-<a name="edgeproto.Controller"></a>
+<a name="edgeproto.Controller"/>
 
 ### Controller
 A Controller is a service that manages the edge-cloud data and controls other edge-cloud micro-services.
@@ -1009,7 +1009,7 @@ A Controller is a service that manages the edge-cloud data and controls other ed
 
 
 
-<a name="edgeproto.ControllerKey"></a>
+<a name="edgeproto.ControllerKey"/>
 
 ### ControllerKey
 ControllerKey uniquely defines a Controller
@@ -1030,27 +1030,27 @@ ControllerKey uniquely defines a Controller
  
 
 
-<a name="edgeproto.ControllerApi"></a>
+<a name="edgeproto.ControllerApi"/>
 
 ### ControllerApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowController | [Controller](#edgeproto.Controller) | [Controller](#edgeproto.Controller) stream | Show Controllers |
+| ShowController | [Controller](#edgeproto.Controller) | [Controller](#edgeproto.Controller) | Show Controllers |
 
  
 
 
 
-<a name="developer.proto"></a>
+<a name="developer.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## developer.proto
 
 
 
-<a name="edgeproto.Developer"></a>
+<a name="edgeproto.Developer"/>
 
 ### Developer
 A Developer defines a Mobiledgex customer that can create and manage applications, clusters, instances, etc. Applications and other objects created by one Developer cannot be seen or managed by other Developers. Billing will likely be done on a per-developer basis.
@@ -1072,7 +1072,7 @@ TODO: user management, auth, etc is not implemented yet.
 
 
 
-<a name="edgeproto.DeveloperKey"></a>
+<a name="edgeproto.DeveloperKey"/>
 
 ### DeveloperKey
 DeveloperKey uniquely identifies a Developer (Mobiledgex customer)
@@ -1093,30 +1093,30 @@ DeveloperKey uniquely identifies a Developer (Mobiledgex customer)
  
 
 
-<a name="edgeproto.DeveloperApi"></a>
+<a name="edgeproto.DeveloperApi"/>
 
 ### DeveloperApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Result) | Create a Developer |
-| DeleteDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Result) | Delete a Developer |
-| UpdateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Result) | Update a Developer |
-| ShowDeveloper | [Developer](#edgeproto.Developer) | [Developer](#edgeproto.Developer) stream | Show Developers |
+| CreateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Developer) | Create a Developer |
+| DeleteDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Developer) | Delete a Developer |
+| UpdateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Developer) | Update a Developer |
+| ShowDeveloper | [Developer](#edgeproto.Developer) | [Developer](#edgeproto.Developer) | Show Developers |
 
  
 
 
 
-<a name="flavor.proto"></a>
+<a name="flavor.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## flavor.proto
 
 
 
-<a name="edgeproto.Flavor"></a>
+<a name="edgeproto.Flavor"/>
 
 ### Flavor
 A Flavor identifies the Cpu, Ram, and Disk resources required for either a node in a Cluster, or an application instance. For a node in a cluster, these are the physical resources provided by that node. For an application instance, this defines the resources (per node) that should be allocated to the instance from the Cluster.
@@ -1135,7 +1135,7 @@ A Flavor identifies the Cpu, Ram, and Disk resources required for either a node 
 
 
 
-<a name="edgeproto.FlavorKey"></a>
+<a name="edgeproto.FlavorKey"/>
 
 ### FlavorKey
 FlavorKey uniquely identifies a Flavor.
@@ -1156,30 +1156,30 @@ FlavorKey uniquely identifies a Flavor.
  
 
 
-<a name="edgeproto.FlavorApi"></a>
+<a name="edgeproto.FlavorApi"/>
 
 ### FlavorApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Result) | Create a Flavor |
-| DeleteFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Result) | Delete a Flavor |
-| UpdateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Result) | Update a Flavor |
-| ShowFlavor | [Flavor](#edgeproto.Flavor) | [Flavor](#edgeproto.Flavor) stream | Show Flavors |
+| CreateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Flavor) | Create a Flavor |
+| DeleteFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Flavor) | Delete a Flavor |
+| UpdateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Flavor) | Update a Flavor |
+| ShowFlavor | [Flavor](#edgeproto.Flavor) | [Flavor](#edgeproto.Flavor) | Show Flavors |
 
  
 
 
 
-<a name="metric.proto"></a>
+<a name="metric.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## metric.proto
 
 
 
-<a name="edgeproto.Metric"></a>
+<a name="edgeproto.Metric"/>
 
 ### Metric
 Metric is an entry/point in a time series of values for Analytics/Billing.
@@ -1197,7 +1197,7 @@ Metric is an entry/point in a time series of values for Analytics/Billing.
 
 
 
-<a name="edgeproto.MetricTag"></a>
+<a name="edgeproto.MetricTag"/>
 
 ### MetricTag
 MetricTag is used as a tag or label to look up the metric, beyond just the name of the metric.
@@ -1213,7 +1213,7 @@ MetricTag is used as a tag or label to look up the metric, beyond just the name 
 
 
 
-<a name="edgeproto.MetricVal"></a>
+<a name="edgeproto.MetricVal"/>
 
 ### MetricVal
 MetricVal is a value associated with the metric.
@@ -1239,14 +1239,14 @@ MetricVal is a value associated with the metric.
 
 
 
-<a name="node.proto"></a>
+<a name="node.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## node.proto
 
 
 
-<a name="edgeproto.Node"></a>
+<a name="edgeproto.Node"/>
 
 ### Node
 Node defines a DME (distributed matching engine) or CRM (cloudlet resource manager) instance.
@@ -1263,7 +1263,7 @@ Node defines a DME (distributed matching engine) or CRM (cloudlet resource manag
 
 
 
-<a name="edgeproto.NodeKey"></a>
+<a name="edgeproto.NodeKey"/>
 
 ### NodeKey
 NodeKey uniquely identifies a DME or CRM node
@@ -1282,7 +1282,7 @@ NodeKey uniquely identifies a DME or CRM node
  
 
 
-<a name="edgeproto.NodeType"></a>
+<a name="edgeproto.NodeType"/>
 
 ### NodeType
 NodeType defines the type of Node
@@ -1299,21 +1299,21 @@ NodeType defines the type of Node
  
 
 
-<a name="edgeproto.NodeApi"></a>
+<a name="edgeproto.NodeApi"/>
 
 ### NodeApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowNodeLocal | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) stream | Show Nodes connected locally only |
-| ShowNode | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) stream | Show all Nodes connected to all Controllers |
+| ShowNodeLocal | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) | Show Nodes connected locally only |
+| ShowNode | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) | Show all Nodes connected to all Controllers |
 
  
 
 
 
-<a name="notice.proto"></a>
+<a name="notice.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## notice.proto
@@ -1321,7 +1321,7 @@ Notice is the message used by the notify protocol to communicate and coordinate 
 In general, the protocol is used to synchronize state from one service to another. The protocol is fairly symmetric, with different state being synchronized both from server to client and client to server.
 
 
-<a name="edgeproto.NoticeReply"></a>
+<a name="edgeproto.NoticeReply"/>
 
 ### NoticeReply
 NoticyReply is sent from server to client.
@@ -1343,7 +1343,7 @@ NoticyReply is sent from server to client.
 
 
 
-<a name="edgeproto.NoticeRequest"></a>
+<a name="edgeproto.NoticeRequest"/>
 
 ### NoticeRequest
 NoticeRequest is sent from client to server.
@@ -1368,7 +1368,7 @@ NoticeRequest is sent from client to server.
  
 
 
-<a name="edgeproto.NoticeAction"></a>
+<a name="edgeproto.NoticeAction"/>
 
 ### NoticeAction
 NoticeAction denotes what kind of action this notification is for.
@@ -1383,7 +1383,7 @@ NoticeAction denotes what kind of action this notification is for.
 
 
 
-<a name="edgeproto.NoticeRequestor"></a>
+<a name="edgeproto.NoticeRequestor"/>
 
 ### NoticeRequestor
 NoticeRequestor indicates which type of service the client is.
@@ -1400,27 +1400,27 @@ NoticeRequestor indicates which type of service the client is.
  
 
 
-<a name="edgeproto.NotifyApi"></a>
+<a name="edgeproto.NotifyApi"/>
 
 ### NotifyApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| StreamNotice | [NoticeRequest](#edgeproto.NoticeRequest) stream | [NoticeReply](#edgeproto.NoticeReply) stream | Bidrectional stream for exchanging data between controller and DME/CRM |
+| StreamNotice | [NoticeRequest](#edgeproto.NoticeRequest) | [NoticeReply](#edgeproto.NoticeRequest) | Bidrectional stream for exchanging data between controller and DME/CRM |
 
  
 
 
 
-<a name="operator.proto"></a>
+<a name="operator.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## operator.proto
 
 
 
-<a name="edgeproto.Operator"></a>
+<a name="edgeproto.Operator"/>
 
 ### Operator
 An Operator defines a telecommunications provider such as AT&amp;T, T-Mobile, etc. The operators in turn provide Mobiledgex with compute resource Cloudlets that serve as the basis for location-based services.
@@ -1436,7 +1436,7 @@ An Operator defines a telecommunications provider such as AT&amp;T, T-Mobile, et
 
 
 
-<a name="edgeproto.OperatorKey"></a>
+<a name="edgeproto.OperatorKey"/>
 
 ### OperatorKey
 OperatorKey uniquely identifies an Operator
@@ -1457,30 +1457,30 @@ OperatorKey uniquely identifies an Operator
  
 
 
-<a name="edgeproto.OperatorApi"></a>
+<a name="edgeproto.OperatorApi"/>
 
 ### OperatorApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Result) | Create an Operator |
-| DeleteOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Result) | Delete an Operator |
-| UpdateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Result) | Update an Operator |
-| ShowOperator | [Operator](#edgeproto.Operator) | [Operator](#edgeproto.Operator) stream | Show Operators |
+| CreateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Operator) | Create an Operator |
+| DeleteOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Operator) | Delete an Operator |
+| UpdateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Operator) | Update an Operator |
+| ShowOperator | [Operator](#edgeproto.Operator) | [Operator](#edgeproto.Operator) | Show Operators |
 
  
 
 
 
-<a name="refs.proto"></a>
+<a name="refs.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## refs.proto
 
 
 
-<a name="edgeproto.CloudletRefs"></a>
+<a name="edgeproto.CloudletRefs"/>
 
 ### CloudletRefs
 CloudletRefs track used resources and Clusters instantiated on a Cloudlet. Used resources are compared against max resources for a Cloudlet to determine if resources are available for a new Cluster to be instantiated on the Cloudlet.
@@ -1502,7 +1502,7 @@ CloudletRefs track used resources and Clusters instantiated on a Cloudlet. Used 
 
 
 
-<a name="edgeproto.CloudletRefs.RootLbPortsEntry"></a>
+<a name="edgeproto.CloudletRefs.RootLbPortsEntry"/>
 
 ### CloudletRefs.RootLbPortsEntry
 
@@ -1518,7 +1518,7 @@ CloudletRefs track used resources and Clusters instantiated on a Cloudlet. Used 
 
 
 
-<a name="edgeproto.ClusterRefs"></a>
+<a name="edgeproto.ClusterRefs"/>
 
 ### ClusterRefs
 ClusterRefs track used resources within a ClusterInst. Each AppInst specifies a set of required resources (Flavor), so tracking resources used by Apps within a Cluster is necessary to determine if enough resources are available for another AppInst to be instantiated on a ClusterInst.
@@ -1543,37 +1543,37 @@ ClusterRefs track used resources within a ClusterInst. Each AppInst specifies a 
  
 
 
-<a name="edgeproto.CloudletRefsApi"></a>
+<a name="edgeproto.CloudletRefsApi"/>
 
 ### CloudletRefsApi
 This API should be admin-only
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowCloudletRefs | [CloudletRefs](#edgeproto.CloudletRefs) | [CloudletRefs](#edgeproto.CloudletRefs) stream | Show CloudletRefs (debug only) |
+| ShowCloudletRefs | [CloudletRefs](#edgeproto.CloudletRefs) | [CloudletRefs](#edgeproto.CloudletRefs) | Show CloudletRefs (debug only) |
 
 
-<a name="edgeproto.ClusterRefsApi"></a>
+<a name="edgeproto.ClusterRefsApi"/>
 
 ### ClusterRefsApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowClusterRefs | [ClusterRefs](#edgeproto.ClusterRefs) | [ClusterRefs](#edgeproto.ClusterRefs) stream | Show ClusterRefs (debug only) |
+| ShowClusterRefs | [ClusterRefs](#edgeproto.ClusterRefs) | [ClusterRefs](#edgeproto.ClusterRefs) | Show ClusterRefs (debug only) |
 
  
 
 
 
-<a name="result.proto"></a>
+<a name="result.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## result.proto
 
 
 
-<a name="edgeproto.Result"></a>
+<a name="edgeproto.Result"/>
 
 ### Result
 Result is a generic object for returning the result of an API call. In general, result is not used. The error value returned by the GRPC API call is used instead.

--- a/edgeproto/doc/index.html
+++ b/edgeproto/doc/index.html
@@ -4,7 +4,7 @@
   <head>
     <title>Protocol Documentation</title>
     <meta charset="UTF-8">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic"/>
+    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic"/>
     <style>
       body {
         width: 60em;
@@ -902,7 +902,7 @@ for example: key1=val1,key2=val2,key3=&#34;val 3&#34; </p></td>
               <tr>
                 <td>ShowApp</td>
                 <td><a href="#edgeproto.App">App</a></td>
-                <td><a href="#edgeproto.App">App</a> stream</td>
+                <td><a href="#edgeproto.App">App</a></td>
                 <td><p>Show applications. Any fields specified will be used to filter results.</p></td>
               </tr>
             
@@ -1157,28 +1157,28 @@ redundant unless they&#39;re needed for billing. </p></td>
               <tr>
                 <td>CreateAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Create an application instance</p></td>
               </tr>
             
               <tr>
                 <td>DeleteAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Delete an application instance</p></td>
               </tr>
             
               <tr>
                 <td>UpdateAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Update an application instance</p></td>
               </tr>
             
               <tr>
                 <td>ShowAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.AppInst">AppInst</a> stream</td>
+                <td><a href="#edgeproto.AppInst">AppInst</a></td>
                 <td><p>Show application instances. Any fields specified will be used to filter results.</p></td>
               </tr>
             
@@ -1196,7 +1196,7 @@ redundant unless they&#39;re needed for billing. </p></td>
               <tr>
                 <td>ShowAppInstInfo</td>
                 <td><a href="#edgeproto.AppInstInfo">AppInstInfo</a></td>
-                <td><a href="#edgeproto.AppInstInfo">AppInstInfo</a> stream</td>
+                <td><a href="#edgeproto.AppInstInfo">AppInstInfo</a></td>
                 <td><p>Show application instances state.</p></td>
               </tr>
             
@@ -1214,7 +1214,7 @@ redundant unless they&#39;re needed for billing. </p></td>
               <tr>
                 <td>ShowAppInstMetrics</td>
                 <td><a href="#edgeproto.AppInstMetrics">AppInstMetrics</a></td>
-                <td><a href="#edgeproto.AppInstMetrics">AppInstMetrics</a> stream</td>
+                <td><a href="#edgeproto.AppInstMetrics">AppInstMetrics</a></td>
                 <td><p>Show application instance metrics.</p></td>
               </tr>
             
@@ -1551,7 +1551,7 @@ is configurable here. This will need to be removed later. </p></td>
               <tr>
                 <td>ListCloudResource</td>
                 <td><a href="#edgeproto.CloudResource">CloudResource</a></td>
-                <td><a href="#edgeproto.CloudResource">CloudResource</a> stream</td>
+                <td><a href="#edgeproto.CloudResource">CloudResource</a></td>
                 <td><p></p></td>
               </tr>
             
@@ -1851,28 +1851,28 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>CreateCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Create a Cloudlet</p></td>
               </tr>
             
               <tr>
                 <td>DeleteCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Delete a Cloudlet</p></td>
               </tr>
             
               <tr>
                 <td>UpdateCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Update a Cloudlet</p></td>
               </tr>
             
               <tr>
                 <td>ShowCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Cloudlet">Cloudlet</a> stream</td>
+                <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
                 <td><p>Show Cloudlets</p></td>
               </tr>
             
@@ -1890,7 +1890,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowCloudletInfo</td>
                 <td><a href="#edgeproto.CloudletInfo">CloudletInfo</a></td>
-                <td><a href="#edgeproto.CloudletInfo">CloudletInfo</a> stream</td>
+                <td><a href="#edgeproto.CloudletInfo">CloudletInfo</a></td>
                 <td><p>Show CloudletInfos</p></td>
               </tr>
             
@@ -1922,7 +1922,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowCloudletMetrics</td>
                 <td><a href="#edgeproto.CloudletMetrics">CloudletMetrics</a></td>
-                <td><a href="#edgeproto.CloudletMetrics">CloudletMetrics</a> stream</td>
+                <td><a href="#edgeproto.CloudletMetrics">CloudletMetrics</a></td>
                 <td><p>Show Cloudlet metrics</p></td>
               </tr>
             
@@ -2042,7 +2042,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowCluster</td>
                 <td><a href="#edgeproto.Cluster">Cluster</a></td>
-                <td><a href="#edgeproto.Cluster">Cluster</a> stream</td>
+                <td><a href="#edgeproto.Cluster">Cluster</a></td>
                 <td><p>Show Clusters</p></td>
               </tr>
             
@@ -2183,7 +2183,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowClusterFlavor</td>
                 <td><a href="#edgeproto.ClusterFlavor">ClusterFlavor</a></td>
-                <td><a href="#edgeproto.ClusterFlavor">ClusterFlavor</a> stream</td>
+                <td><a href="#edgeproto.ClusterFlavor">ClusterFlavor</a></td>
                 <td><p>Show ClusterFlavors</p></td>
               </tr>
             
@@ -2368,28 +2368,28 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>CreateClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Create a Cluster instance</p></td>
               </tr>
             
               <tr>
                 <td>DeleteClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Delete a Cluster instance</p></td>
               </tr>
             
               <tr>
                 <td>UpdateClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Update a Cluster instance</p></td>
               </tr>
             
               <tr>
                 <td>ShowClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.ClusterInst">ClusterInst</a> stream</td>
+                <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
                 <td><p>Show Cluster instances</p></td>
               </tr>
             
@@ -2407,7 +2407,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowClusterInstInfo</td>
                 <td><a href="#edgeproto.ClusterInstInfo">ClusterInstInfo</a></td>
-                <td><a href="#edgeproto.ClusterInstInfo">ClusterInstInfo</a> stream</td>
+                <td><a href="#edgeproto.ClusterInstInfo">ClusterInstInfo</a></td>
                 <td><p>Show Cluster instances state.</p></td>
               </tr>
             
@@ -2723,7 +2723,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowController</td>
                 <td><a href="#edgeproto.Controller">Controller</a></td>
-                <td><a href="#edgeproto.Controller">Controller</a> stream</td>
+                <td><a href="#edgeproto.Controller">Controller</a></td>
                 <td><p>Show Controllers</p></td>
               </tr>
             
@@ -2857,7 +2857,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowDeveloper</td>
                 <td><a href="#edgeproto.Developer">Developer</a></td>
-                <td><a href="#edgeproto.Developer">Developer</a> stream</td>
+                <td><a href="#edgeproto.Developer">Developer</a></td>
                 <td><p>Show Developers</p></td>
               </tr>
             
@@ -2984,7 +2984,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowFlavor</td>
                 <td><a href="#edgeproto.Flavor">Flavor</a></td>
-                <td><a href="#edgeproto.Flavor">Flavor</a> stream</td>
+                <td><a href="#edgeproto.Flavor">Flavor</a></td>
                 <td><p>Show Flavors</p></td>
               </tr>
             
@@ -3244,14 +3244,14 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowNodeLocal</td>
                 <td><a href="#edgeproto.Node">Node</a></td>
-                <td><a href="#edgeproto.Node">Node</a> stream</td>
+                <td><a href="#edgeproto.Node">Node</a></td>
                 <td><p>Show Nodes connected locally only</p></td>
               </tr>
             
               <tr>
                 <td>ShowNode</td>
                 <td><a href="#edgeproto.Node">Node</a></td>
-                <td><a href="#edgeproto.Node">Node</a> stream</td>
+                <td><a href="#edgeproto.Node">Node</a></td>
                 <td><p>Show all Nodes connected to all Controllers</p></td>
               </tr>
             
@@ -3503,8 +3503,8 @@ Certs for accessing cloudlet site </p></td>
             
               <tr>
                 <td>StreamNotice</td>
-                <td><a href="#edgeproto.NoticeRequest">NoticeRequest</a> stream</td>
-                <td><a href="#edgeproto.NoticeReply">NoticeReply</a> stream</td>
+                <td><a href="#edgeproto.NoticeRequest">NoticeRequest</a></td>
+                <td><a href="#edgeproto.NoticeReply">NoticeReply</a></td>
                 <td><p>Bidrectional stream for exchanging data between controller and DME/CRM</p></td>
               </tr>
             
@@ -3610,7 +3610,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowOperator</td>
                 <td><a href="#edgeproto.Operator">Operator</a></td>
-                <td><a href="#edgeproto.Operator">Operator</a> stream</td>
+                <td><a href="#edgeproto.Operator">Operator</a></td>
                 <td><p>Show Operators</p></td>
               </tr>
             
@@ -3795,7 +3795,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowCloudletRefs</td>
                 <td><a href="#edgeproto.CloudletRefs">CloudletRefs</a></td>
-                <td><a href="#edgeproto.CloudletRefs">CloudletRefs</a> stream</td>
+                <td><a href="#edgeproto.CloudletRefs">CloudletRefs</a></td>
                 <td><p>Show CloudletRefs (debug only)</p></td>
               </tr>
             
@@ -3813,7 +3813,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowClusterRefs</td>
                 <td><a href="#edgeproto.ClusterRefs">ClusterRefs</a></td>
-                <td><a href="#edgeproto.ClusterRefs">ClusterRefs</a> stream</td>
+                <td><a href="#edgeproto.ClusterRefs">ClusterRefs</a></td>
                 <td><p>Show ClusterRefs (debug only)</p></td>
               </tr>
             

--- a/setup-env/e2e-tests/data/crm_info.yml
+++ b/setup-env/e2e-tests/data/crm_info.yml
@@ -1,10 +1,5 @@
 flavors:
 - key:
-    name: x1.medium
-  ram: 4096
-  vcpus: 4
-  disk: 4
-- key:
     name: x1.tiny
   ram: 1024
   vcpus: 1
@@ -14,6 +9,11 @@ flavors:
   ram: 2048
   vcpus: 2
   disk: 2
+- key:
+    name: x1.medium
+  ram: 4096
+  vcpus: 4
+  disk: 4
 
 clusterflavors:
 - key:
@@ -207,7 +207,7 @@ appinstances:
   cloudletloc:
     lat: 31
     long: -91
-  uri: acmeappcosomeapplication110.tmus-cloud-1.tmus.mobiledgex.net
+  uri: tmus-cloud-1.tmus.mobiledgex.net
   clusterinstkey:
     clusterkey:
       name: autoclustersomeapplication1
@@ -223,7 +223,7 @@ appinstances:
     fqdnprefix: someapplication1-tcp.
   - proto: LProtoHTTP
     internalport: 443
-    publicport: 443
+    publicport: 10000
     fqdnprefix: someapplication1-tcp.
   - proto: LProtoUDP
     internalport: 10002
@@ -231,9 +231,8 @@ appinstances:
     fqdnprefix: someapplication1-udp.
   flavor:
     name: x1.small
-  ipaccess: IpAccessDedicatedOrShared
+  ipaccess: IpAccessShared
   state: Ready
-  allocatedip: dynamic
 - key:
     appkey:
       developerkey:
@@ -248,7 +247,7 @@ appinstances:
   cloudletloc:
     lat: 35
     long: -95
-  uri: acmeappcosomeapplication110.tmus-cloud-2.tmus.mobiledgex.net
+  uri: tmus-cloud-2.tmus.mobiledgex.net
   clusterinstkey:
     clusterkey:
       name: autoclustersomeapplication1
@@ -264,7 +263,7 @@ appinstances:
     fqdnprefix: someapplication1-tcp.
   - proto: LProtoHTTP
     internalport: 443
-    publicport: 443
+    publicport: 10000
     fqdnprefix: someapplication1-tcp.
   - proto: LProtoUDP
     internalport: 10002
@@ -272,7 +271,6 @@ appinstances:
     fqdnprefix: someapplication1-udp.
   flavor:
     name: x1.small
-  ipaccess: IpAccessDedicatedOrShared
+  ipaccess: IpAccessShared
   state: Ready
-  allocatedip: dynamic
 

--- a/setup-env/e2e-tests/data/get_appinstlist_result_app1.yml
+++ b/setup-env/e2e-tests/data/get_appinstlist_result_app1.yml
@@ -34,13 +34,10 @@ cloudlets:
     ports:
     - proto: LProtoTCP
       internalport: 80
-      fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
-      fqdnprefix: someapplication1-udp.
 - carriername: gcp
   cloudletname: gcp-cloud-10
   gpslocation:
@@ -73,7 +70,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-1.tmus.mobiledgex.net
+    fqdn: tmus-cloud-1.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -81,7 +78,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -96,7 +93,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-2.tmus.mobiledgex.net
+    fqdn: tmus-cloud-2.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -104,7 +101,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -119,7 +116,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-3.tmus.mobiledgex.net
+    fqdn: tmus-cloud-3.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -127,7 +124,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -142,7 +139,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-4.tmus.mobiledgex.net
+    fqdn: tmus-cloud-4.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -150,7 +147,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -165,7 +162,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-5.tmus.mobiledgex.net
+    fqdn: tmus-cloud-5.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -173,7 +170,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -188,7 +185,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-6.tmus.mobiledgex.net
+    fqdn: tmus-cloud-6.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -196,7 +193,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -211,7 +208,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-7.tmus.mobiledgex.net
+    fqdn: tmus-cloud-7.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -219,7 +216,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -234,7 +231,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-8.tmus.mobiledgex.net
+    fqdn: tmus-cloud-8.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -242,7 +239,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002

--- a/setup-env/e2e-tests/data/get_appinstlist_result_app1_no_default.yml
+++ b/setup-env/e2e-tests/data/get_appinstlist_result_app1_no_default.yml
@@ -55,7 +55,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-1.tmus.mobiledgex.net
+    fqdn: tmus-cloud-1.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -63,7 +63,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -78,7 +78,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-2.tmus.mobiledgex.net
+    fqdn: tmus-cloud-2.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -86,7 +86,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -101,7 +101,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-3.tmus.mobiledgex.net
+    fqdn: tmus-cloud-3.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -109,7 +109,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -124,7 +124,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-4.tmus.mobiledgex.net
+    fqdn: tmus-cloud-4.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -132,7 +132,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -147,7 +147,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-5.tmus.mobiledgex.net
+    fqdn: tmus-cloud-5.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -155,7 +155,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -170,7 +170,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-6.tmus.mobiledgex.net
+    fqdn: tmus-cloud-6.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -178,7 +178,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -193,7 +193,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-7.tmus.mobiledgex.net
+    fqdn: tmus-cloud-7.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -201,7 +201,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
@@ -216,7 +216,7 @@ cloudlets:
   appinstances:
   - appname: someapplication1
     appvers: "1.0"
-    fqdn: acmeappcosomeapplication110.tmus-cloud-8.tmus.mobiledgex.net
+    fqdn: tmus-cloud-8.tmus.mobiledgex.net
     ports:
     - proto: LProtoTCP
       internalport: 80
@@ -224,7 +224,7 @@ cloudlets:
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      publicport: 443
+      publicport: 10000
       fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002

--- a/setup-env/e2e-tests/data/get_appinstlist_result_default.yml
+++ b/setup-env/e2e-tests/data/get_appinstlist_result_default.yml
@@ -11,10 +11,7 @@ cloudlets:
     ports:
     - proto: LProtoTCP
       internalport: 80
-      fqdnprefix: someapplication1-tcp.
     - proto: LProtoHTTP
       internalport: 443
-      fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
-      fqdnprefix: someapplication1-udp.

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -547,7 +547,7 @@ var CloudletRefsWithAppInstsData = []edgeproto.CloudletRefs{
 		UsedRam:        GetCloudletUsedRam(0, 1, 0),
 		UsedVcores:     GetCloudletUsedVcores(0, 1, 0),
 		UsedDisk:       GetCloudletUsedDisk(0, 1, 0),
-		RootLbPorts:    map[int32]int32{10000: 1, 10001: 1},
+		RootLbPorts:    map[int32]int32{80: 1, 10000: 1},
 		UsedDynamicIps: 1,
 	},
 	// ClusterInstData[2,5], ClusterInstAutoData[1]:
@@ -558,10 +558,10 @@ var CloudletRefsWithAppInstsData = []edgeproto.CloudletRefs{
 			ClusterData[2].Key,
 			ClusterAutoData[1].Key,
 		},
-		UsedRam:        GetCloudletUsedRam(0, 2, 1),
-		UsedVcores:     GetCloudletUsedVcores(0, 2, 1),
-		UsedDisk:       GetCloudletUsedDisk(0, 2, 1),
-		UsedDynamicIps: 1,
+		UsedRam:     GetCloudletUsedRam(0, 2, 1),
+		UsedVcores:  GetCloudletUsedVcores(0, 2, 1),
+		UsedDisk:    GetCloudletUsedDisk(0, 2, 1),
+		RootLbPorts: map[int32]int32{10000: 1, 11111: 1},
 	},
 	// ClusterInstData[2,6]:
 	edgeproto.CloudletRefs{


### PR DESCRIPTION
This change makes the controller attempt to set the PublicPort equal to the InternalPort if possible for AppInsts. This is not a long-term general solution, but an attempt to help things work better for Samsung who ignores the port mapping for their Enabling Layer.
Also Jim/Bruce noticed that sometimes AppInsts end up with IpAccess set to DedicatedOrShared, which is not intended - that setting is only for Apps. The code was supposed to choose one or the other for AppInsts, but missed a case. So I've fixed up that logic (which is in allocateIP).