### PR TITLE
Repeatable builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ build-docker:
 	docker tag mobiledgex/edge-cloud:${TAG} registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
 	docker push registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
 	for ADDLTAG in ${ADDLTAGS}; do \
-		docker tag mobiledgex/edge-cloud:${TAG} registry.mobiledgex.net:5000/mobiledgex/edge-cloud:$$ADDLTAG; \
-		docker push registry.mobiledgex.net:5000/mobiledgex/edge-cloud:$$ADDLTAG; \
+		docker tag mobiledgex/edge-cloud:${TAG} $$ADDLTAG; \
+		docker push $$ADDLTAG; \
 	done
 
 install:


### PR DESCRIPTION
EDGECLOUD-99 cicd node to build and notify per each commit (follow-up)

Appears that docker push does not push all tags associated with an
image, but instead pushes just the tag specified in the push command
line.  The current accepted workaround is to docker push each additional
tag for the same image.

There is an additional pull request being submitted to the edge-cloud-qa
repo which uses these additional tags to push images to a separate
CI/CD registry. 