### PR TITLE
fix app template to default to 1 replica, and do not populate command if not present

### DIFF
--- a/deploygen/kube.go
+++ b/deploygen/kube.go
@@ -125,12 +125,16 @@ func (g *kubeBasicGen) kubeApp() {
 	if g.err != nil {
 		return
 	}
+	var cs []string
+	if g.app.Command != "" {
+		cs = strings.Split(g.app.Command, " ")
+	}
 	data := appData{
 		Name:      util.K8SSanitize(g.app.Name + "-deployment"),
 		Run:       util.K8SSanitize(g.app.Name),
 		Ports:     g.ports,
 		ImagePath: g.app.ImagePath,
-		Command:   strings.Split(g.app.Command, " "),
+		Command:   cs,
 	}
 	buf := bytes.Buffer{}
 	g.err = kubeAppT.Execute(&buf, &data)
@@ -156,7 +160,7 @@ spec:
   selector:
     matchLabels:
       run: {{.Run}}
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -174,8 +178,10 @@ spec:
         - containerPort: {{.Port}}
           protocol: {{.KubeProto}}
 {{- end}}
+{{- if .Command}}
         command:
 {{- range .Command}}
         - "{{.}}"
+{{- end}}
 {{- end}}
 `


### PR DESCRIPTION
If an app is using the default template but not command, the resulting k8s manifest will still have a command section, but with an empty string. This causes the apps to fail to start.   Make the command optional in the template.  Also, default the number of replicas to 1, since this is the most basic simple config possible (and some apps including the face detection server cannot really handle 2).  

These changes are prompted by the fact that the apptemplate field seems to no longer work the way it used to, or really at all as best I can tell.  That will be dealt with later.