### PR TITLE
fixes

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -191,6 +191,10 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 					return objstore.ErrKVStoreKeyExists
 				}
 				in.Errors = nil
+				if !defaultCloudlet {
+					// must reset Uri
+					in.Uri = ""
+				}
 			} else {
 				err := in.Validate(edgeproto.AppInstAllFieldsMap)
 				if err != nil {
@@ -337,7 +341,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		if in.Uri == "" && defaultCloudlet {
 			return errors.New("URI (Public FQDN) is required for default cloudlet")
 		} else if in.Uri != "" && !defaultCloudlet {
-			return errors.New("Cannot specify URI for non-default cloudlet")
+			return fmt.Errorf("Cannot specify URI %s for non-default cloudlet", in.Uri)
 		}
 
 		if defaultCloudlet {

--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -86,6 +86,7 @@ func TestAppInstApi(t *testing.T) {
 	responder.SetSimulateDeleteFailure(false)
 	checkAppInstState(t, commonApi, &obj, edgeproto.TrackedState_Ready)
 
+	obj = testutil.AppInstData[0]
 	// check override of error DeleteError
 	err = forceAppInstState(&obj, edgeproto.TrackedState_DeleteError)
 	assert.Nil(t, err, "force state")
@@ -212,16 +213,17 @@ func TestAutoClusterInst(t *testing.T) {
 	testutil.InternalAppCreate(t, &appApi, testutil.AppData)
 
 	// since cluster inst does not exist, it will be auto-created
-	err := appInstApi.CreateAppInst(&testutil.AppInstData[0], &testutil.CudStreamoutAppInst{})
+	copy := testutil.AppInstData[0]
+	err := appInstApi.CreateAppInst(&copy, &testutil.CudStreamoutAppInst{})
 	assert.Nil(t, err, "create app inst")
 	clusterInst := edgeproto.ClusterInst{}
-	found := clusterInstApi.Get(&testutil.AppInstData[0].ClusterInstKey, &clusterInst)
+	found := clusterInstApi.Get(&copy.ClusterInstKey, &clusterInst)
 	assert.True(t, found, "get auto-clusterinst")
 	assert.True(t, clusterInst.Auto, "clusterinst is auto")
 	// delete appinst should also delete clusterinst
-	err = appInstApi.DeleteAppInst(&testutil.AppInstData[0], &testutil.CudStreamoutAppInst{})
+	err = appInstApi.DeleteAppInst(&copy, &testutil.CudStreamoutAppInst{})
 	assert.Nil(t, err, "delete app inst")
-	found = clusterInstApi.Get(&testutil.AppInstData[0].ClusterInstKey, &clusterInst)
+	found = clusterInstApi.Get(&copy.ClusterInstKey, &clusterInst)
 	assert.False(t, found, "get auto-clusterinst")
 
 	dummy.Stop()

--- a/edgeproto/doc/README.md
+++ b/edgeproto/doc/README.md
@@ -1,5 +1,5 @@
 # Protocol Documentation
-<a name="top"></a>
+<a name="top"/>
 
 ## Table of Contents
 
@@ -178,14 +178,14 @@
 
 
 
-<a name="app.proto"></a>
+<a name="app.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## app.proto
 
 
 
-<a name="edgeproto.App"></a>
+<a name="edgeproto.App"/>
 
 ### App
 Apps are applications that may be instantiated on Cloudlets, providing a back-end service to an application client (using the mobiledgex SDK) running on a user device such as a cell phone, wearable, drone, etc. Applications belong to Developers, and must specify their image and accessibility. Applications are analagous to Pods in Kubernetes, and similarly are tied to a Cluster.
@@ -219,7 +219,7 @@ An application in itself is not tied to a Cloudlet, but provides a definition th
 
 
 
-<a name="edgeproto.AppKey"></a>
+<a name="edgeproto.AppKey"/>
 
 ### AppKey
 AppKey uniquely identifies an Application.
@@ -238,7 +238,7 @@ AppKey uniquely identifies an Application.
  
 
 
-<a name="edgeproto.DeleteType"></a>
+<a name="edgeproto.DeleteType"/>
 
 ### DeleteType
 
@@ -250,7 +250,7 @@ AppKey uniquely identifies an Application.
 
 
 
-<a name="edgeproto.ImageType"></a>
+<a name="edgeproto.ImageType"/>
 
 ### ImageType
 ImageType specifies the image type of the application.
@@ -267,30 +267,30 @@ ImageType specifies the image type of the application.
  
 
 
-<a name="edgeproto.AppApi"></a>
+<a name="edgeproto.AppApi"/>
 
 ### AppApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateApp | [App](#edgeproto.App) | [Result](#edgeproto.Result) | Create an application |
-| DeleteApp | [App](#edgeproto.App) | [Result](#edgeproto.Result) | Delete an application |
-| UpdateApp | [App](#edgeproto.App) | [Result](#edgeproto.Result) | Update an application |
-| ShowApp | [App](#edgeproto.App) | [App](#edgeproto.App) stream | Show applications. Any fields specified will be used to filter results. |
+| CreateApp | [App](#edgeproto.App) | [Result](#edgeproto.App) | Create an application |
+| DeleteApp | [App](#edgeproto.App) | [Result](#edgeproto.App) | Delete an application |
+| UpdateApp | [App](#edgeproto.App) | [Result](#edgeproto.App) | Update an application |
+| ShowApp | [App](#edgeproto.App) | [App](#edgeproto.App) | Show applications. Any fields specified will be used to filter results. |
 
  
 
 
 
-<a name="app_inst.proto"></a>
+<a name="app_inst.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## app_inst.proto
 
 
 
-<a name="edgeproto.AppInst"></a>
+<a name="edgeproto.AppInst"/>
 
 ### AppInst
 AppInst is an instance of an App (application) on a Cloudlet. It is defined by an App plus a Cloudlet key. This separation of the definition of the App versus its instantiation is unique to Mobiledgex, and allows the Developer to provide the App defintion, while either the Developer may statically define the instances, or the Mobiledgex platform may dynamically create and destroy instances in response to demand.
@@ -319,7 +319,7 @@ Many of the fields here are inherited from the App definition. Some are derived,
 
 
 
-<a name="edgeproto.AppInstInfo"></a>
+<a name="edgeproto.AppInstInfo"/>
 
 ### AppInstInfo
 AppInstInfo provides information from the Cloudlet Resource Manager about the state of the AppInst on the Cloudlet. Whereas the AppInst defines the intent of instantiating an App on a Cloudlet, the AppInstInfo defines the current state of trying to apply that intent on the physical resources of the Cloudlet.
@@ -338,7 +338,7 @@ AppInstInfo provides information from the Cloudlet Resource Manager about the st
 
 
 
-<a name="edgeproto.AppInstKey"></a>
+<a name="edgeproto.AppInstKey"/>
 
 ### AppInstKey
 AppInstKey uniquely identifies an Application Instance (AppInst) or Application Instance state (AppInstInfo).
@@ -355,7 +355,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.AppInstMetrics"></a>
+<a name="edgeproto.AppInstMetrics"/>
 
 ### AppInstMetrics
 (TODO) AppInstMetrics provide metrics collected about the application instance on the Cloudlet. They are sent to a metrics collector for analytics. They are not stored in the persistent distributed database, but are stored as a time series in some other database or files.
@@ -376,50 +376,50 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
  
 
 
-<a name="edgeproto.AppInstApi"></a>
+<a name="edgeproto.AppInstApi"/>
 
 ### AppInstApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.Result) stream | Create an application instance |
-| DeleteAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.Result) stream | Delete an application instance |
-| UpdateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.Result) stream | Update an application instance |
-| ShowAppInst | [AppInst](#edgeproto.AppInst) | [AppInst](#edgeproto.AppInst) stream | Show application instances. Any fields specified will be used to filter results. |
+| CreateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.AppInst) | Create an application instance |
+| DeleteAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.AppInst) | Delete an application instance |
+| UpdateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.AppInst) | Update an application instance |
+| ShowAppInst | [AppInst](#edgeproto.AppInst) | [AppInst](#edgeproto.AppInst) | Show application instances. Any fields specified will be used to filter results. |
 
 
-<a name="edgeproto.AppInstInfoApi"></a>
+<a name="edgeproto.AppInstInfoApi"/>
 
 ### AppInstInfoApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowAppInstInfo | [AppInstInfo](#edgeproto.AppInstInfo) | [AppInstInfo](#edgeproto.AppInstInfo) stream | Show application instances state. |
+| ShowAppInstInfo | [AppInstInfo](#edgeproto.AppInstInfo) | [AppInstInfo](#edgeproto.AppInstInfo) | Show application instances state. |
 
 
-<a name="edgeproto.AppInstMetricsApi"></a>
+<a name="edgeproto.AppInstMetricsApi"/>
 
 ### AppInstMetricsApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowAppInstMetrics | [AppInstMetrics](#edgeproto.AppInstMetrics) | [AppInstMetrics](#edgeproto.AppInstMetrics) stream | Show application instance metrics. |
+| ShowAppInstMetrics | [AppInstMetrics](#edgeproto.AppInstMetrics) | [AppInstMetrics](#edgeproto.AppInstMetrics) | Show application instance metrics. |
 
  
 
 
 
-<a name="cloud-resource-manager.proto"></a>
+<a name="cloud-resource-manager.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## cloud-resource-manager.proto
 
 
 
-<a name="edgeproto.CloudResource"></a>
+<a name="edgeproto.CloudResource"/>
 
 ### CloudResource
 
@@ -439,7 +439,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.EdgeCloudApp"></a>
+<a name="edgeproto.EdgeCloudApp"/>
 
 ### EdgeCloudApp
 
@@ -467,7 +467,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.EdgeCloudApplication"></a>
+<a name="edgeproto.EdgeCloudApplication"/>
 
 ### EdgeCloudApplication
 
@@ -486,7 +486,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
  
 
 
-<a name="edgeproto.CloudResourceCategory"></a>
+<a name="edgeproto.CloudResourceCategory"/>
 
 ### CloudResourceCategory
 
@@ -514,31 +514,31 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
  
 
 
-<a name="edgeproto.CloudResourceManager"></a>
+<a name="edgeproto.CloudResourceManager"/>
 
 ### CloudResourceManager
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListCloudResource | [CloudResource](#edgeproto.CloudResource) | [CloudResource](#edgeproto.CloudResource) stream |  |
-| AddCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.Result) |  |
-| DeleteCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.Result) |  |
-| DeployApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.Result) |  |
-| DeleteApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.Result) |  |
+| ListCloudResource | [CloudResource](#edgeproto.CloudResource) | [CloudResource](#edgeproto.CloudResource) |  |
+| AddCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.CloudResource) |  |
+| DeleteCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.CloudResource) |  |
+| DeployApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.EdgeCloudApplication) |  |
+| DeleteApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.EdgeCloudApplication) |  |
 
  
 
 
 
-<a name="cloudlet.proto"></a>
+<a name="cloudlet.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## cloudlet.proto
 
 
 
-<a name="edgeproto.Cloudlet"></a>
+<a name="edgeproto.Cloudlet"/>
 
 ### Cloudlet
 A Cloudlet is a set of compute resources at a particular location, typically an Operator&#39;s regional data center, or a cell tower. The Cloudlet is managed by a Cloudlet Resource Manager, which communicates with the Mobiledgex Controller and allows AppInsts (application instances) to be instantiated on the Cloudlet.
@@ -562,7 +562,7 @@ Certs for accessing cloudlet site |
 
 
 
-<a name="edgeproto.CloudletInfo"></a>
+<a name="edgeproto.CloudletInfo"/>
 
 ### CloudletInfo
 CloudletInfo provides information from the Cloudlet Resource Manager about the state of the Cloudlet.
@@ -585,7 +585,7 @@ CloudletInfo provides information from the Cloudlet Resource Manager about the s
 
 
 
-<a name="edgeproto.CloudletKey"></a>
+<a name="edgeproto.CloudletKey"/>
 
 ### CloudletKey
 CloudletKey uniquely identifies a Cloudlet.
@@ -601,7 +601,7 @@ CloudletKey uniquely identifies a Cloudlet.
 
 
 
-<a name="edgeproto.CloudletMetrics"></a>
+<a name="edgeproto.CloudletMetrics"/>
 
 ### CloudletMetrics
 (TODO) CloudletMetrics provide metrics collected about the Cloudlet. They are sent to a metrics collector for analytics. They are not stored in the persistent distributed database, but are stored as a time series in some other database or files.
@@ -618,7 +618,7 @@ CloudletKey uniquely identifies a Cloudlet.
  
 
 
-<a name="edgeproto.CloudletState"></a>
+<a name="edgeproto.CloudletState"/>
 
 ### CloudletState
 CloudletState is the state of the Cloudlet.
@@ -637,52 +637,52 @@ CloudletState is the state of the Cloudlet.
  
 
 
-<a name="edgeproto.CloudletApi"></a>
+<a name="edgeproto.CloudletApi"/>
 
 ### CloudletApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Result) stream | Create a Cloudlet |
-| DeleteCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Result) stream | Delete a Cloudlet |
-| UpdateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Result) stream | Update a Cloudlet |
-| ShowCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Cloudlet](#edgeproto.Cloudlet) stream | Show Cloudlets |
+| CreateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Cloudlet) | Create a Cloudlet |
+| DeleteCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Cloudlet) | Delete a Cloudlet |
+| UpdateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Cloudlet) | Update a Cloudlet |
+| ShowCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Cloudlet](#edgeproto.Cloudlet) | Show Cloudlets |
 
 
-<a name="edgeproto.CloudletInfoApi"></a>
+<a name="edgeproto.CloudletInfoApi"/>
 
 ### CloudletInfoApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [CloudletInfo](#edgeproto.CloudletInfo) stream | Show CloudletInfos |
-| InjectCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.Result) | Inject (create) a CloudletInfo for regression testing |
-| EvictCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.Result) | Evict (delete) a CloudletInfo for regression testing |
+| ShowCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [CloudletInfo](#edgeproto.CloudletInfo) | Show CloudletInfos |
+| InjectCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.CloudletInfo) | Inject (create) a CloudletInfo for regression testing |
+| EvictCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.CloudletInfo) | Evict (delete) a CloudletInfo for regression testing |
 
 
-<a name="edgeproto.CloudletMetricsApi"></a>
+<a name="edgeproto.CloudletMetricsApi"/>
 
 ### CloudletMetricsApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowCloudletMetrics | [CloudletMetrics](#edgeproto.CloudletMetrics) | [CloudletMetrics](#edgeproto.CloudletMetrics) stream | Show Cloudlet metrics |
