### PR TITLE
EDGECLOUD-446 explicit auto-cluster

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -218,8 +218,12 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 
 			}
 			in.ClusterInstKey.CloudletKey = in.Key.CloudletKey
+			// Explicit auto-cluster requirement
+			if cikey.ClusterKey.Name == "" {
+				return fmt.Errorf("No cluster name specified. Create one first or use \"%s\" as the name to automatically create a ClusterInst", ClusterAutoPrefix)
+			}
 			// Check if specified ClusterInst exists
-			if cikey.ClusterKey.Name != "" {
+			if cikey.ClusterKey.Name != ClusterAutoPrefix {
 				if !clusterInstApi.store.STMGet(stm, &in.ClusterInstKey, nil) {
 					// developer may or may not be specified
 					// in clusterinst.
@@ -231,7 +235,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 				// cluster inst exists so we're good.
 				return nil
 			}
-			// No ClusterInst specified, auto-create one
+			// Auto-cluster
 			cikey.ClusterKey.Name = fmt.Sprintf("%s%s", ClusterAutoPrefix, in.Key.AppKey.Name)
 			cikey.ClusterKey.Name = util.K8SSanitize(cikey.ClusterKey.Name)
 			autocluster = true

--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -214,7 +214,7 @@ func TestAutoClusterInst(t *testing.T) {
 
 	// since cluster inst does not exist, it will be auto-created
 	copy := testutil.AppInstData[0]
-	copy.ClusterInstKey.ClusterKey.Name = ""
+	copy.ClusterInstKey.ClusterKey.Name = ClusterAutoPrefix
 	err := appInstApi.CreateAppInst(&copy, &testutil.CudStreamoutAppInst{})
 	assert.Nil(t, err, "create app inst")
 	clusterInst := edgeproto.ClusterInst{}

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/coreos/etcd/clientv3/concurrency"
@@ -123,6 +124,9 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 			err := in.Validate(edgeproto.ClusterInstAllFieldsMap)
 			if err != nil {
 				return err
+			}
+			if !in.Auto && strings.HasPrefix(in.Key.ClusterKey.Name, ClusterAutoPrefix) {
+				return errors.New(ClusterAutoPrefixErr)
 			}
 		}
 		if in.Liveness == edgeproto.Liveness_LivenessUnknown {

--- a/setup-env/e2e-tests/data/appdata_10.yml
+++ b/setup-env/e2e-tests/data/appdata_10.yml
@@ -243,7 +243,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 1
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -260,7 +262,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 1
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -277,7 +281,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 2
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -294,7 +300,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 2
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -311,7 +319,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 3
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -328,7 +338,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 3
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -345,7 +357,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 4
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -362,7 +376,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 4
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -379,7 +395,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 5
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -396,7 +414,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 5
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -413,7 +433,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 6
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -430,7 +452,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 6
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -447,7 +471,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 7
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -464,7 +490,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 7
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -481,7 +509,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 8
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -498,7 +528,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 8
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -515,7 +547,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 9
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -532,7 +566,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 9
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -549,7 +585,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 10
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -566,6 +604,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 10
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:

--- a/setup-env/e2e-tests/data/appdata_2.yml
+++ b/setup-env/e2e-tests/data/appdata_2.yml
@@ -116,7 +116,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 1
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -133,24 +135,9 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 1
-
-
-- key:
-    appkey:
-      developerkey:
-        name: AcmeAppCo
-      name: someapplication1
-      version: "1.0"
-    cloudletkey:
-      operatorkey:
-        name: tmus
-      name: tmus-cloud-2
-
-    id: 2
-  cloudletloc:
-    latitude: 1
-    longitude: 2
-
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:
@@ -167,6 +154,28 @@ appinstances:
   cloudletloc:
     latitude: 1
     longitude: 2
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
+
+- key:
+    appkey:
+      developerkey:
+        name: AcmeAppCo
+      name: someapplication1
+      version: "1.0"
+    cloudletkey:
+      operatorkey:
+        name: tmus
+      name: tmus-cloud-2
+
+    id: 2
+  cloudletloc:
+    latitude: 1
+    longitude: 2
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 
 - key:
     appkey:

--- a/setup-env/e2e-tests/data/appdata_no_cluster.yml
+++ b/setup-env/e2e-tests/data/appdata_no_cluster.yml
@@ -109,6 +109,9 @@ appinstances:
   liveness: LivenessStatic
   flavor:
     name: x1.small
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 - key:
     appkey:
       developerkey:
@@ -126,3 +129,6 @@ appinstances:
   liveness: LivenessStatic
   flavor:
     name: x1.small
+  clusterinstkey:
+    clusterkey:
+      name: autocluster

--- a/setup-env/e2e-tests/data/appinst2.yml
+++ b/setup-env/e2e-tests/data/appinst2.yml
@@ -10,3 +10,6 @@ appinstances:
         name: tmus
       name: tmus-cloud-2
     id: 123
+  clusterinstkey:
+    clusterkey:
+      name: autocluster

--- a/setup-env/e2e-tests/data/appinst_azure.yml
+++ b/setup-env/e2e-tests/data/appinst_azure.yml
@@ -10,3 +10,6 @@ appinstances:
         name: azure
       name: azure-cloud-9
     id: 123
+  clusterinstkey:
+    clusterkey:
+      name: autocluster

--- a/setup-env/e2e-tests/data/genAppData.pl
+++ b/setup-env/e2e-tests/data/genAppData.pl
@@ -130,6 +130,9 @@ sub printAppinst{
   cloudletloc:
     latitude: $lat
     longitude: $long
+  clusterinstkey:
+    clusterkey:
+      name: autocluster
 \n");
 
 }

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -382,6 +382,11 @@ var AppInstData = []edgeproto.AppInst{
 		},
 		CloudletLoc: CloudletData[1].Location,
 		// ClusterInst is ClusterInstAutoData[0]
+		ClusterInstKey: edgeproto.ClusterInstKey{
+			ClusterKey: edgeproto.ClusterKey{
+				Name: "autocluster",
+			},
+		},
 	},
 	edgeproto.AppInst{
 		Key: edgeproto.AppInstKey{
@@ -391,6 +396,11 @@ var AppInstData = []edgeproto.AppInst{
 		},
 		CloudletLoc: CloudletData[2].Location,
 		// ClusterInst is ClusterInstAutoData[1]
+		ClusterInstKey: edgeproto.ClusterInstKey{
+			ClusterKey: edgeproto.ClusterKey{
+				Name: "autocluster",
+			},
+		},
 	},
 	edgeproto.AppInst{
 		Key: edgeproto.AppInstKey{


### PR DESCRIPTION
Per request, auto-cluster is performed only when explicitly requested by the user. Before, if the cluster name was left blank during CreateAppInst, we would create an auto-cluster. Now, the user must put in "autocluster" to trigger auto-cluster creation, otherwise a blank name is treated as an error (user did not specify auto-cluster nor did they specify an existing clusterinst).