### PR TITLE
Make target to update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ all: build install
 
 linux: build-linux install-linux
 
+dep:
+	dep ensure -update github.com/mobiledgex/edge-cloud-infra
+	dep ensure -vendor-only
+
 build:
 	make -C protogen
 	make -C ./protoc-gen-gomex


### PR DESCRIPTION
This will ensure that the infra repo is always up to date.  The second
"-vendor-only" command is to make sure the external vendor packages do
not get updated without explicit user action.

Will update the instructions in Confluence to use this step instead of using "dep" directly.  After this change, updating an external dependency would involve changing Gopkg.toml followed by a "dep ensure -update <dependency>" to update Gopkg.lock.

I'd have added the "dep" step to the default make target, except that dep takes ages to complete even when it does nothing.