+| ShowCloudletMetrics | [CloudletMetrics](#edgeproto.CloudletMetrics) | [CloudletMetrics](#edgeproto.CloudletMetrics) | Show Cloudlet metrics |
 
  
 
 
 
-<a name="cluster.proto"></a>
+<a name="cluster.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## cluster.proto
 
 
 
-<a name="edgeproto.Cluster"></a>
+<a name="edgeproto.Cluster"/>
 
 ### Cluster
 Clusters define a set of resources that are provided to one or more Apps tied to the cluster. The set of resources is defined by the Cluster flavor. The Cluster definition here is analogous to a Kubernetes cluster.
@@ -702,7 +702,7 @@ In comparison to ClusterFlavors which are fairly static and controller by admini
 
 
 
-<a name="edgeproto.ClusterKey"></a>
+<a name="edgeproto.ClusterKey"/>
 
 ### ClusterKey
 ClusterKey uniquely identifies a Cluster.
@@ -723,30 +723,30 @@ ClusterKey uniquely identifies a Cluster.
  
 
 
-<a name="edgeproto.ClusterApi"></a>
+<a name="edgeproto.ClusterApi"/>
 
 ### ClusterApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Result) | Create a Cluster |
-| DeleteCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Result) | Delete a Cluster |
-| UpdateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Result) | Update a Cluster |
-| ShowCluster | [Cluster](#edgeproto.Cluster) | [Cluster](#edgeproto.Cluster) stream | Show Clusters |
+| CreateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Cluster) | Create a Cluster |
+| DeleteCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Cluster) | Delete a Cluster |
+| UpdateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Cluster) | Update a Cluster |
+| ShowCluster | [Cluster](#edgeproto.Cluster) | [Cluster](#edgeproto.Cluster) | Show Clusters |
 
  
 
 
 
-<a name="clusterflavor.proto"></a>
+<a name="clusterflavor.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## clusterflavor.proto
 
 
 
-<a name="edgeproto.ClusterFlavor"></a>
+<a name="edgeproto.ClusterFlavor"/>
 
 ### ClusterFlavor
 ClusterFlavor defines a set of resources for a Cluster. ClusterFlavors should be fairly static objects that are almost never changed, and are only modified by Mobiledgex administrators.
@@ -767,7 +767,7 @@ ClusterFlavor defines a set of resources for a Cluster. ClusterFlavors should be
 
 
 
-<a name="edgeproto.ClusterFlavorKey"></a>
+<a name="edgeproto.ClusterFlavorKey"/>
 
 ### ClusterFlavorKey
 ClusterFlavorKey uniquely identifies a Cluster Flavor.
@@ -788,30 +788,30 @@ ClusterFlavorKey uniquely identifies a Cluster Flavor.
  
 
 
-<a name="edgeproto.ClusterFlavorApi"></a>
+<a name="edgeproto.ClusterFlavorApi"/>
 
 ### ClusterFlavorApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.Result) | Create a ClusterFlavor |
-| DeleteClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.Result) | Delete a ClusterFlavor |
-| UpdateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.Result) | Update a ClusterFlavor |
-| ShowClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [ClusterFlavor](#edgeproto.ClusterFlavor) stream | Show ClusterFlavors |
+| CreateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.ClusterFlavor) | Create a ClusterFlavor |
+| DeleteClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.ClusterFlavor) | Delete a ClusterFlavor |
+| UpdateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.ClusterFlavor) | Update a ClusterFlavor |
+| ShowClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [ClusterFlavor](#edgeproto.ClusterFlavor) | Show ClusterFlavors |
 
  
 
 
 
-<a name="clusterinst.proto"></a>
+<a name="clusterinst.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## clusterinst.proto
 
 
 
-<a name="edgeproto.ClusterInst"></a>
+<a name="edgeproto.ClusterInst"/>
 
 ### ClusterInst
 ClusterInst is an instance of a Cluster on a Cloudlet. It is defined by a Cluster plus a Cloudlet key. This separation of the definition of the Cluster versus its instance is unique to Mobiledgex, and allows the Developer to provide the Cluster definition, while either the Developer may statically define the instances, or the Mobiledgex platform may dynamically create and destroy instances in response to demand.
@@ -834,7 +834,7 @@ When a Cluster is instantiated on a Cloudlet, the user may override the default 
 
 
 
-<a name="edgeproto.ClusterInstInfo"></a>
+<a name="edgeproto.ClusterInstInfo"/>
 
 ### ClusterInstInfo
 ClusterInstInfo provides information from the Cloudlet Resource Manager about the state of the ClusterInst on the Cloudlet. Whereas the ClusterInst defines the intent of instantiating a Cluster on a Cloudlet, the ClusterInstInfo defines the current state of trying to apply that intent on the physical resources of the Cloudlet.
@@ -853,7 +853,7 @@ ClusterInstInfo provides information from the Cloudlet Resource Manager about th
 
 
 
-<a name="edgeproto.ClusterInstKey"></a>
+<a name="edgeproto.ClusterInstKey"/>
 
 ### ClusterInstKey
 ClusterInstKey uniquely identifies a Cluster Instance (ClusterInst) or Cluster Instance state (ClusterInstInfo).
@@ -875,33 +875,33 @@ ClusterInstKey uniquely identifies a Cluster Instance (ClusterInst) or Cluster I
  
 
 
-<a name="edgeproto.ClusterInstApi"></a>
+<a name="edgeproto.ClusterInstApi"/>
 
 ### ClusterInstApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.Result) stream | Create a Cluster instance |
-| DeleteClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.Result) stream | Delete a Cluster instance |
-| UpdateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.Result) stream | Update a Cluster instance |
-| ShowClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [ClusterInst](#edgeproto.ClusterInst) stream | Show Cluster instances |
+| CreateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.ClusterInst) | Create a Cluster instance |
+| DeleteClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.ClusterInst) | Delete a Cluster instance |
+| UpdateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.ClusterInst) | Update a Cluster instance |
+| ShowClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [ClusterInst](#edgeproto.ClusterInst) | Show Cluster instances |
 
 
-<a name="edgeproto.ClusterInstInfoApi"></a>
+<a name="edgeproto.ClusterInstInfoApi"/>
 
 ### ClusterInstInfoApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowClusterInstInfo | [ClusterInstInfo](#edgeproto.ClusterInstInfo) | [ClusterInstInfo](#edgeproto.ClusterInstInfo) stream | Show Cluster instances state. |
+| ShowClusterInstInfo | [ClusterInstInfo](#edgeproto.ClusterInstInfo) | [ClusterInstInfo](#edgeproto.ClusterInstInfo) | Show Cluster instances state. |
 
  
 
 
 
-<a name="common.proto"></a>
+<a name="common.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## common.proto
@@ -910,7 +910,7 @@ ClusterInstKey uniquely identifies a Cluster Instance (ClusterInst) or Cluster I
  
 
 
-<a name="edgeproto.CRMOverride"></a>
+<a name="edgeproto.CRMOverride"/>
 
 ### CRMOverride
 CRMOverride can be applied to commands that issue requests to the CRM.
@@ -929,7 +929,7 @@ Controller to ignore errors from the CRM, or ignore the CRM completely
 
 
 
-<a name="edgeproto.IpAccess"></a>
+<a name="edgeproto.IpAccess"/>
 
 ### IpAccess
 
@@ -943,7 +943,7 @@ Controller to ignore errors from the CRM, or ignore the CRM completely
 
 
 
-<a name="edgeproto.IpSupport"></a>
+<a name="edgeproto.IpSupport"/>
 
 ### IpSupport
 IpSupport indicates the type of public IP support provided by the Cloudlet. Static IP support indicates a set of static public IPs are available for use, and managed by the Controller. Dynamic indicates the Cloudlet uses a DHCP server to provide public IP addresses, and the controller has no control over which IPs are assigned.
@@ -956,7 +956,7 @@ IpSupport indicates the type of public IP support provided by the Cloudlet. Stat
 
 
 
-<a name="edgeproto.Liveness"></a>
+<a name="edgeproto.Liveness"/>
 
 ### Liveness
 Liveness indicates if an object was created statically via an external API call, or dynamically via an internal algorithm.
@@ -969,7 +969,7 @@ Liveness indicates if an object was created statically via an external API call,
 
 
 
-<a name="edgeproto.TrackedState"></a>
+<a name="edgeproto.TrackedState"/>
 
 ### TrackedState
 TrackedState is used to track the state of an object on a remote node,
@@ -999,14 +999,14 @@ i.e. track the state of a ClusterInst object on the CRM (Cloudlet).
 
 
 
-<a name="controller.proto"></a>
+<a name="controller.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## controller.proto
 
 
 
-<a name="edgeproto.Controller"></a>
+<a name="edgeproto.Controller"/>
 
 ### Controller
 A Controller is a service that manages the edge-cloud data and controls other edge-cloud micro-services.
@@ -1022,7 +1022,7 @@ A Controller is a service that manages the edge-cloud data and controls other ed
 
 
 
-<a name="edgeproto.ControllerKey"></a>
+<a name="edgeproto.ControllerKey"/>
 
 ### ControllerKey
 ControllerKey uniquely defines a Controller
@@ -1043,27 +1043,27 @@ ControllerKey uniquely defines a Controller
  
 
 
-<a name="edgeproto.ControllerApi"></a>
+<a name="edgeproto.ControllerApi"/>
 
 ### ControllerApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowController | [Controller](#edgeproto.Controller) | [Controller](#edgeproto.Controller) stream | Show Controllers |
+| ShowController | [Controller](#edgeproto.Controller) | [Controller](#edgeproto.Controller) | Show Controllers |
 
  
 
 
 
-<a name="developer.proto"></a>
+<a name="developer.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## developer.proto
 
 
 
-<a name="edgeproto.Developer"></a>
+<a name="edgeproto.Developer"/>
 
 ### Developer
 A Developer defines a Mobiledgex customer that can create and manage applications, clusters, instances, etc. Applications and other objects created by one Developer cannot be seen or managed by other Developers. Billing will likely be done on a per-developer basis.
@@ -1085,7 +1085,7 @@ TODO: user management, auth, etc is not implemented yet.
 
 
 
-<a name="edgeproto.DeveloperKey"></a>
+<a name="edgeproto.DeveloperKey"/>
 
 ### DeveloperKey
 DeveloperKey uniquely identifies a Developer (Mobiledgex customer)
@@ -1106,30 +1106,30 @@ DeveloperKey uniquely identifies a Developer (Mobiledgex customer)
  
 
 
-<a name="edgeproto.DeveloperApi"></a>
+<a name="edgeproto.DeveloperApi"/>
 
 ### DeveloperApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Result) | Create a Developer |
-| DeleteDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Result) | Delete a Developer |
-| UpdateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Result) | Update a Developer |
-| ShowDeveloper | [Developer](#edgeproto.Developer) | [Developer](#edgeproto.Developer) stream | Show Developers |
+| CreateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Developer) | Create a Developer |
+| DeleteDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Developer) | Delete a Developer |
+| UpdateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Developer) | Update a Developer |
+| ShowDeveloper | [Developer](#edgeproto.Developer) | [Developer](#edgeproto.Developer) | Show Developers |
 
  
 
 
 
-<a name="flavor.proto"></a>
+<a name="flavor.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## flavor.proto
 
 
 
-<a name="edgeproto.Flavor"></a>
+<a name="edgeproto.Flavor"/>
 
 ### Flavor
 A Flavor identifies the Cpu, Ram, and Disk resources required for either a node in a Cluster, or an application instance. For a node in a cluster, these are the physical resources provided by that node. For an application instance, this defines the resources (per node) that should be allocated to the instance from the Cluster.
@@ -1148,7 +1148,7 @@ A Flavor identifies the Cpu, Ram, and Disk resources required for either a node 
 
 
 
-<a name="edgeproto.FlavorKey"></a>
+<a name="edgeproto.FlavorKey"/>
 
 ### FlavorKey
 FlavorKey uniquely identifies a Flavor.
@@ -1169,30 +1169,30 @@ FlavorKey uniquely identifies a Flavor.
  
 
 
-<a name="edgeproto.FlavorApi"></a>
+<a name="edgeproto.FlavorApi"/>
 
 ### FlavorApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Result) | Create a Flavor |
-| DeleteFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Result) | Delete a Flavor |
-| UpdateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Result) | Update a Flavor |
-| ShowFlavor | [Flavor](#edgeproto.Flavor) | [Flavor](#edgeproto.Flavor) stream | Show Flavors |
+| CreateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Flavor) | Create a Flavor |
+| DeleteFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Flavor) | Delete a Flavor |
+| UpdateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Flavor) | Update a Flavor |
+| ShowFlavor | [Flavor](#edgeproto.Flavor) | [Flavor](#edgeproto.Flavor) | Show Flavors |
 
  
 
 
 
-<a name="metric.proto"></a>
+<a name="metric.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## metric.proto
 
 
 
-<a name="edgeproto.Metric"></a>
+<a name="edgeproto.Metric"/>
 
 ### Metric
 Metric is an entry/point in a time series of values for Analytics/Billing.
@@ -1210,7 +1210,7 @@ Metric is an entry/point in a time series of values for Analytics/Billing.
 
 
 
-<a name="edgeproto.MetricTag"></a>
+<a name="edgeproto.MetricTag"/>
 
 ### MetricTag
 MetricTag is used as a tag or label to look up the metric, beyond just the name of the metric.
@@ -1226,7 +1226,7 @@ MetricTag is used as a tag or label to look up the metric, beyond just the name 
 
 
 
-<a name="edgeproto.MetricVal"></a>
+<a name="edgeproto.MetricVal"/>
 
 ### MetricVal
 MetricVal is a value associated with the metric.
@@ -1252,14 +1252,14 @@ MetricVal is a value associated with the metric.
 
 
 
-<a name="node.proto"></a>
+<a name="node.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## node.proto
 
 
 
-<a name="edgeproto.Node"></a>
+<a name="edgeproto.Node"/>
 
 ### Node
 Node defines a DME (distributed matching engine) or CRM (cloudlet resource manager) instance.
@@ -1276,7 +1276,7 @@ Node defines a DME (distributed matching engine) or CRM (cloudlet resource manag
 
 
 
-<a name="edgeproto.NodeKey"></a>
+<a name="edgeproto.NodeKey"/>
 
 ### NodeKey
 NodeKey uniquely identifies a DME or CRM node
@@ -1295,7 +1295,7 @@ NodeKey uniquely identifies a DME or CRM node
  
 
 
-<a name="edgeproto.NodeType"></a>
+<a name="edgeproto.NodeType"/>
 
 ### NodeType
 NodeType defines the type of Node
@@ -1312,21 +1312,21 @@ NodeType defines the type of Node
  
 
 
-<a name="edgeproto.NodeApi"></a>
+<a name="edgeproto.NodeApi"/>
 
 ### NodeApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowNodeLocal | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) stream | Show Nodes connected locally only |
-| ShowNode | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) stream | Show all Nodes connected to all Controllers |
+| ShowNodeLocal | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) | Show Nodes connected locally only |
+| ShowNode | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) | Show all Nodes connected to all Controllers |
 
  
 
 
 
