### PR TITLE
prometheus for dind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,10 @@ test-sdk:
 
 ## note: DIND requires make from edge-cloud-infra to install dependencies
 test-dind-start:
-	e2e-tests -testfile ./setup-env/e2e-tests/testfiles/deploy_start_create_dind.yml -setupfile ./setup-env/e2e-tests/setups/local_dind.yml
+	e2e-tests -testfile ./setup-env/e2e-tests/testfiles/deploy_start_create_dind.yml -setupfile ./setup-env/e2e-tests/setups/local_dind.yml -notimestamp
 
 test-dind-stop:
-	e2e-tests -testfile ./setup-env/e2e-tests/testfiles/delete_dind_stop_cleanup.yml -setupfile ./setup-env/e2e-tests/setups/local_dind.yml
+	e2e-tests -testfile ./setup-env/e2e-tests/testfiles/delete_dind_stop_cleanup.yml -setupfile ./setup-env/e2e-tests/setups/local_dind.yml -notimestamp
 
 
 clean:

--- a/cluster-svc/cluster-svc-main.go
+++ b/cluster-svc/cluster-svc-main.go
@@ -62,6 +62,7 @@ var MEXPrometheusApp = edgeproto.App{
 	Deployment:    cloudcommon.AppDeploymentTypeHelm,
 	DefaultFlavor: edgeproto.FlavorKey{Name: "x1.medium"}, // TODO flavor
 	DelOpt:        edgeproto.DeleteType_AutoDelete,
+	AccessPorts:   "tcp:9090",
 }
 
 var dialOpts grpc.DialOption

--- a/setup-env/e2e-tests/setups/local_dind.yml
+++ b/setup-env/e2e-tests/setups/local_dind.yml
@@ -124,3 +124,12 @@ crms:
        clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
 
+clustersvcs:
+- clustersvclocal:
+    name: cluster-svc1
+    notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+    ctrladdrs: "127.0.0.1:55001"
+    tls:
+       servercert: "{{tlsoutdir}}/mex-server.crt"
+       clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "127.0.0.1"


### PR DESCRIPTION
This adds cluster-svc to the local_dind setup so that it will create helm prometheus pods to monitor cluster metrics on dind.