### PR TITLE
EDGECLOUD-387, EDGECLOUD-361

### DIFF
--- a/controller/cluster_api.go
+++ b/controller/cluster_api.go
@@ -73,7 +73,7 @@ func (s *ClusterApi) DeleteCluster(ctx context.Context, in *edgeproto.Cluster) (
 		return &edgeproto.Result{}, errors.New("Cluster in use by ClusterInst")
 	}
 	if err := appApi.AutoDeleteApps(ctx, &in.Key); err != nil {
-		return &edgeproto.Result{}, errors.New("Could not auto-delete apps")
+		return &edgeproto.Result{}, fmt.Errorf("Could not auto-delete apps, %s", err.Error())
 	}
 	return s.store.Delete(in, s.sync.syncWait)
 }

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -241,7 +241,7 @@ func (s *ClusterInstApi) deleteClusterInstInternal(cctx *CallContext, in *edgepr
 	}
 	// Delete appInsts that are set for autodelete
 	if err := appInstApi.AutoDeleteAppInsts(&in.Key, cb); err != nil {
-		return fmt.Errorf("Failed to auto-delete applications from clusterInst %s - %s",
+		return fmt.Errorf("Failed to auto-delete applications from clusterInst %s, %s",
 			in.Key.ClusterKey.Name, err.Error())
 	}
 

--- a/deploygen/kube.go
+++ b/deploygen/kube.go
@@ -73,7 +73,7 @@ func (g *kubeBasicGen) kubeLb(protos []string) {
 		return
 	}
 	lb := lbData{
-		Name:  util.K8SSanitize(g.app.Name + "-" + protos[0]),
+		Name:  util.DNSSanitize(g.app.Name + "-" + protos[0]),
 		Run:   util.K8SSanitize(g.app.Name),
 		Ports: []kubePort{},
 	}
@@ -130,7 +130,8 @@ func (g *kubeBasicGen) kubeApp() {
 		cs = strings.Split(g.app.Command, " ")
 	}
 	data := appData{
-		Name:      util.K8SSanitize(g.app.Name + "-deployment"),
+		Name:      util.DNSSanitize(g.app.Name + "-deployment"),
+		DNSName:   util.DNSSanitize(g.app.Name),
 		Run:       util.K8SSanitize(g.app.Name),
 		Ports:     g.ports,
 		ImagePath: g.app.ImagePath,
@@ -146,6 +147,7 @@ func (g *kubeBasicGen) kubeApp() {
 
 type appData struct {
 	Name      string
+	DNSName   string
 	Run       string
 	ImagePath string
 	Ports     []kubePort
@@ -170,7 +172,7 @@ spec:
       imagePullSecrets:
       - name: mexregistrysecret
       containers:
-      - name: {{.Run}}
+      - name: {{.DNSName}}
         image: {{.ImagePath}}
         imagePullPolicy: Always
         ports:

--- a/edgeproto/doc/README.md
+++ b/edgeproto/doc/README.md
@@ -1,5 +1,5 @@
 # Protocol Documentation
-<a name="top"></a>
+<a name="top"/>
 
 ## Table of Contents
 
@@ -184,14 +184,14 @@
 
 
 
-<a name="app.proto"></a>
+<a name="app.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## app.proto
 
 
 
-<a name="edgeproto.App"></a>
+<a name="edgeproto.App"/>
 
 ### App
 Apps are applications that may be instantiated on Cloudlets, providing a back-end service to an application client (using the mobiledgex SDK) running on a user device such as a cell phone, wearable, drone, etc. Applications belong to Developers, and must specify their image and accessibility. Applications are analagous to Pods in Kubernetes, and similarly are tied to a Cluster.
@@ -225,7 +225,7 @@ An application in itself is not tied to a Cloudlet, but provides a definition th
 
 
 
-<a name="edgeproto.AppKey"></a>
+<a name="edgeproto.AppKey"/>
 
 ### AppKey
 AppKey uniquely identifies an Application.
@@ -244,7 +244,7 @@ AppKey uniquely identifies an Application.
  
 
 
-<a name="edgeproto.DeleteType"></a>
+<a name="edgeproto.DeleteType"/>
 
 ### DeleteType
 
@@ -256,7 +256,7 @@ AppKey uniquely identifies an Application.
 
 
 
-<a name="edgeproto.ImageType"></a>
+<a name="edgeproto.ImageType"/>
 
 ### ImageType
 ImageType specifies the image type of the application.
@@ -273,30 +273,30 @@ ImageType specifies the image type of the application.
  
 
 
-<a name="edgeproto.AppApi"></a>
+<a name="edgeproto.AppApi"/>
 
 ### AppApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateApp | [App](#edgeproto.App) | [Result](#edgeproto.Result) | Create an application |
-| DeleteApp | [App](#edgeproto.App) | [Result](#edgeproto.Result) | Delete an application |
-| UpdateApp | [App](#edgeproto.App) | [Result](#edgeproto.Result) | Update an application |
-| ShowApp | [App](#edgeproto.App) | [App](#edgeproto.App) stream | Show applications. Any fields specified will be used to filter results. |
+| CreateApp | [App](#edgeproto.App) | [Result](#edgeproto.App) | Create an application |
+| DeleteApp | [App](#edgeproto.App) | [Result](#edgeproto.App) | Delete an application |
+| UpdateApp | [App](#edgeproto.App) | [Result](#edgeproto.App) | Update an application |
+| ShowApp | [App](#edgeproto.App) | [App](#edgeproto.App) | Show applications. Any fields specified will be used to filter results. |
 
  
 
 
 
-<a name="app_inst.proto"></a>
+<a name="app_inst.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## app_inst.proto
 
 
 
-<a name="edgeproto.AppInst"></a>
+<a name="edgeproto.AppInst"/>
 
 ### AppInst
 AppInst is an instance of an App (application) on a Cloudlet. It is defined by an App plus a Cloudlet key. This separation of the definition of the App versus its instantiation is unique to Mobiledgex, and allows the Developer to provide the App defintion, while either the Developer may statically define the instances, or the Mobiledgex platform may dynamically create and destroy instances in response to demand.
@@ -325,7 +325,7 @@ Many of the fields here are inherited from the App definition. Some are derived,
 
 
 
-<a name="edgeproto.AppInstInfo"></a>
+<a name="edgeproto.AppInstInfo"/>
 
 ### AppInstInfo
 AppInstInfo provides information from the Cloudlet Resource Manager about the state of the AppInst on the Cloudlet. Whereas the AppInst defines the intent of instantiating an App on a Cloudlet, the AppInstInfo defines the current state of trying to apply that intent on the physical resources of the Cloudlet.
@@ -344,7 +344,7 @@ AppInstInfo provides information from the Cloudlet Resource Manager about the st
 
 
 
-<a name="edgeproto.AppInstKey"></a>
+<a name="edgeproto.AppInstKey"/>
 
 ### AppInstKey
 AppInstKey uniquely identifies an Application Instance (AppInst) or Application Instance state (AppInstInfo).
@@ -361,7 +361,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.AppInstMetrics"></a>
+<a name="edgeproto.AppInstMetrics"/>
 
 ### AppInstMetrics
 (TODO) AppInstMetrics provide metrics collected about the application instance on the Cloudlet. They are sent to a metrics collector for analytics. They are not stored in the persistent distributed database, but are stored as a time series in some other database or files.
@@ -382,50 +382,50 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
  
 
 
-<a name="edgeproto.AppInstApi"></a>
+<a name="edgeproto.AppInstApi"/>
 
 ### AppInstApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.Result) stream | Create an application instance |
-| DeleteAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.Result) stream | Delete an application instance |
-| UpdateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.Result) stream | Update an application instance |
-| ShowAppInst | [AppInst](#edgeproto.AppInst) | [AppInst](#edgeproto.AppInst) stream | Show application instances. Any fields specified will be used to filter results. |
+| CreateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.AppInst) | Create an application instance |
+| DeleteAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.AppInst) | Delete an application instance |
+| UpdateAppInst | [AppInst](#edgeproto.AppInst) | [Result](#edgeproto.AppInst) | Update an application instance |
+| ShowAppInst | [AppInst](#edgeproto.AppInst) | [AppInst](#edgeproto.AppInst) | Show application instances. Any fields specified will be used to filter results. |
 
 
-<a name="edgeproto.AppInstInfoApi"></a>
+<a name="edgeproto.AppInstInfoApi"/>
 
 ### AppInstInfoApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowAppInstInfo | [AppInstInfo](#edgeproto.AppInstInfo) | [AppInstInfo](#edgeproto.AppInstInfo) stream | Show application instances state. |
+| ShowAppInstInfo | [AppInstInfo](#edgeproto.AppInstInfo) | [AppInstInfo](#edgeproto.AppInstInfo) | Show application instances state. |
 
 
-<a name="edgeproto.AppInstMetricsApi"></a>
+<a name="edgeproto.AppInstMetricsApi"/>
 
 ### AppInstMetricsApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowAppInstMetrics | [AppInstMetrics](#edgeproto.AppInstMetrics) | [AppInstMetrics](#edgeproto.AppInstMetrics) stream | Show application instance metrics. |
+| ShowAppInstMetrics | [AppInstMetrics](#edgeproto.AppInstMetrics) | [AppInstMetrics](#edgeproto.AppInstMetrics) | Show application instance metrics. |
 
  
 
 
 
-<a name="cloud-resource-manager.proto"></a>
+<a name="cloud-resource-manager.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## cloud-resource-manager.proto
 
 
 
-<a name="edgeproto.CloudResource"></a>
+<a name="edgeproto.CloudResource"/>
 
 ### CloudResource
 
@@ -445,7 +445,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.EdgeCloudApp"></a>
+<a name="edgeproto.EdgeCloudApp"/>
 
 ### EdgeCloudApp
 
@@ -473,7 +473,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.EdgeCloudApplication"></a>
+<a name="edgeproto.EdgeCloudApplication"/>
 
 ### EdgeCloudApplication
 
@@ -492,7 +492,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
  
 
 
-<a name="edgeproto.CloudResourceCategory"></a>
+<a name="edgeproto.CloudResourceCategory"/>
 
 ### CloudResourceCategory
 
@@ -520,31 +520,31 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
  
 
 
-<a name="edgeproto.CloudResourceManager"></a>
+<a name="edgeproto.CloudResourceManager"/>
 
 ### CloudResourceManager
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ListCloudResource | [CloudResource](#edgeproto.CloudResource) | [CloudResource](#edgeproto.CloudResource) stream |  |
-| AddCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.Result) |  |
-| DeleteCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.Result) |  |
-| DeployApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.Result) |  |
-| DeleteApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.Result) |  |
+| ListCloudResource | [CloudResource](#edgeproto.CloudResource) | [CloudResource](#edgeproto.CloudResource) |  |
+| AddCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.CloudResource) |  |
+| DeleteCloudResource | [CloudResource](#edgeproto.CloudResource) | [Result](#edgeproto.CloudResource) |  |
+| DeployApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.EdgeCloudApplication) |  |
+| DeleteApplication | [EdgeCloudApplication](#edgeproto.EdgeCloudApplication) | [Result](#edgeproto.EdgeCloudApplication) |  |
 
  
 
 
 
-<a name="cloudlet.proto"></a>
+<a name="cloudlet.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## cloudlet.proto
 
 
 
-<a name="edgeproto.AzureProperties"></a>
+<a name="edgeproto.AzureProperties"/>
 
 ### AzureProperties
 
@@ -560,7 +560,7 @@ AppInstKey uniquely identifies an Application Instance (AppInst) or Application 
 
 
 
-<a name="edgeproto.Cloudlet"></a>
+<a name="edgeproto.Cloudlet"/>
 
 ### Cloudlet
 A Cloudlet is a set of compute resources at a particular location, typically an Operator&#39;s regional data center, or a cell tower. The Cloudlet is managed by a Cloudlet Resource Manager, which communicates with the Mobiledgex Controller and allows AppInsts (application instances) to be instantiated on the Cloudlet.
@@ -584,7 +584,7 @@ Certs for accessing cloudlet site |
 
 
 
-<a name="edgeproto.CloudletInfo"></a>
+<a name="edgeproto.CloudletInfo"/>
 
 ### CloudletInfo
 CloudletInfo provides information from the Cloudlet Resource Manager about the state of the Cloudlet.
@@ -607,7 +607,7 @@ CloudletInfo provides information from the Cloudlet Resource Manager about the s
 
 
 
-<a name="edgeproto.CloudletInfraCommon"></a>
+<a name="edgeproto.CloudletInfraCommon"/>
 
 ### CloudletInfraCommon
 properites common to all cloudlets
@@ -633,7 +633,7 @@ MEX_DOCKER_REG_PASS |
 
 
 
-<a name="edgeproto.CloudletInfraProperties"></a>
+<a name="edgeproto.CloudletInfraProperties"/>
 
 ### CloudletInfraProperties
 
@@ -652,7 +652,7 @@ MEX_DOCKER_REG_PASS |
 
 
 
-<a name="edgeproto.CloudletKey"></a>
+<a name="edgeproto.CloudletKey"/>
 
 ### CloudletKey
 CloudletKey uniquely identifies a Cloudlet.
@@ -668,7 +668,7 @@ CloudletKey uniquely identifies a Cloudlet.
 
 
 
-<a name="edgeproto.CloudletMetrics"></a>
+<a name="edgeproto.CloudletMetrics"/>
 
 ### CloudletMetrics
 (TODO) CloudletMetrics provide metrics collected about the Cloudlet. They are sent to a metrics collector for analytics. They are not stored in the persistent distributed database, but are stored as a time series in some other database or files.
@@ -683,7 +683,7 @@ CloudletKey uniquely identifies a Cloudlet.
 
 
 
-<a name="edgeproto.GcpProperties"></a>
+<a name="edgeproto.GcpProperties"/>
 
 ### GcpProperties
 
@@ -699,7 +699,7 @@ CloudletKey uniquely identifies a Cloudlet.
 
 
 
-<a name="edgeproto.OpenStackProperties"></a>
+<a name="edgeproto.OpenStackProperties"/>
 
 ### OpenStackProperties
 
@@ -719,7 +719,7 @@ CloudletKey uniquely identifies a Cloudlet.
 
 
 
-<a name="edgeproto.OpenStackProperties.OpenRcVarsEntry"></a>
+<a name="edgeproto.OpenStackProperties.OpenRcVarsEntry"/>
 
 ### OpenStackProperties.OpenRcVarsEntry
 
@@ -737,7 +737,7 @@ CloudletKey uniquely identifies a Cloudlet.
  
 
 
-<a name="edgeproto.CloudletState"></a>
+<a name="edgeproto.CloudletState"/>
 
 ### CloudletState
 CloudletState is the state of the Cloudlet.
@@ -756,52 +756,52 @@ CloudletState is the state of the Cloudlet.
  
 
 
-<a name="edgeproto.CloudletApi"></a>
+<a name="edgeproto.CloudletApi"/>
 
 ### CloudletApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Result) stream | Create a Cloudlet |
-| DeleteCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Result) stream | Delete a Cloudlet |
-| UpdateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Result) stream | Update a Cloudlet |
-| ShowCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Cloudlet](#edgeproto.Cloudlet) stream | Show Cloudlets |
+| CreateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Cloudlet) | Create a Cloudlet |
+| DeleteCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Cloudlet) | Delete a Cloudlet |
+| UpdateCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Result](#edgeproto.Cloudlet) | Update a Cloudlet |
+| ShowCloudlet | [Cloudlet](#edgeproto.Cloudlet) | [Cloudlet](#edgeproto.Cloudlet) | Show Cloudlets |
 
 
-<a name="edgeproto.CloudletInfoApi"></a>
+<a name="edgeproto.CloudletInfoApi"/>
 
 ### CloudletInfoApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [CloudletInfo](#edgeproto.CloudletInfo) stream | Show CloudletInfos |
-| InjectCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.Result) | Inject (create) a CloudletInfo for regression testing |
-| EvictCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.Result) | Evict (delete) a CloudletInfo for regression testing |
+| ShowCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [CloudletInfo](#edgeproto.CloudletInfo) | Show CloudletInfos |
+| InjectCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.CloudletInfo) | Inject (create) a CloudletInfo for regression testing |
+| EvictCloudletInfo | [CloudletInfo](#edgeproto.CloudletInfo) | [Result](#edgeproto.CloudletInfo) | Evict (delete) a CloudletInfo for regression testing |
 
 
-<a name="edgeproto.CloudletMetricsApi"></a>
+<a name="edgeproto.CloudletMetricsApi"/>
 
 ### CloudletMetricsApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowCloudletMetrics | [CloudletMetrics](#edgeproto.CloudletMetrics) | [CloudletMetrics](#edgeproto.CloudletMetrics) stream | Show Cloudlet metrics |
+| ShowCloudletMetrics | [CloudletMetrics](#edgeproto.CloudletMetrics) | [CloudletMetrics](#edgeproto.CloudletMetrics) | Show Cloudlet metrics |
 
  
 
 
 
-<a name="cluster.proto"></a>
+<a name="cluster.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## cluster.proto
 
 
 
-<a name="edgeproto.Cluster"></a>
+<a name="edgeproto.Cluster"/>
 
 ### Cluster
 Clusters define a set of resources that are provided to one or more Apps tied to the cluster. The set of resources is defined by the Cluster flavor. The Cluster definition here is analogous to a Kubernetes cluster.
@@ -821,7 +821,7 @@ In comparison to ClusterFlavors which are fairly static and controller by admini
 
 
 
-<a name="edgeproto.ClusterKey"></a>
+<a name="edgeproto.ClusterKey"/>
 
 ### ClusterKey
 ClusterKey uniquely identifies a Cluster.
@@ -842,30 +842,30 @@ ClusterKey uniquely identifies a Cluster.
  
 
 
-<a name="edgeproto.ClusterApi"></a>
+<a name="edgeproto.ClusterApi"/>
 
 ### ClusterApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Result) | Create a Cluster |
-| DeleteCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Result) | Delete a Cluster |
-| UpdateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Result) | Update a Cluster |
-| ShowCluster | [Cluster](#edgeproto.Cluster) | [Cluster](#edgeproto.Cluster) stream | Show Clusters |
+| CreateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Cluster) | Create a Cluster |
+| DeleteCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Cluster) | Delete a Cluster |
+| UpdateCluster | [Cluster](#edgeproto.Cluster) | [Result](#edgeproto.Cluster) | Update a Cluster |
+| ShowCluster | [Cluster](#edgeproto.Cluster) | [Cluster](#edgeproto.Cluster) | Show Clusters |
 
  
 
 
 
-<a name="clusterflavor.proto"></a>
+<a name="clusterflavor.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## clusterflavor.proto
 
 
 
-<a name="edgeproto.ClusterFlavor"></a>
+<a name="edgeproto.ClusterFlavor"/>
 
 ### ClusterFlavor
 ClusterFlavor defines a set of resources for a Cluster. ClusterFlavors should be fairly static objects that are almost never changed, and are only modified by Mobiledgex administrators.
@@ -886,7 +886,7 @@ ClusterFlavor defines a set of resources for a Cluster. ClusterFlavors should be
 
 
 
-<a name="edgeproto.ClusterFlavorKey"></a>
+<a name="edgeproto.ClusterFlavorKey"/>
 
 ### ClusterFlavorKey
 ClusterFlavorKey uniquely identifies a Cluster Flavor.
@@ -907,30 +907,30 @@ ClusterFlavorKey uniquely identifies a Cluster Flavor.
  
 
 
-<a name="edgeproto.ClusterFlavorApi"></a>
+<a name="edgeproto.ClusterFlavorApi"/>
 
 ### ClusterFlavorApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.Result) | Create a ClusterFlavor |
-| DeleteClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.Result) | Delete a ClusterFlavor |
-| UpdateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.Result) | Update a ClusterFlavor |
-| ShowClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [ClusterFlavor](#edgeproto.ClusterFlavor) stream | Show ClusterFlavors |
+| CreateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.ClusterFlavor) | Create a ClusterFlavor |
+| DeleteClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.ClusterFlavor) | Delete a ClusterFlavor |
+| UpdateClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [Result](#edgeproto.ClusterFlavor) | Update a ClusterFlavor |
+| ShowClusterFlavor | [ClusterFlavor](#edgeproto.ClusterFlavor) | [ClusterFlavor](#edgeproto.ClusterFlavor) | Show ClusterFlavors |
 
  
 
 
 
-<a name="clusterinst.proto"></a>
+<a name="clusterinst.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## clusterinst.proto
 
 
 
-<a name="edgeproto.ClusterInst"></a>
+<a name="edgeproto.ClusterInst"/>
 
 ### ClusterInst
 ClusterInst is an instance of a Cluster on a Cloudlet. It is defined by a Cluster plus a Cloudlet key. This separation of the definition of the Cluster versus its instance is unique to Mobiledgex, and allows the Developer to provide the Cluster definition, while either the Developer may statically define the instances, or the Mobiledgex platform may dynamically create and destroy instances in response to demand.
@@ -953,7 +953,7 @@ When a Cluster is instantiated on a Cloudlet, the user may override the default 
 
 
 
-<a name="edgeproto.ClusterInstInfo"></a>
+<a name="edgeproto.ClusterInstInfo"/>
 
 ### ClusterInstInfo
 ClusterInstInfo provides information from the Cloudlet Resource Manager about the state of the ClusterInst on the Cloudlet. Whereas the ClusterInst defines the intent of instantiating a Cluster on a Cloudlet, the ClusterInstInfo defines the current state of trying to apply that intent on the physical resources of the Cloudlet.
@@ -972,7 +972,7 @@ ClusterInstInfo provides information from the Cloudlet Resource Manager about th
 
 
 
-<a name="edgeproto.ClusterInstKey"></a>
+<a name="edgeproto.ClusterInstKey"/>
 
 ### ClusterInstKey
 ClusterInstKey uniquely identifies a Cluster Instance (ClusterInst) or Cluster Instance state (ClusterInstInfo).
@@ -994,33 +994,33 @@ ClusterInstKey uniquely identifies a Cluster Instance (ClusterInst) or Cluster I
  
 
 
-<a name="edgeproto.ClusterInstApi"></a>
+<a name="edgeproto.ClusterInstApi"/>
 
 ### ClusterInstApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.Result) stream | Create a Cluster instance |
-| DeleteClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.Result) stream | Delete a Cluster instance |
-| UpdateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.Result) stream | Update a Cluster instance |
-| ShowClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [ClusterInst](#edgeproto.ClusterInst) stream | Show Cluster instances |
+| CreateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.ClusterInst) | Create a Cluster instance |
+| DeleteClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.ClusterInst) | Delete a Cluster instance |
+| UpdateClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [Result](#edgeproto.ClusterInst) | Update a Cluster instance |
+| ShowClusterInst | [ClusterInst](#edgeproto.ClusterInst) | [ClusterInst](#edgeproto.ClusterInst) | Show Cluster instances |
 
 
-<a name="edgeproto.ClusterInstInfoApi"></a>
+<a name="edgeproto.ClusterInstInfoApi"/>
 
 ### ClusterInstInfoApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowClusterInstInfo | [ClusterInstInfo](#edgeproto.ClusterInstInfo) | [ClusterInstInfo](#edgeproto.ClusterInstInfo) stream | Show Cluster instances state. |
+| ShowClusterInstInfo | [ClusterInstInfo](#edgeproto.ClusterInstInfo) | [ClusterInstInfo](#edgeproto.ClusterInstInfo) | Show Cluster instances state. |
 
  
 
 
 
-<a name="common.proto"></a>
+<a name="common.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## common.proto
@@ -1029,7 +1029,7 @@ ClusterInstKey uniquely identifies a Cluster Instance (ClusterInst) or Cluster I
  
 
 
-<a name="edgeproto.CRMOverride"></a>
+<a name="edgeproto.CRMOverride"/>
 
 ### CRMOverride
 CRMOverride can be applied to commands that issue requests to the CRM.
@@ -1048,7 +1048,7 @@ Controller to ignore errors from the CRM, or ignore the CRM completely
 
 
 
-<a name="edgeproto.IpAccess"></a>
+<a name="edgeproto.IpAccess"/>
 
 ### IpAccess
 
@@ -1062,7 +1062,7 @@ Controller to ignore errors from the CRM, or ignore the CRM completely
 
 
 
-<a name="edgeproto.IpSupport"></a>
+<a name="edgeproto.IpSupport"/>
 
 ### IpSupport
 IpSupport indicates the type of public IP support provided by the Cloudlet. Static IP support indicates a set of static public IPs are available for use, and managed by the Controller. Dynamic indicates the Cloudlet uses a DHCP server to provide public IP addresses, and the controller has no control over which IPs are assigned.
@@ -1075,7 +1075,7 @@ IpSupport indicates the type of public IP support provided by the Cloudlet. Stat
 
 
 
-<a name="edgeproto.Liveness"></a>
+<a name="edgeproto.Liveness"/>
 
 ### Liveness
 Liveness indicates if an object was created statically via an external API call, or dynamically via an internal algorithm.
@@ -1088,7 +1088,7 @@ Liveness indicates if an object was created statically via an external API call,
 
 
 
-<a name="edgeproto.TrackedState"></a>
+<a name="edgeproto.TrackedState"/>
 
 ### TrackedState
 TrackedState is used to track the state of an object on a remote node,
@@ -1118,14 +1118,14 @@ i.e. track the state of a ClusterInst object on the CRM (Cloudlet).
 
 
 
-<a name="controller.proto"></a>
+<a name="controller.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## controller.proto
 
 
 
-<a name="edgeproto.Controller"></a>
+<a name="edgeproto.Controller"/>
 
 ### Controller
 A Controller is a service that manages the edge-cloud data and controls other edge-cloud micro-services.
@@ -1141,7 +1141,7 @@ A Controller is a service that manages the edge-cloud data and controls other ed
 
 
 
-<a name="edgeproto.ControllerKey"></a>
+<a name="edgeproto.ControllerKey"/>
 
 ### ControllerKey
 ControllerKey uniquely defines a Controller
@@ -1162,27 +1162,27 @@ ControllerKey uniquely defines a Controller
  
 
 
-<a name="edgeproto.ControllerApi"></a>
+<a name="edgeproto.ControllerApi"/>
 
 ### ControllerApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowController | [Controller](#edgeproto.Controller) | [Controller](#edgeproto.Controller) stream | Show Controllers |
+| ShowController | [Controller](#edgeproto.Controller) | [Controller](#edgeproto.Controller) | Show Controllers |
 
  
 
 
 
-<a name="developer.proto"></a>
+<a name="developer.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## developer.proto
 
 
 
-<a name="edgeproto.Developer"></a>
+<a name="edgeproto.Developer"/>
 
 ### Developer
 A Developer defines a Mobiledgex customer that can create and manage applications, clusters, instances, etc. Applications and other objects created by one Developer cannot be seen or managed by other Developers. Billing will likely be done on a per-developer basis.
@@ -1204,7 +1204,7 @@ TODO: user management, auth, etc is not implemented yet.
 
 
 
-<a name="edgeproto.DeveloperKey"></a>
+<a name="edgeproto.DeveloperKey"/>
 
 ### DeveloperKey
 DeveloperKey uniquely identifies a Developer (Mobiledgex customer)
@@ -1225,30 +1225,30 @@ DeveloperKey uniquely identifies a Developer (Mobiledgex customer)
  
 
 
-<a name="edgeproto.DeveloperApi"></a>
+<a name="edgeproto.DeveloperApi"/>
 
 ### DeveloperApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Result) | Create a Developer |
-| DeleteDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Result) | Delete a Developer |
-| UpdateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Result) | Update a Developer |
-| ShowDeveloper | [Developer](#edgeproto.Developer) | [Developer](#edgeproto.Developer) stream | Show Developers |
+| CreateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Developer) | Create a Developer |
+| DeleteDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Developer) | Delete a Developer |
+| UpdateDeveloper | [Developer](#edgeproto.Developer) | [Result](#edgeproto.Developer) | Update a Developer |
+| ShowDeveloper | [Developer](#edgeproto.Developer) | [Developer](#edgeproto.Developer) | Show Developers |
 
  
 
 
 
-<a name="flavor.proto"></a>
+<a name="flavor.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## flavor.proto
 
 
 
-<a name="edgeproto.Flavor"></a>
+<a name="edgeproto.Flavor"/>
 
 ### Flavor
 A Flavor identifies the Cpu, Ram, and Disk resources required for either a node in a Cluster, or an application instance. For a node in a cluster, these are the physical resources provided by that node. For an application instance, this defines the resources (per node) that should be allocated to the instance from the Cluster.
@@ -1267,7 +1267,7 @@ A Flavor identifies the Cpu, Ram, and Disk resources required for either a node 
 
 
 
-<a name="edgeproto.FlavorKey"></a>
+<a name="edgeproto.FlavorKey"/>
 
 ### FlavorKey
 FlavorKey uniquely identifies a Flavor.
@@ -1288,30 +1288,30 @@ FlavorKey uniquely identifies a Flavor.
  
 
 
-<a name="edgeproto.FlavorApi"></a>
+<a name="edgeproto.FlavorApi"/>
 
 ### FlavorApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Result) | Create a Flavor |
-| DeleteFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Result) | Delete a Flavor |
-| UpdateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Result) | Update a Flavor |
-| ShowFlavor | [Flavor](#edgeproto.Flavor) | [Flavor](#edgeproto.Flavor) stream | Show Flavors |
+| CreateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Flavor) | Create a Flavor |
+| DeleteFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Flavor) | Delete a Flavor |
+| UpdateFlavor | [Flavor](#edgeproto.Flavor) | [Result](#edgeproto.Flavor) | Update a Flavor |
+| ShowFlavor | [Flavor](#edgeproto.Flavor) | [Flavor](#edgeproto.Flavor) | Show Flavors |
 
  
 
 
 
-<a name="metric.proto"></a>
+<a name="metric.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## metric.proto
 
 
 
-<a name="edgeproto.Metric"></a>
+<a name="edgeproto.Metric"/>
 
 ### Metric
 Metric is an entry/point in a time series of values for Analytics/Billing.
@@ -1329,7 +1329,7 @@ Metric is an entry/point in a time series of values for Analytics/Billing.
 
 
 
-<a name="edgeproto.MetricTag"></a>
+<a name="edgeproto.MetricTag"/>
 
 ### MetricTag
 MetricTag is used as a tag or label to look up the metric, beyond just the name of the metric.
@@ -1345,7 +1345,7 @@ MetricTag is used as a tag or label to look up the metric, beyond just the name 
 
 
 
-<a name="edgeproto.MetricVal"></a>
+<a name="edgeproto.MetricVal"/>
 
 ### MetricVal
 MetricVal is a value associated with the metric.
@@ -1371,14 +1371,14 @@ MetricVal is a value associated with the metric.
 
 
 
-<a name="node.proto"></a>
+<a name="node.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## node.proto
 
 
 
-<a name="edgeproto.Node"></a>
+<a name="edgeproto.Node"/>
 
 ### Node
 Node defines a DME (distributed matching engine) or CRM (cloudlet resource manager) instance.
@@ -1395,7 +1395,7 @@ Node defines a DME (distributed matching engine) or CRM (cloudlet resource manag
 
 
 
-<a name="edgeproto.NodeKey"></a>
+<a name="edgeproto.NodeKey"/>
 
 ### NodeKey
 NodeKey uniquely identifies a DME or CRM node
@@ -1414,7 +1414,7 @@ NodeKey uniquely identifies a DME or CRM node
  
 
 
-<a name="edgeproto.NodeType"></a>
+<a name="edgeproto.NodeType"/>
 
 ### NodeType
 NodeType defines the type of Node
@@ -1431,21 +1431,21 @@ NodeType defines the type of Node
  
 
 
-<a name="edgeproto.NodeApi"></a>
+<a name="edgeproto.NodeApi"/>
 
 ### NodeApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowNodeLocal | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) stream | Show Nodes connected locally only |
-| ShowNode | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) stream | Show all Nodes connected to all Controllers |
+| ShowNodeLocal | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) | Show Nodes connected locally only |
+| ShowNode | [Node](#edgeproto.Node) | [Node](#edgeproto.Node) | Show all Nodes connected to all Controllers |
 
  
 
 
 
-<a name="notice.proto"></a>
+<a name="notice.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## notice.proto
@@ -1453,7 +1453,7 @@ Notice is the message used by the notify protocol to communicate and coordinate 
 In general, the protocol is used to synchronize state from one service to another. The protocol is fairly symmetric, with different state being synchronized both from server to client and client to server.
 
 
-<a name="edgeproto.Notice"></a>
+<a name="edgeproto.Notice"/>
 
 ### Notice
 
@@ -1474,7 +1474,7 @@ In general, the protocol is used to synchronize state from one service to anothe
  
 
 
-<a name="edgeproto.NoticeAction"></a>
+<a name="edgeproto.NoticeAction"/>
 
 ### NoticeAction
 NoticeAction denotes what kind of action this notification is for.
@@ -1493,27 +1493,27 @@ NoticeAction denotes what kind of action this notification is for.
  
 
 
-<a name="edgeproto.NotifyApi"></a>
+<a name="edgeproto.NotifyApi"/>
 
 ### NotifyApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| StreamNotice | [Notice](#edgeproto.Notice) stream | [Notice](#edgeproto.Notice) stream | Bidrectional stream for exchanging data between controller and DME/CRM |
+| StreamNotice | [Notice](#edgeproto.Notice) | [Notice](#edgeproto.Notice) | Bidrectional stream for exchanging data between controller and DME/CRM |
 
  
 
 
 
-<a name="operator.proto"></a>
+<a name="operator.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## operator.proto
 
 
 
-<a name="edgeproto.Operator"></a>
+<a name="edgeproto.Operator"/>
 
 ### Operator
 An Operator defines a telecommunications provider such as AT&amp;T, T-Mobile, etc. The operators in turn provide Mobiledgex with compute resource Cloudlets that serve as the basis for location-based services.
@@ -1529,7 +1529,7 @@ An Operator defines a telecommunications provider such as AT&amp;T, T-Mobile, et
 
 
 
-<a name="edgeproto.OperatorKey"></a>
+<a name="edgeproto.OperatorKey"/>
 
 ### OperatorKey
 OperatorKey uniquely identifies an Operator
@@ -1550,30 +1550,30 @@ OperatorKey uniquely identifies an Operator
  
 
 
-<a name="edgeproto.OperatorApi"></a>
+<a name="edgeproto.OperatorApi"/>
 
 ### OperatorApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Result) | Create an Operator |
-| DeleteOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Result) | Delete an Operator |
-| UpdateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Result) | Update an Operator |
-| ShowOperator | [Operator](#edgeproto.Operator) | [Operator](#edgeproto.Operator) stream | Show Operators |
+| CreateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Operator) | Create an Operator |
+| DeleteOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Operator) | Delete an Operator |
+| UpdateOperator | [Operator](#edgeproto.Operator) | [Result](#edgeproto.Operator) | Update an Operator |
+| ShowOperator | [Operator](#edgeproto.Operator) | [Operator](#edgeproto.Operator) | Show Operators |
 
  
 
 
 
-<a name="refs.proto"></a>
+<a name="refs.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## refs.proto
 
 
 
-<a name="edgeproto.CloudletRefs"></a>
+<a name="edgeproto.CloudletRefs"/>
 
 ### CloudletRefs
 CloudletRefs track used resources and Clusters instantiated on a Cloudlet. Used resources are compared against max resources for a Cloudlet to determine if resources are available for a new Cluster to be instantiated on the Cloudlet.
@@ -1595,7 +1595,7 @@ CloudletRefs track used resources and Clusters instantiated on a Cloudlet. Used 
 
 
 
-<a name="edgeproto.CloudletRefs.RootLbPortsEntry"></a>
+<a name="edgeproto.CloudletRefs.RootLbPortsEntry"/>
 
 ### CloudletRefs.RootLbPortsEntry
 
@@ -1611,7 +1611,7 @@ CloudletRefs track used resources and Clusters instantiated on a Cloudlet. Used 
 
 
 
-<a name="edgeproto.ClusterRefs"></a>
+<a name="edgeproto.ClusterRefs"/>
 
 ### ClusterRefs
 ClusterRefs track used resources within a ClusterInst. Each AppInst specifies a set of required resources (Flavor), so tracking resources used by Apps within a Cluster is necessary to determine if enough resources are available for another AppInst to be instantiated on a ClusterInst.
@@ -1636,37 +1636,37 @@ ClusterRefs track used resources within a ClusterInst. Each AppInst specifies a 
  
 
 
-<a name="edgeproto.CloudletRefsApi"></a>
+<a name="edgeproto.CloudletRefsApi"/>
 
 ### CloudletRefsApi
 This API should be admin-only
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowCloudletRefs | [CloudletRefs](#edgeproto.CloudletRefs) | [CloudletRefs](#edgeproto.CloudletRefs) stream | Show CloudletRefs (debug only) |
+| ShowCloudletRefs | [CloudletRefs](#edgeproto.CloudletRefs) | [CloudletRefs](#edgeproto.CloudletRefs) | Show CloudletRefs (debug only) |
 
 
-<a name="edgeproto.ClusterRefsApi"></a>
+<a name="edgeproto.ClusterRefsApi"/>
 
 ### ClusterRefsApi
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ShowClusterRefs | [ClusterRefs](#edgeproto.ClusterRefs) | [ClusterRefs](#edgeproto.ClusterRefs) stream | Show ClusterRefs (debug only) |
+| ShowClusterRefs | [ClusterRefs](#edgeproto.ClusterRefs) | [ClusterRefs](#edgeproto.ClusterRefs) | Show ClusterRefs (debug only) |
 
  
 
 
 
-<a name="result.proto"></a>
+<a name="result.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## result.proto
 
 
 
-<a name="edgeproto.Result"></a>
+<a name="edgeproto.Result"/>
 
 ### Result
 Result is a generic object for returning the result of an API call. In general, result is not used. The error value returned by the GRPC API call is used instead.

--- a/edgeproto/doc/index.html
+++ b/edgeproto/doc/index.html
@@ -4,7 +4,7 @@
   <head>
     <title>Protocol Documentation</title>
     <meta charset="UTF-8">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic"/>
+    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic"/>
     <style>
       body {
         width: 60em;
@@ -960,7 +960,7 @@ on behalf of this app, such as FindCloudlet </p></td>
               <tr>
                 <td>ShowApp</td>
                 <td><a href="#edgeproto.App">App</a></td>
-                <td><a href="#edgeproto.App">App</a> stream</td>
+                <td><a href="#edgeproto.App">App</a></td>
                 <td><p>Show applications. Any fields specified will be used to filter results.</p></td>
               </tr>
             
@@ -1215,28 +1215,28 @@ redundant unless they&#39;re needed for billing. </p></td>
               <tr>
                 <td>CreateAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Create an application instance</p></td>
               </tr>
             
               <tr>
                 <td>DeleteAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Delete an application instance</p></td>
               </tr>
             
               <tr>
                 <td>UpdateAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Update an application instance</p></td>
               </tr>
             
               <tr>
                 <td>ShowAppInst</td>
                 <td><a href="#edgeproto.AppInst">AppInst</a></td>
-                <td><a href="#edgeproto.AppInst">AppInst</a> stream</td>
+                <td><a href="#edgeproto.AppInst">AppInst</a></td>
                 <td><p>Show application instances. Any fields specified will be used to filter results.</p></td>
               </tr>
             
@@ -1254,7 +1254,7 @@ redundant unless they&#39;re needed for billing. </p></td>
               <tr>
                 <td>ShowAppInstInfo</td>
                 <td><a href="#edgeproto.AppInstInfo">AppInstInfo</a></td>
-                <td><a href="#edgeproto.AppInstInfo">AppInstInfo</a> stream</td>
+                <td><a href="#edgeproto.AppInstInfo">AppInstInfo</a></td>
                 <td><p>Show application instances state.</p></td>
               </tr>
             
@@ -1272,7 +1272,7 @@ redundant unless they&#39;re needed for billing. </p></td>
               <tr>
                 <td>ShowAppInstMetrics</td>
                 <td><a href="#edgeproto.AppInstMetrics">AppInstMetrics</a></td>
-                <td><a href="#edgeproto.AppInstMetrics">AppInstMetrics</a> stream</td>
+                <td><a href="#edgeproto.AppInstMetrics">AppInstMetrics</a></td>
                 <td><p>Show application instance metrics.</p></td>
               </tr>
             
@@ -1609,7 +1609,7 @@ is configurable here. This will need to be removed later. </p></td>
               <tr>
                 <td>ListCloudResource</td>
                 <td><a href="#edgeproto.CloudResource">CloudResource</a></td>
-                <td><a href="#edgeproto.CloudResource">CloudResource</a> stream</td>
+                <td><a href="#edgeproto.CloudResource">CloudResource</a></td>
                 <td><p></p></td>
               </tr>
             
@@ -2172,28 +2172,28 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>CreateCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Create a Cloudlet</p></td>
               </tr>
             
               <tr>
                 <td>DeleteCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Delete a Cloudlet</p></td>
               </tr>
             
               <tr>
                 <td>UpdateCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Update a Cloudlet</p></td>
               </tr>
             
               <tr>
                 <td>ShowCloudlet</td>
                 <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
-                <td><a href="#edgeproto.Cloudlet">Cloudlet</a> stream</td>
+                <td><a href="#edgeproto.Cloudlet">Cloudlet</a></td>
                 <td><p>Show Cloudlets</p></td>
               </tr>
             
@@ -2211,7 +2211,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowCloudletInfo</td>
                 <td><a href="#edgeproto.CloudletInfo">CloudletInfo</a></td>
-                <td><a href="#edgeproto.CloudletInfo">CloudletInfo</a> stream</td>
+                <td><a href="#edgeproto.CloudletInfo">CloudletInfo</a></td>
                 <td><p>Show CloudletInfos</p></td>
               </tr>
             
@@ -2243,7 +2243,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowCloudletMetrics</td>
                 <td><a href="#edgeproto.CloudletMetrics">CloudletMetrics</a></td>
-                <td><a href="#edgeproto.CloudletMetrics">CloudletMetrics</a> stream</td>
+                <td><a href="#edgeproto.CloudletMetrics">CloudletMetrics</a></td>
                 <td><p>Show Cloudlet metrics</p></td>
               </tr>
             
@@ -2363,7 +2363,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowCluster</td>
                 <td><a href="#edgeproto.Cluster">Cluster</a></td>
-                <td><a href="#edgeproto.Cluster">Cluster</a> stream</td>
+                <td><a href="#edgeproto.Cluster">Cluster</a></td>
                 <td><p>Show Clusters</p></td>
               </tr>
             
@@ -2504,7 +2504,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowClusterFlavor</td>
                 <td><a href="#edgeproto.ClusterFlavor">ClusterFlavor</a></td>
-                <td><a href="#edgeproto.ClusterFlavor">ClusterFlavor</a> stream</td>
+                <td><a href="#edgeproto.ClusterFlavor">ClusterFlavor</a></td>
                 <td><p>Show ClusterFlavors</p></td>
               </tr>
             
@@ -2689,28 +2689,28 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>CreateClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Create a Cluster instance</p></td>
               </tr>
             
               <tr>
                 <td>DeleteClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Delete a Cluster instance</p></td>
               </tr>
             
               <tr>
                 <td>UpdateClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.Result">Result</a> stream</td>
+                <td><a href="#edgeproto.Result">Result</a></td>
                 <td><p>Update a Cluster instance</p></td>
               </tr>
             
               <tr>
                 <td>ShowClusterInst</td>
                 <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
-                <td><a href="#edgeproto.ClusterInst">ClusterInst</a> stream</td>
+                <td><a href="#edgeproto.ClusterInst">ClusterInst</a></td>
                 <td><p>Show Cluster instances</p></td>
               </tr>
             
@@ -2728,7 +2728,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowClusterInstInfo</td>
                 <td><a href="#edgeproto.ClusterInstInfo">ClusterInstInfo</a></td>
-                <td><a href="#edgeproto.ClusterInstInfo">ClusterInstInfo</a> stream</td>
+                <td><a href="#edgeproto.ClusterInstInfo">ClusterInstInfo</a></td>
                 <td><p>Show Cluster instances state.</p></td>
               </tr>
             
@@ -3044,7 +3044,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowController</td>
                 <td><a href="#edgeproto.Controller">Controller</a></td>
-                <td><a href="#edgeproto.Controller">Controller</a> stream</td>
+                <td><a href="#edgeproto.Controller">Controller</a></td>
                 <td><p>Show Controllers</p></td>
               </tr>
             
@@ -3178,7 +3178,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowDeveloper</td>
                 <td><a href="#edgeproto.Developer">Developer</a></td>
-                <td><a href="#edgeproto.Developer">Developer</a> stream</td>
+                <td><a href="#edgeproto.Developer">Developer</a></td>
                 <td><p>Show Developers</p></td>
               </tr>
             
@@ -3305,7 +3305,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowFlavor</td>
                 <td><a href="#edgeproto.Flavor">Flavor</a></td>
-                <td><a href="#edgeproto.Flavor">Flavor</a> stream</td>
+                <td><a href="#edgeproto.Flavor">Flavor</a></td>
                 <td><p>Show Flavors</p></td>
               </tr>
             
@@ -3565,14 +3565,14 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowNodeLocal</td>
                 <td><a href="#edgeproto.Node">Node</a></td>
-                <td><a href="#edgeproto.Node">Node</a> stream</td>
+                <td><a href="#edgeproto.Node">Node</a></td>
                 <td><p>Show Nodes connected locally only</p></td>
               </tr>
             
               <tr>
                 <td>ShowNode</td>
                 <td><a href="#edgeproto.Node">Node</a></td>
-                <td><a href="#edgeproto.Node">Node</a> stream</td>
+                <td><a href="#edgeproto.Node">Node</a></td>
                 <td><p>Show all Nodes connected to all Controllers</p></td>
               </tr>
             
@@ -3695,8 +3695,8 @@ MEX_DOCKER_REG_PASS </p></td>
             
               <tr>
                 <td>StreamNotice</td>
-                <td><a href="#edgeproto.Notice">Notice</a> stream</td>
-                <td><a href="#edgeproto.Notice">Notice</a> stream</td>
+                <td><a href="#edgeproto.Notice">Notice</a></td>
+                <td><a href="#edgeproto.Notice">Notice</a></td>
                 <td><p>Bidrectional stream for exchanging data between controller and DME/CRM</p></td>
               </tr>
             
@@ -3802,7 +3802,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowOperator</td>
                 <td><a href="#edgeproto.Operator">Operator</a></td>
-                <td><a href="#edgeproto.Operator">Operator</a> stream</td>
+                <td><a href="#edgeproto.Operator">Operator</a></td>
                 <td><p>Show Operators</p></td>
               </tr>
             
@@ -3987,7 +3987,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowCloudletRefs</td>
                 <td><a href="#edgeproto.CloudletRefs">CloudletRefs</a></td>
-                <td><a href="#edgeproto.CloudletRefs">CloudletRefs</a> stream</td>
+                <td><a href="#edgeproto.CloudletRefs">CloudletRefs</a></td>
                 <td><p>Show CloudletRefs (debug only)</p></td>
               </tr>
             
@@ -4005,7 +4005,7 @@ MEX_DOCKER_REG_PASS </p></td>
               <tr>
                 <td>ShowClusterRefs</td>
                 <td><a href="#edgeproto.ClusterRefs">ClusterRefs</a></td>
-                <td><a href="#edgeproto.ClusterRefs">ClusterRefs</a> stream</td>
+                <td><a href="#edgeproto.ClusterRefs">ClusterRefs</a></td>
                 <td><p>Show ClusterRefs (debug only)</p></td>
               </tr>
             

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -241,6 +241,10 @@ func (s *Cloudlet) Validate(fields map[string]struct{}) error {
 			return errors.New("Invalid longitude value")
 		}
 	}
+	if err := s.ValidateEnums(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/testutil/app_testutil.go
+++ b/testutil/app_testutil.go
@@ -34,6 +34,7 @@ It has these top-level messages:
 	EdgeCloudApp
 	EdgeCloudApplication
 	CloudletKey
+	CloudletInfraCommon
 	AzureProperties
 	GcpProperties
 	OpenStackProperties


### PR DESCRIPTION
387: kubernetes does not like "." in names (requires DNS-compatibility), so changed sanitizing function to DNS one. This fix requires changes to edge-cloud-infra as well or it breaks dns assignment (edge-cloud-infra PR #34).
361: Add enum validation call