### PR TITLE
pruneAppInst deletes apps from app table

### DIFF
--- a/d-match-engine/dme-server/match-engine.go
+++ b/d-match-engine/dme-server/match-engine.go
@@ -195,6 +195,8 @@ func pruneApps(apps map[edgeproto.AppKey]struct{}) {
 func pruneAppInsts(appInsts map[edgeproto.AppInstKey]struct{}) {
 	var key edgeproto.AppInstKey
 
+	log.DebugLog(log.DebugLevelDmereq, "pruneAppInsts called")
+
 	tbl := dmeAppTbl
 	tbl.Lock()
 	defer tbl.Unlock()
@@ -211,11 +213,9 @@ func pruneAppInsts(appInsts map[edgeproto.AppInstKey]struct{}) {
 				}
 			}
 			if len(carr.insts) == 0 {
+				log.DebugLog(log.DebugLevelDmereq, "pruneAppInsts delete carriers")
 				delete(app.carriers, c)
 			}
-		}
-		if len(app.carriers) == 0 {
-			delete(tbl.apps, key.AppKey)
 		}
 		app.Unlock()
 	}


### PR DESCRIPTION
EDGECLOUD-429.  

If there are > 1 DME and both are restarted at once, apps are unable to register afterwards due to "app no found" .

The cause is pruneAppInsts which deletes the app from the table if there are no instances left. This was OK in the original design, but not correct since we split the app table to separate apps from app instances.

While believe this fix is necessary, it's not clear to me why pruneApps is being invoked by the notification mechanism before the appInst's are fully populated to begin with.   It only happens with > 1 DME.   That is something to discuss and better understand.

This is similar to another recent issue (410) in which the DME deletes apps from the app table but a different scenario.