### PR TITLE
fix e2etest findcloudlet cmp no-op

### DIFF
--- a/setup-env/e2e-tests/data/find-cloudlet-response-azure.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-azure.yml
@@ -1,12 +1,18 @@
-fqdn: acmeappcosomeapplication10.azure-cloud-9.azure.mobiledgex.net
+fqdn: acmeappcosomeapplication110.azure-cloud-9.azure.mobiledgex.net
 ports:
 - proto: LProtoTCP
   internalport: 80
   publicport: 80
+  fqdnprefix: someapplication1-tcp.
 - proto: LProtoHTTP
   internalport: 443
   publicport: 443
+  fqdnprefix: someapplication1-tcp.
 - proto: LProtoUDP
   internalport: 10002
   publicport: 10002
+  fqdnprefix: someapplication1-udp.
 status: FIND_FOUND
+cloudletlocation:
+  latitude: 32
+  longitude: -91

--- a/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet1.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet1.yml
@@ -1,12 +1,18 @@
-fqdn: acmeappcosomeapplication10.tmus-cloud-1.tmus.mobiledgex.net
+fqdn: tmus-cloud-1.tmus.mobiledgex.net
 ports:
 - proto: LProtoTCP
   internalport: 80
   publicport: 80
+  fqdnprefix: someapplication1-tcp.
 - proto: LProtoHTTP
   internalport: 443
   publicport: 443
+  fqdnprefix: someapplication1-tcp.
 - proto: LProtoUDP
   internalport: 10002
   publicport: 10002
+  fqdnprefix: someapplication1-udp.
 status: FIND_FOUND
+cloudletlocation:
+  latitude: 31
+  longitude: -91

--- a/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet2.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet2.yml
@@ -1,12 +1,18 @@
-fqdn: acmeappcosomeapplication10.tmus-cloud-2.tmus.mobiledgex.net
+fqdn: tmus-cloud-2.tmus.mobiledgex.net
 ports:
 - proto: LProtoTCP
   internalport: 80
   publicport: 80
+  fqdnprefix: someapplication1-tcp.
 - proto: LProtoHTTP
   internalport: 443
   publicport: 443
+  fqdnprefix: someapplication1-tcp.
 - proto: LProtoUDP
   internalport: 10002
   publicport: 10002
+  fqdnprefix: someapplication1-udp.
 status: FIND_FOUND
+cloudletlocation:
+  latitude: 35
+  longitude: -95

--- a/setup-env/e2e-tests/data/find-cloudlet-response-default_appinst.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-default_appinst.yml
@@ -1,5 +1,5 @@
 status: FIND_FOUND
-fqdn: acmeappcosomeapplication110.default.developer.mobiledgex.net
+fqdn: default.someapplication.acme.com
 ports:
 - proto: LProtoTCP
   internalport: 80

--- a/setup-env/util/util.go
+++ b/setup-env/util/util.go
@@ -604,7 +604,7 @@ func CompareYamlFiles(firstYamlFile string, secondYamlFile string, fileType stri
 			p.PublicPort = 0
 		}
 		y1 = f1
-		y2 = f1
+		y2 = f2
 	} else {
 		err1 = ReadYamlFile(firstYamlFile, &y1, "", false)
 		err2 = ReadYamlFile(secondYamlFile, &y2, "", false)


### PR DESCRIPTION
I found this bug in the e2e test code while working on some related code. The findcloudlet cmp was comparing the same objects, so always succeeded.

I updated the "expected" files to match the generated files, I assume the generated files are currently what's correctly expected.
