### PR TITLE
EDGECLOUD-410

### DIFF
--- a/d-match-engine/dme-server/match-engine.go
+++ b/d-match-engine/dme-server/match-engine.go
@@ -99,6 +99,7 @@ func addAppInst(appInst *edgeproto.AppInst) {
 	if _, foundCarrier := app.carriers[carrierName]; foundCarrier {
 		log.DebugLog(log.DebugLevelDmedb, "carrier already exists", "carrierName", carrierName)
 	} else {
+		log.DebugLog(log.DebugLevelDmedb, "adding carrier for app", "carrierName", carrierName)
 		app.carriers[carrierName] = new(dmeAppInsts)
 		app.carriers[carrierName].insts = make(map[edgeproto.CloudletKey]*dmeAppInst)
 	}
@@ -168,12 +169,6 @@ func removeAppInst(appInst *edgeproto.AppInst) {
 				delete(tbl.apps[appkey].carriers, carrierName)
 				log.DebugLog(log.DebugLevelDmedb, "Removing carrier for app",
 					"carrier", carrierName,
-					"appName", appkey.Name,
-					"appVersion", appkey.Version)
-			}
-			if len(app.carriers) == 0 {
-				delete(tbl.apps, appkey)
-				log.DebugLog(log.DebugLevelDmedb, "Removing app",
 					"appName", appkey.Name,
 					"appVersion", appkey.Version)
 			}


### PR DESCRIPTION
EDGECLOUD-410 fix:

Some time back we modified the design such that the controller performs notify for add and delete Apps separately from AppInstances to the DME so we could do RegisterClient without an AppInstance.  

In the process a bug was created in that if the last AppInstance is deleted, the app entry itself is deleted.  This was a holdover from the original design.  It does not work with the updated design in that the controller sends app data separately from AppInstance data.

The fix is just to stop removing the app table entry when removing the last AppInstance.  We will remove the app table if and when the controller removes the app as per the new design.