### PR TITLE
fix e2e test failures

### DIFF
--- a/cluster-svc/cluster-svc-main.go
+++ b/cluster-svc/cluster-svc-main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strings"
@@ -145,7 +146,20 @@ func createAppInstCommon(dialOpts grpc.DialOption, instKey edgeproto.ClusterInst
 	}
 
 	ctx := context.TODO()
-	_, err = apiClient.CreateAppInst(ctx, &appInst)
+	stream, err := apiClient.CreateAppInst(ctx, &appInst)
+	var res *edgeproto.Result
+	if err == nil {
+		for {
+			res, err = stream.Recv()
+			if err == io.EOF {
+				err = nil
+				break
+			}
+			if err != nil {
+				break
+			}
+		}
+	}
 	if err != nil {
 		errstr := err.Error()
 		st, ok := status.FromError(err)
@@ -154,7 +168,7 @@ func createAppInstCommon(dialOpts grpc.DialOption, instKey edgeproto.ClusterInst
 		}
 		return fmt.Errorf("CreateAppInst failed: %s", errstr)
 	}
-	log.DebugLog(log.DebugLevelMexos, "create appinst", "appinst", appInst.String())
+	log.DebugLog(log.DebugLevelMexos, "create appinst", "appinst", appInst.String(), "result", res.String())
 	return nil
 
 }

--- a/setup-env/e2e-tests/data/appdata_no_cluster.yml
+++ b/setup-env/e2e-tests/data/appdata_no_cluster.yml
@@ -106,7 +106,6 @@ appinstances:
   cloudletloc:
     latitude: 31
     longitude: -91
-  uri: someapplication1.tmus-cloud-1.mobiledgex.net
   liveness: LivenessStatic
   flavor:
     name: x1.small
@@ -124,7 +123,6 @@ appinstances:
   cloudletloc:
     latitude: 35
     longitude: -95
-  uri: someapplication1.tmus-cloud-2.mobiledgex.net
   liveness: LivenessStatic
   flavor:
     name: x1.small

--- a/setup-env/e2e-tests/setups/local_multi.yml
+++ b/setup-env/e2e-tests/setups/local_multi.yml
@@ -96,7 +96,7 @@ clustersvcs:
   hostname: "127.0.0.1"
 
 - clustersvclocal:
-    name: clister-svc2
+    name: cluster-svc2
     notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
     ctrladdrs: "127.0.0.1:55002"
     tls:


### PR DESCRIPTION
This fixes issues causing some of the e2e tests to fail. Some were issues with test-only data and some were actual bugs in the code.

One thing to pay attention to is for grpc stream-out funcs, the stream must be read until it returns EOF. Otherwise the client could prematurely end the connection before the server is done and cause the server to abort the function early.

All the e2e test for "make test" are now passing.