### PR TITLE
EDGECLOUD-99 cicd node to build and notify per each commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ build-linux:
 build-docker:
 	docker build -t mobiledgex/edge-cloud:${TAG} -f docker/Dockerfile.edge-cloud .
 	docker tag mobiledgex/edge-cloud:${TAG} registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
+	for ADDLTAG in ${ADDLTAGS}; do \
+		docker tag mobiledgex/edge-cloud:${TAG} mobiledgex/edge-cloud:$$ADDLTAG; \
+	done
 	docker push registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
 
 install:


### PR DESCRIPTION
Add support for tagging a docker image with multiple tags.  This will be
used by the nightly build infrastructure to tag an image using unique
git descriptors alongside the timestamp-based tag being used currently.

In the optional ADDLTAGS environment variable is not set, the build-docker
target skips the additional tagging.