### PR TITLE
EDGECLOUD-391 create x1.medium if it doesn't exist

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -180,7 +180,7 @@ func (s *AppApi) CreateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 
 	err = s.sync.ApplySTMWait(func(stm concurrency.STM) error {
 		if !flavorApi.store.STMGet(stm, &in.DefaultFlavor, nil) {
-			return errors.New("Specified default flavor not found")
+			return edgeproto.ErrEdgeApiFlavorNotFound
 		}
 		if s.store.STMGet(stm, &in.Key, nil) {
 			return objstore.ErrKVStoreKeyExists

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -13,6 +13,9 @@ import (
 	"github.com/mobiledgex/edge-cloud/util"
 )
 
+//TODO - need to move out Errors into a separate package
+var ErrEdgeApiFlavorNotFound = errors.New("Specified flavor not found")
+
 // contains sets of each applications for yaml marshalling
 type ApplicationData struct {
 	Operators        []Operator        `yaml:"operators"`


### PR DESCRIPTION
Added code to create x1.medium flavor if it doesn't exist at time of app creation.
Also added some "TODO" items pending EDGECLOUD-386
Added a well-defined error flavorDoesntExists error in objs.go
   - long term we should move this to a separate file.