### PR TITLE
missing wakeup call in notify send message

### DIFF
--- a/protoc-gen-notify/gennotify.go
+++ b/protoc-gen-notify/gennotify.go
@@ -216,6 +216,7 @@ func (s *{{.Name}}Send) Update(msg *{{.NameType}}) {
 	s.Mux.Lock()
 	s.Data = append(s.Data, msg)
 	s.Mux.Unlock()
+	s.sendrecv.wakeup()
 }
 {{- end}}
 


### PR DESCRIPTION
This fixes a memory leak Jim ran into a tracked down to the notify code. My recent re-org missed a call to wakeup the send thread for metric-type messages, which caused the queued metrics to build up over time and hog memory.