### PR TITLE
Remove mexexample from tests

### DIFF
--- a/setup-env/e2e-tests/setups/local_1ctrl1dme1crm.yml
+++ b/setup-env/e2e-tests/setups/local_1ctrl1dme1crm.yml
@@ -8,14 +8,6 @@ tlscerts:
     - 127.0.0.1
     - 0.0.0.0
 
-sampleapps:
-- sampleapplocal:
-    name: mexexample1
-    exename: mexexample
-    args: 
-     - "-debug"
-  hostname: "127.0.0.1"
- 
 locsims:
 - locapisimlocal:
     name: locsim1

--- a/setup-env/e2e-tests/setups/local_multi.yml
+++ b/setup-env/e2e-tests/setups/local_multi.yml
@@ -8,14 +8,6 @@ tlscerts:
     - 127.0.0.1
     - 0.0.0.0
 
-sampleapps:
-- sampleapplocal:
-    name: mexexample1
-    exename: mexexample
-    args: 
-     - "-debug"
-  hostname: "127.0.0.1"
- 
 locsims:
 - locapisimlocal:
     name: locsim1

--- a/setup-env/e2e-tests/setups/local_multi_automation.yml
+++ b/setup-env/e2e-tests/setups/local_multi_automation.yml
@@ -8,13 +8,6 @@ tlscerts:
     - 127.0.0.1
     - 0.0.0.0
 
-sampleapps:
-- sampleapplocal:
-    name: mexexample1
-    exename: mexexample
-    args: 
-     - "-debug"
-  hostname: "127.0.0.1"
  
 locsims:
 - locapisimlocal:

--- a/setup-env/e2e-tests/setups/local_multi_automation_noShortTimeouts.yml
+++ b/setup-env/e2e-tests/setups/local_multi_automation_noShortTimeouts.yml
@@ -8,14 +8,6 @@ tlscerts:
     - 127.0.0.1
     - 0.0.0.0
 
-sampleapps:
-- sampleapplocal:
-    name: mexexample1
-    exename: mexexample
-    args: 
-     - "-debug"
-  hostname: "127.0.0.1"
- 
 locsims:
 - locapisimlocal:
     name: locsim1

--- a/setup-env/e2e-tests/setups/local_multi_notls.yml
+++ b/setup-env/e2e-tests/setups/local_multi_notls.yml
@@ -2,14 +2,6 @@ vars:
   - locverurl: "http://127.0.0.1:8888/verifyLocation" 
   - toksrvurl: "http://127.0.0.1:9999/its?followURL%3Dhttps://dme.mobiledgex.net/verifyLoc" 
 
-sampleapps:
-- sampleapplocal:
-    name: mexexample1
-    exename: mexexample
-    args: 
-     - "-debug"
-  hostname: "127.0.0.1"
- 
 locsims:
 - locapisimlocal:
     name: locsim1


### PR DESCRIPTION
The mexexample stand alone binary no longer exists as part of the CRM changes.  The e2e tool attempts to start this as part of the local tests.  An old version was still in my bin dir so this was not causing a problem until I cleaned that up and then everything failed.   

Remove the sampleapps tests from the e2e setups, they are not really needed any more anyway as we have real k8s deployments we can do now.