### PR TITLE
EDGECLOUD-438 autocluster not cleaned up on failure

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -159,7 +159,7 @@ func (s *AppInstApi) CreateAppInst(in *edgeproto.AppInst, cb edgeproto.AppInstAp
 
 // createAppInstInternal is used to create dynamic app insts internally,
 // bypassing static assignment.
-func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppInst, cb edgeproto.AppInstApi_CreateAppInstServer) error {
+func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppInst, cb edgeproto.AppInstApi_CreateAppInstServer) (err error) {
 	if in.Liveness == edgeproto.Liveness_LivenessUnknown {
 		in.Liveness = edgeproto.Liveness_LivenessDynamic
 	}
@@ -291,7 +291,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		return fmt.Errorf("Cannot specify URI %s for non-default cloudlet", in.Uri)
 	}
 
-	err := s.sync.ApplySTMWait(func(stm concurrency.STM) error {
+	err = s.sync.ApplySTMWait(func(stm concurrency.STM) error {
 		buf := in
 		if !defaultCloudlet {
 			// lookup already done, don't overwrite changes


### PR DESCRIPTION
Error variable name needs to be declared in return declarations, such that defer funcs can refer to it. This makes things like:
```
defer func() {
     if err != nil {
          // do something
     }
}()
return fmt.Errorf("something failed")
```
Work properly so the defer func will recognize that err is set, even if the return statement doesn't explicitly set it.