### PR TITLE
EDGECLOUD-72 Adding cluster-svc example deployment yaml

### DIFF
--- a/cluster-svc/cluster-svc-main.go
+++ b/cluster-svc/cluster-svc-main.go
@@ -25,6 +25,9 @@ var ctrlAddr = flag.String("ctrlAddrs", "127.0.0.1:55001", "address to connect t
 var standalone = flag.Bool("standalone", false, "Standalone mode. AppInst data is pre-populated. Dme does not interact with controller. AppInsts can be created directly on Dme using controller AppInst API")
 var debugLevels = flag.String("d", "", fmt.Sprintf("comma separated list of %v", log.DebugLevelStrings))
 var tlsCertFile = flag.String("tls", "", "server tls cert file.  Keyfile and CA file mex-ca.crt must be in same directory")
+var influxDBAddr = flag.String("influxdb", "0.0.0.0:8086", "InfluxDB address to export to")
+var influxDBUser = flag.String("influxdb-user", "root", "InfluxDB username")
+var influxDBPass = flag.String("influxdb-pass", "root", "InfluxDB password")
 
 // Hard coded username - TODO to move to user db
 var MEXDeveloper = "mexinfradev_"

--- a/docker/Dockerfile.edge-cloud
+++ b/docker/Dockerfile.edge-cloud
@@ -30,6 +30,7 @@ COPY --from=build /go/bin/controller /usr/local/bin
 COPY --from=build /go/bin/crmctl /usr/local/bin
 COPY --from=build /go/bin/crmserver /usr/local/bin
 COPY --from=build /go/bin/dme-server /usr/local/bin
+COPY --from=build /go/bin/cluster-svc /usr/local/bin
 COPY --from=build /go/bin/edgectl /usr/local/bin
 COPY --from=build /go/bin/tok-srv-sim /usr/local/bin
 COPY --from=build /go/bin/loc-api-sim /usr/local/bin

--- a/setup-env/e2e-tests/setups/mexdemo/mex-cluster-svc-deploy.yml
+++ b/setup-env/e2e-tests/setups/mexdemo/mex-cluster-svc-deploy.yml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-svc
+  labels:
+    app: cluster-svc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-svc
+  template:
+    metadata:
+      labels:
+        app: cluster-svc
+    spec:
+      containers:
+      - name: cluster-svc
+        image: registry.mobiledgex.net:5000/mobiledgex/edge-cloud:latest
+        imagePullPolicy: Always
+        command:
+         - "cluster-svc"
+         - "--notifyAddrs"
+         - "controller:37001"
+         - "--ctrlAddrs"
+         - "controller:55001"
+         - "--d"
+         - "mexos,notify"
+         - "--tls"
+         - "/root/tls/mex-server.crt"
+         - "--influxdb"
+         - "monitoring-influxdb:8086"
+      imagePullSecrets:
+       - name: mexreg-secret 
+


### PR DESCRIPTION
Adding an example yaml file for cluster-svc deployment.
NOTE: Options in the cluster-svc are for the future use