### PR TITLE
Fix long/lat swap for test app utility funciton. Fix createUri. 

### DIFF
--- a/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDK.sln
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDK.sln
@@ -22,6 +22,6 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 1.3.1
+		version = 1.3.5.5
 	EndGlobalSection
 EndGlobal

--- a/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -105,7 +105,7 @@ namespace DistributedMatchEngine
     {
       if (host != null && host != "")
       {
-        return "http://" + host + ":" + port;
+        return "https://" + host + ":" + port;
       }
       return generateDmeBaseUri(null, port);
     }

--- a/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>1.3.5.4</ReleaseVersion>
+    <ReleaseVersion>1.3.5.5</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.3.5.4</PackageVersion>
+    <PackageVersion>1.3.5.5</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Library for Unity</Description>
     <Owners>MobiledgeX, Inc.</Owners>

--- a/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/Util.cs
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/Util.cs
@@ -36,8 +36,8 @@ namespace DistributedMatchEngine
         altitude = 100,
         horizontal_accuracy = 5,
         speed = 2,
-        longitude = 37.459601,
-        latitude = -122.149349,
+        longitude = -122.149349,
+        latitude = 37.459601,
         vertical_accuracy = 20,
         timestamp = ts
       };

--- a/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.cs
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.cs
@@ -33,7 +33,9 @@ namespace RestSample
         MatchingEngine me = new MatchingEngine();
         port = MatchingEngine.defaultDmeRestPort;
 
-        // Start location task:
+        // Start location task. This is for test use only. The source of the
+        // location in an Unity application should be from an application context
+        // LocationService.
         var locTask = Util.GetLocationFromDevice();
 
         var registerClientRequest = me.CreateRegisterClientRequest(carrierName, appName, devName, appVers, developerAuthToken);

--- a/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.csproj
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.csproj
@@ -4,10 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>1.3.1</ReleaseVersion>
+    <ReleaseVersion>1.3.5.5</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.3.5.4" />
+    <PackageReference Include="MobiledgeX.MatchingEngineUnityRestSDKLibrary" Version="1.3.5.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- C#/Unity Utility function that was used for test only caused HTTP 500 status to be returned. Fixed by swapping long/lat.
  - LocationService should be used in a real Unity app (sample code in another pull request)
- Updated project/nuget versions. It's not entirely clear which values for "version" are still in use between all the editor updates.