-<a name="notice.proto"></a>
+<a name="notice.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## notice.proto
@@ -1334,7 +1334,7 @@ Notice is the message used by the notify protocol to communicate and coordinate 
 In general, the protocol is used to synchronize state from one service to another. The protocol is fairly symmetric, with different state being synchronized both from server to client and client to server.
 
 
-<a name="edgeproto.Notice"></a>
+<a name="edgeproto.Notice"/>
 
 ### Notice
 
@@ -1355,7 +1355,7 @@ In general, the protocol is used to synchronize state from one service to anothe
  
 
 
-<a name="edgeproto.NoticeAction"></a>
+<a name="edgeproto.NoticeAction"/>
 
 ### NoticeAction
 NoticeAction denotes what kind of action this notification is for.
@@ -1374,27 +1374,27 @@ NoticeAction denotes what kind of action this notification is for.
  
 
 
-<a name="edgeproto.NotifyApi"></a>
+<a name="edgeproto.NotifyApi"/>
 
 ### NotifyApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| StreamNotice | [Notice](#edgeproto.Notice) stream | [Notice](#edgeproto.Notice) stream | Bidrectional stream for exchanging data between controller and DME/CRM |
+| StreamNotice | [Notice](#edgeproto.Notice) | [Notice](#edgeproto.Notice) | Bidrectional stream for exchanging data between controller and DME/CRM |
 
  
 
 
 
-<a name="operator.proto"></a>
+<a name="operator.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## operator.proto
 
 
 
-<a name="edgeproto.Operator"></a>
+<a name="edgeproto.Operator"/>
 
 ### Operator
 An Operator defines a telecommunications provider such as AT&amp;T, T-Mobile, etc. The operators in turn provide Mobiledgex with compute resource Cloudlets that serve as the basis for location-based services.
@@ -1410,7 +1410,7 @@ An Operator defines a telecommunications provider such as AT&amp;T, T-Mobile, et
 
 
 
-<a name="edgeproto.OperatorKey"></a>
+<a name="edgeproto.OperatorKey"/>
 
 ### OperatorKey
 OperatorKey uniquely identifies an Operator
@@ -1431,30 +1431,30 @@ OperatorKey uniquely identifies an Operator
  
 
 
-<a name="edgeproto.OperatorApi"></a>
+<a name="edgeproto.OperatorApi"/>
 
 ### OperatorApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Result) | Create an Operator |
-| DeleteOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Result) | Delete an Operator |
-| UpdateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Result) | Update an Operator |
-| ShowOperator | [Operator](#edgeproto.Operator) | [Operator](#edgeproto.Operator) stream | Show Operators |
+| CreateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Operator) | Create an Operator |
+| DeleteOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Operator) | Delete an Operator |
+| UpdateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Operator) | Update an Operator |
+| ShowOperator | [Operator](#edgeproto.Operator) | [Operator](#edgeproto.Operator) | Show Operators |
 
  
 
 
 
-<a name="refs.proto"></a>
+<a name="refs.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## refs.proto
 
 
 
-<a name="edgeproto.CloudletRefs"></a>
+<a name="edgeproto.CloudletRefs"/>
 
 ### CloudletRefs
 CloudletRefs track used resources and Clusters instantiated on a Cloudlet. Used resources are compared against max resources for a Cloudlet to determine if resources are available for a new Cluster to be instantiated on the Cloudlet.
@@ -1476,7 +1476,7 @@ CloudletRefs track used resources and Clusters instantiated on a Cloudlet. Used 
 
 
 
-<a name="edgeproto.CloudletRefs.RootLbPortsEntry"></a>
+<a name="edgeproto.CloudletRefs.RootLbPortsEntry"/>
 
 ### CloudletRefs.RootLbPortsEntry
 
@@ -1492,7 +1492,7 @@ CloudletRefs track used resources and Clusters instantiated on a Cloudlet. Used 
 
 
 
-<a name="edgeproto.ClusterRefs"></a>
+<a name="edgeproto.ClusterRefs"/>
 
 ### ClusterRefs
 ClusterRefs track used resources within a ClusterInst. Each AppInst specifies a set of required resources (Flavor), so tracking resources used by Apps within a Cluster is necessary to determine if enough resources are available for another AppInst to be instantiated on a ClusterInst.
@@ -1517,37 +1517,37 @@ ClusterRefs track used resources within a ClusterInst. Each AppInst specifies a 
  
 
 
-<a name="edgeproto.CloudletRefsApi"></a>
+<a name="edgeproto.CloudletRefsApi"/>
 
 ### CloudletRefsApi
 This API should be admin-only
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowCloudletRefs | [CloudletRefs](#edgeproto.CloudletRefs) | [CloudletRefs](#edgeproto.CloudletRefs) stream | Show CloudletRefs (debug only) |
+| ShowCloudletRefs | [CloudletRefs](#edgeproto.CloudletRefs) | [CloudletRefs](#edgeproto.CloudletRefs) | Show CloudletRefs (debug only) |
 
 
-<a name="edgeproto.ClusterRefsApi"></a>
+<a name="edgeproto.ClusterRefsApi"/>
 
 ### ClusterRefsApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowClusterRefs | [ClusterRefs](#edgeproto.ClusterRefs) | [ClusterRefs](#edgeproto.ClusterRefs) stream | Show ClusterRefs (debug only) |
+| ShowClusterRefs | [ClusterRefs](#edgeproto.ClusterRefs) | [ClusterRefs](#edgeproto.ClusterRefs) | Show ClusterRefs (debug only) |
 
  
 
 
 
-<a name="result.proto"></a>
+<a name="result.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## result.proto
 
 
 
-<a name="edgeproto.Result"></a>
+<a name="edgeproto.Result"/>
 
 ### Result
 Result is a generic object for returning the result of an API call. In general, result is not used. The error value returned by the GRPC API call is used instead.

--- a/edgeproto/doc/index.html
+++ b/edgeproto/doc/index.html
@@ -4,7 +4,7 @@
   <head>
     <title>Protocol Documentation</title>
     <meta charset="UTF-8">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic"/>
+    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic"/>
     <style>
       body {
         width: 60em;
@@ -936,7 +936,7 @@ on behalf of this app, such as FindCloudlet </p></td>
               <tr>
                 <td>ShowApp</td>
                 <td><a href="#edgeproto.App">App</a></td>
-                <td><a href="#edgeproto.App">App</a> stream</td>
+                <td><a href="#edgeproto.App">App</a></td>
                 <td><p>Show applications. Any fields specified will be used to filter results.</p></td>
               </tr>
             
@@ -1191,28 +1191,28 @@ redundant unless they&#39;re needed for billing. </p></td>
               <tr>
                 <td>CreateAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Create an application instance</p></td>
               </tr>
             
               <tr>
                 <td>DeleteAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Delete an application instance</p></td>
               </tr>
             
               <tr>
                 <td>UpdateAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Update an application instance</p></td>
               </tr>
             
               <tr>
                 <td>ShowAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.AppInst">AppInst</a> stream</td>
+                <td><a href="#edgeproto.AppInst">AppInst</a></td>
                 <td><p>Show application instances. Any fields specified will be used to filter results.</p></td>
               </tr>
             
@@ -1230,7 +1230,7 @@ redundant unless they&#39;re needed for billing. </p></td>
               <tr>
                 <td>ShowAppInstInfo</td>
                 <td><a href="#edgeproto.AppInstInfo">AppInstInfo</a></td>
-                <td><a href="#edgeproto.AppInstInfo">AppInstInfo</a> stream</td>
+                <td><a href="#edgeproto.AppInstInfo">AppInstInfo</a></td>
                 <td><p>Show application instances state.</p></td>
               </tr>
             
@@ -1248,7 +1248,7 @@ redundant unless they&#39;re needed for billing. </p></td>
               <tr>
                 <td>ShowAppInstMetrics</td>
                 <td><a href="#edgeproto.AppInstMetrics">AppInstMetrics</a></td>
-                <td><a href="#edgeproto.AppInstMetrics">AppInstMetrics</a> stream</td>
+                <td><a href="#edgeproto.AppInstMetrics">AppInstMetrics</a></td>
                 <td><p>Show application instance metrics.</p></td>
               </tr>
             
@@ -1585,7 +1585,7 @@ is configurable here. This will need to be removed later. </p></td>
               <tr>
                 <td>ListCloudResource</td>
                 <td><a href="#edgeproto.CloudResource">CloudResource</a></td>
-                <td><a href="#edgeproto.CloudResource">CloudResource</a> stream</td>
+                <td><a href="#edgeproto.CloudResource">CloudResource</a></td>
                 <td><p></p></td>
               </tr>
             
@@ -1885,28 +1885,28 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>CreateCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Create a Cloudlet</p></td>
               </tr>
             
               <tr>
                 <td>DeleteCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Delete a Cloudlet</p></td>
               </tr>
             
               <tr>
                 <td>UpdateCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Update a Cloudlet</p></td>
               </tr>
             
               <tr>
                 <td>ShowCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Cloudlet">Cloudlet</a> stream</td>
+                <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
                 <td><p>Show Cloudlets</p></td>
               </tr>
             
@@ -1924,7 +1924,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowCloudletInfo</td>
                 <td><a href="#edgeproto.CloudletInfo">CloudletInfo</a></td>
-                <td><a href="#edgeproto.CloudletInfo">CloudletInfo</a> stream</td>
+                <td><a href="#edgeproto.CloudletInfo">CloudletInfo</a></td>
                 <td><p>Show CloudletInfos</p></td>
               </tr>
             
@@ -1956,7 +1956,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowCloudletMetrics</td>
                 <td><a href="#edgeproto.CloudletMetrics">CloudletMetrics</a></td>
-                <td><a href="#edgeproto.CloudletMetrics">CloudletMetrics</a> stream</td>
+                <td><a href="#edgeproto.CloudletMetrics">CloudletMetrics</a></td>
                 <td><p>Show Cloudlet metrics</p></td>
               </tr>
             
@@ -2076,7 +2076,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowCluster</td>
                 <td><a href="#edgeproto.Cluster">Cluster</a></td>
-                <td><a href="#edgeproto.Cluster">Cluster</a> stream</td>
+                <td><a href="#edgeproto.Cluster">Cluster</a></td>
                 <td><p>Show Clusters</p></td>
               </tr>
             
@@ -2217,7 +2217,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowClusterFlavor</td>
                 <td><a href="#edgeproto.ClusterFlavor">ClusterFlavor</a></td>
-                <td><a href="#edgeproto.ClusterFlavor">ClusterFlavor</a> stream</td>
+                <td><a href="#edgeproto.ClusterFlavor">ClusterFlavor</a></td>
                 <td><p>Show ClusterFlavors</p></td>
               </tr>
             
@@ -2402,28 +2402,28 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>CreateClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Create a Cluster instance</p></td>
               </tr>
             
               <tr>
                 <td>DeleteClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Delete a Cluster instance</p></td>
               </tr>
             
               <tr>
                 <td>UpdateClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Update a Cluster instance</p></td>
               </tr>
             
               <tr>
                 <td>ShowClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.ClusterInst">ClusterInst</a> stream</td>
+                <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
                 <td><p>Show Cluster instances</p></td>
               </tr>
             
@@ -2441,7 +2441,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowClusterInstInfo</td>
                 <td><a href="#edgeproto.ClusterInstInfo">ClusterInstInfo</a></td>
-                <td><a href="#edgeproto.ClusterInstInfo">ClusterInstInfo</a> stream</td>
+                <td><a href="#edgeproto.ClusterInstInfo">ClusterInstInfo</a></td>
                 <td><p>Show Cluster instances state.</p></td>
               </tr>
             
@@ -2757,7 +2757,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowController</td>
                 <td><a href="#edgeproto.Controller">Controller</a></td>
-                <td><a href="#edgeproto.Controller">Controller</a> stream</td>
+                <td><a href="#edgeproto.Controller">Controller</a></td>
                 <td><p>Show Controllers</p></td>
               </tr>
             
@@ -2891,7 +2891,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowDeveloper</td>
                 <td><a href="#edgeproto.Developer">Developer</a></td>
-                <td><a href="#edgeproto.Developer">Developer</a> stream</td>
+                <td><a href="#edgeproto.Developer">Developer</a></td>
                 <td><p>Show Developers</p></td>
               </tr>
             
@@ -3018,7 +3018,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowFlavor</td>
                 <td><a href="#edgeproto.Flavor">Flavor</a></td>
-                <td><a href="#edgeproto.Flavor">Flavor</a> stream</td>
+                <td><a href="#edgeproto.Flavor">Flavor</a></td>
                 <td><p>Show Flavors</p></td>
               </tr>
             
@@ -3278,14 +3278,14 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowNodeLocal</td>
                 <td><a href="#edgeproto.Node">Node</a></td>
-                <td><a href="#edgeproto.Node">Node</a> stream</td>
+                <td><a href="#edgeproto.Node">Node</a></td>
                 <td><p>Show Nodes connected locally only</p></td>
               </tr>
             
               <tr>
                 <td>ShowNode</td>
                 <td><a href="#edgeproto.Node">Node</a></td>
-                <td><a href="#edgeproto.Node">Node</a> stream</td>
+                <td><a href="#edgeproto.Node">Node</a></td>
                 <td><p>Show all Nodes connected to all Controllers</p></td>
               </tr>
             
@@ -3408,8 +3408,8 @@ Certs for accessing cloudlet site </p></td>
             
               <tr>
                 <td>StreamNotice</td>
-                <td><a href="#edgeproto.Notice">Notice</a> stream</td>
-                <td><a href="#edgeproto.Notice">Notice</a> stream</td>
+                <td><a href="#edgeproto.Notice">Notice</a></td>
+                <td><a href="#edgeproto.Notice">Notice</a></td>
                 <td><p>Bidrectional stream for exchanging data between controller and DME/CRM</p></td>
               </tr>
             
@@ -3515,7 +3515,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowOperator</td>
                 <td><a href="#edgeproto.Operator">Operator</a></td>
-                <td><a href="#edgeproto.Operator">Operator</a> stream</td>
+                <td><a href="#edgeproto.Operator">Operator</a></td>
                 <td><p>Show Operators</p></td>
               </tr>
             
@@ -3700,7 +3700,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowCloudletRefs</td>
                 <td><a href="#edgeproto.CloudletRefs">CloudletRefs</a></td>
-                <td><a href="#edgeproto.CloudletRefs">CloudletRefs</a> stream</td>
+                <td><a href="#edgeproto.CloudletRefs">CloudletRefs</a></td>
                 <td><p>Show CloudletRefs (debug only)</p></td>
               </tr>
             
@@ -3718,7 +3718,7 @@ Certs for accessing cloudlet site </p></td>
               <tr>
                 <td>ShowClusterRefs</td>
                 <td><a href="#edgeproto.ClusterRefs">ClusterRefs</a></td>
-                <td><a href="#edgeproto.ClusterRefs">ClusterRefs</a> stream</td>
+                <td><a href="#edgeproto.ClusterRefs">ClusterRefs</a></td>
                 <td><p>Show ClusterRefs (debug only)</p></td>
               </tr>
             

--- a/protoc-gen-test/testcud.go
+++ b/protoc-gen-test/testcud.go
@@ -179,20 +179,22 @@ type {{.Name}}CommonApi struct {
 {{- if not .ShowOnly}}
 {{range .CudFuncs}}
 func (x *{{.Name}}CommonApi) {{.Func}}{{.Name}}(ctx context.Context, in *{{.Pkg}}.{{.Name}}) (*{{.Pkg}}.Result, error) {
+	copy := &{{.Pkg}}.{{.Name}}{}
+	*copy = *in
 {{- if .Streamout}}
 	if x.internal_api != nil {
-		err := x.internal_api.{{.Func}}{{.Name}}(in, &CudStreamout{{.Name}}{})
+		err := x.internal_api.{{.Func}}{{.Name}}(copy, &CudStreamout{{.Name}}{})
 		return &{{.Pkg}}.Result{}, err
 	} else {
-		stream, err := x.client_api.{{.Func}}{{.Name}}(ctx, in)
+		stream, err := x.client_api.{{.Func}}{{.Name}}(ctx, copy)
 		err = {{.Name}}ReadResultStream(stream, err)
 		return &{{.Pkg}}.Result{}, err
 	}
 {{- else}}
 	if x.internal_api != nil {
-		return x.internal_api.{{.Func}}{{.Name}}(ctx, in)
+		return x.internal_api.{{.Func}}{{.Name}}(ctx, copy)
 	} else {
-		return x.client_api.{{.Func}}{{.Name}}(ctx, in)
+		return x.client_api.{{.Func}}{{.Name}}(ctx, copy)
 	}
 {{- end}}
 }

--- a/testutil/app_inst_testutil.go
+++ b/testutil/app_inst_testutil.go
@@ -151,33 +151,39 @@ type AppInstCommonApi struct {
 }
 
 func (x *AppInstCommonApi) CreateAppInst(ctx context.Context, in *edgeproto.AppInst) (*edgeproto.Result, error) {
+	copy := &edgeproto.AppInst{}
+	*copy = *in
 	if x.internal_api != nil {
-		err := x.internal_api.CreateAppInst(in, &CudStreamoutAppInst{})
+		err := x.internal_api.CreateAppInst(copy, &CudStreamoutAppInst{})
 		return &edgeproto.Result{}, err
 	} else {
-		stream, err := x.client_api.CreateAppInst(ctx, in)
+		stream, err := x.client_api.CreateAppInst(ctx, copy)
 		err = AppInstReadResultStream(stream, err)
 		return &edgeproto.Result{}, err
 	}
 }
 
 func (x *AppInstCommonApi) UpdateAppInst(ctx context.Context, in *edgeproto.AppInst) (*edgeproto.Result, error) {
+	copy := &edgeproto.AppInst{}
+	*copy = *in
 	if x.internal_api != nil {
-		err := x.internal_api.UpdateAppInst(in, &CudStreamoutAppInst{})
+		err := x.internal_api.UpdateAppInst(copy, &CudStreamoutAppInst{})
 		return &edgeproto.Result{}, err
 	} else {
-		stream, err := x.client_api.UpdateAppInst(ctx, in)
+		stream, err := x.client_api.UpdateAppInst(ctx, copy)
 		err = AppInstReadResultStream(stream, err)
 		return &edgeproto.Result{}, err
 	}
 }
 
 func (x *AppInstCommonApi) DeleteAppInst(ctx context.Context, in *edgeproto.AppInst) (*edgeproto.Result, error) {
+	copy := &edgeproto.AppInst{}
+	*copy = *in
 	if x.internal_api != nil {
-		err := x.internal_api.DeleteAppInst(in, &CudStreamoutAppInst{})
+		err := x.internal_api.DeleteAppInst(copy, &CudStreamoutAppInst{})
 		return &edgeproto.Result{}, err
 	} else {
-		stream, err := x.client_api.DeleteAppInst(ctx, in)
+		stream, err := x.client_api.DeleteAppInst(ctx, copy)
 		err = AppInstReadResultStream(stream, err)
 		return &edgeproto.Result{}, err
 	}

--- a/testutil/app_testutil.go
+++ b/testutil/app_testutil.go
@@ -178,26 +178,32 @@ type AppCommonApi struct {
 }
 
 func (x *AppCommonApi) CreateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.Result, error) {
+	copy := &edgeproto.App{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.CreateApp(ctx, in)
+		return x.internal_api.CreateApp(ctx, copy)
 	} else {
-		return x.client_api.CreateApp(ctx, in)
+		return x.client_api.CreateApp(ctx, copy)
 	}
 }
 
 func (x *AppCommonApi) UpdateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.Result, error) {
+	copy := &edgeproto.App{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.UpdateApp(ctx, in)
+		return x.internal_api.UpdateApp(ctx, copy)
 	} else {
-		return x.client_api.UpdateApp(ctx, in)
+		return x.client_api.UpdateApp(ctx, copy)
 	}
 }
 
 func (x *AppCommonApi) DeleteApp(ctx context.Context, in *edgeproto.App) (*edgeproto.Result, error) {
+	copy := &edgeproto.App{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.DeleteApp(ctx, in)
+		return x.internal_api.DeleteApp(ctx, copy)
 	} else {
-		return x.client_api.DeleteApp(ctx, in)
+		return x.client_api.DeleteApp(ctx, copy)
 	}
 }
 

--- a/testutil/cloudlet_testutil.go
+++ b/testutil/cloudlet_testutil.go
@@ -150,33 +150,39 @@ type CloudletCommonApi struct {
 }
 
 func (x *CloudletCommonApi) CreateCloudlet(ctx context.Context, in *edgeproto.Cloudlet) (*edgeproto.Result, error) {
+	copy := &edgeproto.Cloudlet{}
+	*copy = *in
 	if x.internal_api != nil {
-		err := x.internal_api.CreateCloudlet(in, &CudStreamoutCloudlet{})
+		err := x.internal_api.CreateCloudlet(copy, &CudStreamoutCloudlet{})
 		return &edgeproto.Result{}, err
 	} else {
-		stream, err := x.client_api.CreateCloudlet(ctx, in)
+		stream, err := x.client_api.CreateCloudlet(ctx, copy)
 		err = CloudletReadResultStream(stream, err)
 		return &edgeproto.Result{}, err
 	}
 }
 
 func (x *CloudletCommonApi) UpdateCloudlet(ctx context.Context, in *edgeproto.Cloudlet) (*edgeproto.Result, error) {
+	copy := &edgeproto.Cloudlet{}
+	*copy = *in
 	if x.internal_api != nil {
-		err := x.internal_api.UpdateCloudlet(in, &CudStreamoutCloudlet{})
+		err := x.internal_api.UpdateCloudlet(copy, &CudStreamoutCloudlet{})
 		return &edgeproto.Result{}, err
 	} else {
-		stream, err := x.client_api.UpdateCloudlet(ctx, in)
+		stream, err := x.client_api.UpdateCloudlet(ctx, copy)
 		err = CloudletReadResultStream(stream, err)
 		return &edgeproto.Result{}, err
 	}
 }
 
 func (x *CloudletCommonApi) DeleteCloudlet(ctx context.Context, in *edgeproto.Cloudlet) (*edgeproto.Result, error) {
+	copy := &edgeproto.Cloudlet{}
+	*copy = *in
 	if x.internal_api != nil {
-		err := x.internal_api.DeleteCloudlet(in, &CudStreamoutCloudlet{})
+		err := x.internal_api.DeleteCloudlet(copy, &CudStreamoutCloudlet{})
 		return &edgeproto.Result{}, err
 	} else {
-		stream, err := x.client_api.DeleteCloudlet(ctx, in)
+		stream, err := x.client_api.DeleteCloudlet(ctx, copy)
 		err = CloudletReadResultStream(stream, err)
 		return &edgeproto.Result{}, err
 	}

--- a/testutil/cluster_testutil.go
+++ b/testutil/cluster_testutil.go
@@ -117,26 +117,32 @@ type ClusterCommonApi struct {
 }
 
 func (x *ClusterCommonApi) CreateCluster(ctx context.Context, in *edgeproto.Cluster) (*edgeproto.Result, error) {
+	copy := &edgeproto.Cluster{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.CreateCluster(ctx, in)
+		return x.internal_api.CreateCluster(ctx, copy)
 	} else {
-		return x.client_api.CreateCluster(ctx, in)
+		return x.client_api.CreateCluster(ctx, copy)
 	}
 }
 
 func (x *ClusterCommonApi) UpdateCluster(ctx context.Context, in *edgeproto.Cluster) (*edgeproto.Result, error) {
+	copy := &edgeproto.Cluster{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.UpdateCluster(ctx, in)
+		return x.internal_api.UpdateCluster(ctx, copy)
 	} else {
-		return x.client_api.UpdateCluster(ctx, in)
+		return x.client_api.UpdateCluster(ctx, copy)
 	}
 }
 
 func (x *ClusterCommonApi) DeleteCluster(ctx context.Context, in *edgeproto.Cluster) (*edgeproto.Result, error) {
+	copy := &edgeproto.Cluster{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.DeleteCluster(ctx, in)
+		return x.internal_api.DeleteCluster(ctx, copy)
 	} else {
-		return x.client_api.DeleteCluster(ctx, in)
+		return x.client_api.DeleteCluster(ctx, copy)
 	}
 }
 

--- a/testutil/clusterflavor_testutil.go
+++ b/testutil/clusterflavor_testutil.go
@@ -117,26 +117,32 @@ type ClusterFlavorCommonApi struct {
 }
 
 func (x *ClusterFlavorCommonApi) CreateClusterFlavor(ctx context.Context, in *edgeproto.ClusterFlavor) (*edgeproto.Result, error) {
+	copy := &edgeproto.ClusterFlavor{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.CreateClusterFlavor(ctx, in)
+		return x.internal_api.CreateClusterFlavor(ctx, copy)
 	} else {
-		return x.client_api.CreateClusterFlavor(ctx, in)
+		return x.client_api.CreateClusterFlavor(ctx, copy)
 	}
 }
 
 func (x *ClusterFlavorCommonApi) UpdateClusterFlavor(ctx context.Context, in *edgeproto.ClusterFlavor) (*edgeproto.Result, error) {
+	copy := &edgeproto.ClusterFlavor{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.UpdateClusterFlavor(ctx, in)
+		return x.internal_api.UpdateClusterFlavor(ctx, copy)
 	} else {
-		return x.client_api.UpdateClusterFlavor(ctx, in)
+		return x.client_api.UpdateClusterFlavor(ctx, copy)
 	}
 }
 
 func (x *ClusterFlavorCommonApi) DeleteClusterFlavor(ctx context.Context, in *edgeproto.ClusterFlavor) (*edgeproto.Result, error) {
+	copy := &edgeproto.ClusterFlavor{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.DeleteClusterFlavor(ctx, in)
+		return x.internal_api.DeleteClusterFlavor(ctx, copy)
 	} else {
-		return x.client_api.DeleteClusterFlavor(ctx, in)
+		return x.client_api.DeleteClusterFlavor(ctx, copy)
 	}
 }
 

--- a/testutil/clusterinst_testutil.go
+++ b/testutil/clusterinst_testutil.go
@@ -149,33 +149,39 @@ type ClusterInstCommonApi struct {
 }
 
 func (x *ClusterInstCommonApi) CreateClusterInst(ctx context.Context, in *edgeproto.ClusterInst) (*edgeproto.Result, error) {
+	copy := &edgeproto.ClusterInst{}
+	*copy = *in
 	if x.internal_api != nil {
-		err := x.internal_api.CreateClusterInst(in, &CudStreamoutClusterInst{})
+		err := x.internal_api.CreateClusterInst(copy, &CudStreamoutClusterInst{})
 		return &edgeproto.Result{}, err
 	} else {
-		stream, err := x.client_api.CreateClusterInst(ctx, in)
+		stream, err := x.client_api.CreateClusterInst(ctx, copy)
 		err = ClusterInstReadResultStream(stream, err)
 		return &edgeproto.Result{}, err
 	}
 }
 
 func (x *ClusterInstCommonApi) UpdateClusterInst(ctx context.Context, in *edgeproto.ClusterInst) (*edgeproto.Result, error) {
+	copy := &edgeproto.ClusterInst{}
+	*copy = *in
 	if x.internal_api != nil {
-		err := x.internal_api.UpdateClusterInst(in, &CudStreamoutClusterInst{})
+		err := x.internal_api.UpdateClusterInst(copy, &CudStreamoutClusterInst{})
 		return &edgeproto.Result{}, err
 	} else {
-		stream, err := x.client_api.UpdateClusterInst(ctx, in)
+		stream, err := x.client_api.UpdateClusterInst(ctx, copy)
 		err = ClusterInstReadResultStream(stream, err)
 		return &edgeproto.Result{}, err
 	}
 }
 
 func (x *ClusterInstCommonApi) DeleteClusterInst(ctx context.Context, in *edgeproto.ClusterInst) (*edgeproto.Result, error) {
+	copy := &edgeproto.ClusterInst{}
+	*copy = *in
 	if x.internal_api != nil {
-		err := x.internal_api.DeleteClusterInst(in, &CudStreamoutClusterInst{})
+		err := x.internal_api.DeleteClusterInst(copy, &CudStreamoutClusterInst{})
 		return &edgeproto.Result{}, err
 	} else {
-		stream, err := x.client_api.DeleteClusterInst(ctx, in)
+		stream, err := x.client_api.DeleteClusterInst(ctx, copy)
 		err = ClusterInstReadResultStream(stream, err)
 		return &edgeproto.Result{}, err
 	}

--- a/testutil/developer_testutil.go
+++ b/testutil/developer_testutil.go
@@ -116,26 +116,32 @@ type DeveloperCommonApi struct {
 }
 
 func (x *DeveloperCommonApi) CreateDeveloper(ctx context.Context, in *edgeproto.Developer) (*edgeproto.Result, error) {
+	copy := &edgeproto.Developer{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.CreateDeveloper(ctx, in)
+		return x.internal_api.CreateDeveloper(ctx, copy)
 	} else {
-		return x.client_api.CreateDeveloper(ctx, in)
+		return x.client_api.CreateDeveloper(ctx, copy)
 	}
 }
 
 func (x *DeveloperCommonApi) UpdateDeveloper(ctx context.Context, in *edgeproto.Developer) (*edgeproto.Result, error) {
+	copy := &edgeproto.Developer{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.UpdateDeveloper(ctx, in)
+		return x.internal_api.UpdateDeveloper(ctx, copy)
 	} else {
-		return x.client_api.UpdateDeveloper(ctx, in)
+		return x.client_api.UpdateDeveloper(ctx, copy)
 	}
 }
 
 func (x *DeveloperCommonApi) DeleteDeveloper(ctx context.Context, in *edgeproto.Developer) (*edgeproto.Result, error) {
+	copy := &edgeproto.Developer{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.DeleteDeveloper(ctx, in)
+		return x.internal_api.DeleteDeveloper(ctx, copy)
 	} else {
-		return x.client_api.DeleteDeveloper(ctx, in)
+		return x.client_api.DeleteDeveloper(ctx, copy)
 	}
 }
 

--- a/testutil/flavor_testutil.go
+++ b/testutil/flavor_testutil.go
@@ -117,26 +117,32 @@ type FlavorCommonApi struct {
 }
 
 func (x *FlavorCommonApi) CreateFlavor(ctx context.Context, in *edgeproto.Flavor) (*edgeproto.Result, error) {
+	copy := &edgeproto.Flavor{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.CreateFlavor(ctx, in)
+		return x.internal_api.CreateFlavor(ctx, copy)
 	} else {
-		return x.client_api.CreateFlavor(ctx, in)
+		return x.client_api.CreateFlavor(ctx, copy)
 	}
 }
 
 func (x *FlavorCommonApi) UpdateFlavor(ctx context.Context, in *edgeproto.Flavor) (*edgeproto.Result, error) {
+	copy := &edgeproto.Flavor{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.UpdateFlavor(ctx, in)
+		return x.internal_api.UpdateFlavor(ctx, copy)
 	} else {
-		return x.client_api.UpdateFlavor(ctx, in)
+		return x.client_api.UpdateFlavor(ctx, copy)
 	}
 }
 
 func (x *FlavorCommonApi) DeleteFlavor(ctx context.Context, in *edgeproto.Flavor) (*edgeproto.Result, error) {
+	copy := &edgeproto.Flavor{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.DeleteFlavor(ctx, in)
+		return x.internal_api.DeleteFlavor(ctx, copy)
 	} else {
-		return x.client_api.DeleteFlavor(ctx, in)
+		return x.client_api.DeleteFlavor(ctx, copy)
 	}
 }
 

--- a/testutil/operator_testutil.go
+++ b/testutil/operator_testutil.go
@@ -116,26 +116,32 @@ type OperatorCommonApi struct {
 }
 
 func (x *OperatorCommonApi) CreateOperator(ctx context.Context, in *edgeproto.Operator) (*edgeproto.Result, error) {
+	copy := &edgeproto.Operator{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.CreateOperator(ctx, in)
+		return x.internal_api.CreateOperator(ctx, copy)
 	} else {
-		return x.client_api.CreateOperator(ctx, in)
+		return x.client_api.CreateOperator(ctx, copy)
 	}
 }
 
 func (x *OperatorCommonApi) UpdateOperator(ctx context.Context, in *edgeproto.Operator) (*edgeproto.Result, error) {
+	copy := &edgeproto.Operator{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.UpdateOperator(ctx, in)
+		return x.internal_api.UpdateOperator(ctx, copy)
 	} else {
-		return x.client_api.UpdateOperator(ctx, in)
+		return x.client_api.UpdateOperator(ctx, copy)
 	}
 }
 
 func (x *OperatorCommonApi) DeleteOperator(ctx context.Context, in *edgeproto.Operator) (*edgeproto.Result, error) {
+	copy := &edgeproto.Operator{}
+	*copy = *in
 	if x.internal_api != nil {
-		return x.internal_api.DeleteOperator(ctx, in)
+		return x.internal_api.DeleteOperator(ctx, copy)
 	} else {
-		return x.client_api.DeleteOperator(ctx, in)
+		return x.client_api.DeleteOperator(ctx, copy)
 	}
 }
 

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -395,7 +395,6 @@ var AppInstData = []edgeproto.AppInst{
 			Id:          1,
 		},
 		CloudletLoc: CloudletData[0].Location,
-		Uri:         "10.100.10.1",
 		// Cluster is ClusterData[0]
 	},
 	edgeproto.AppInst{
@@ -405,7 +404,6 @@ var AppInstData = []edgeproto.AppInst{
 			Id:          2,
 		},
 		CloudletLoc: CloudletData[0].Location,
-		Uri:         "10.100.10.2",
 		// Cluster is ClusterData[0]
 	},
 	edgeproto.AppInst{
@@ -415,7 +413,6 @@ var AppInstData = []edgeproto.AppInst{
 			Id:          1,
 		},
 		CloudletLoc: CloudletData[1].Location,
-		Uri:         "pokemon.ny.mex.io",
 		// Cluster is ClusterData[0]
 	},
 	edgeproto.AppInst{
@@ -425,7 +422,6 @@ var AppInstData = []edgeproto.AppInst{
 			Id:          1,
 		},
 		CloudletLoc: CloudletData[1].Location,
-		Uri:         "pokemon.ny.mex.io",
 		// Cluster is ClusterAutoData[0]
 	},
 	edgeproto.AppInst{
@@ -435,7 +431,6 @@ var AppInstData = []edgeproto.AppInst{
 			Id:          1,
 		},
 		CloudletLoc: CloudletData[2].Location,
-		Uri:         "harrypotter.sf.mex.io",
 		// Cluster is ClusterAutoData[1]
 	},
 	edgeproto.AppInst{


### PR DESCRIPTION
This fixes unit tests that were broken by changes to AppInst.Uri checks added recently. Some of the unit tests end up adding a Uri to the test data during create. When the test data gets reused later for other tests, the non-blank Uri then triggers a failure. So during these tests we make a copy of the testdata so the original testdata is not modified by the AppInst Create function.