### PR TITLE
EDGECLOUD-435 EDGECLOUD-436

### DIFF
--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -24,6 +24,7 @@ var OperatorAzure = "azure"
 var OperatorDeveloper = "developer"
 
 var DeveloperSamsung = "Samsung"
+var DeveloperMobiledgeX = "MobiledgeX"
 
 // platform apps
 var SamsungEnablingLayer = "SamsungEnablingLayer"

--- a/cluster-svc/cluster-svc-main.go
+++ b/cluster-svc/cluster-svc-main.go
@@ -94,6 +94,9 @@ var MEXMetricsExporterApp = edgeproto.App{
 	Key: edgeproto.AppKey{
 		Name:    MEXMetricsExporterAppName,
 		Version: MEXMetricsExporterAppVer,
+		DeveloperKey: edgeproto.DeveloperKey{
+			Name: cloudcommon.DeveloperMobiledgeX,
+		},
 	},
 	ImagePath:     "registry.mobiledgex.net:5000/mobiledgex/metrics-exporter:latest",
 	ImageType:     edgeproto.ImageType_ImageTypeDocker,
@@ -108,6 +111,9 @@ var MEXPrometheusApp = edgeproto.App{
 	Key: edgeproto.AppKey{
 		Name:    MEXPrometheusAppName,
 		Version: MEXPrometheusAppVer,
+		DeveloperKey: edgeproto.DeveloperKey{
+			Name: cloudcommon.DeveloperMobiledgeX,
+		},
 	},
 	ImagePath:     "stable/prometheus-operator",
 	Deployment:    cloudcommon.AppDeploymentTypeHelm,

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -188,6 +188,9 @@ func (key *AppKey) Validate() error {
 	if !util.ValidName(key.Version) {
 		return errors.New("Invalid app version string")
 	}
+	if err := key.DeveloperKey.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
+++ b/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
@@ -209,6 +209,8 @@ apps:
   androidpackagename: com.acme.helmApplication
   permitsplatformapps: true
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXMetricsExporter
     version: "1.0"
   imagepath: registry.mobiledgex.net:5000/mobiledgex/metrics-exporter:latest
@@ -251,6 +253,8 @@ apps:
             key: OperatorName
             optional: true
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXPrometheusAppName
     version: "1.0"
   imagepath: stable/prometheus-operator
@@ -380,6 +384,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -403,6 +409,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -426,6 +434,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -449,6 +459,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
@@ -108,6 +108,8 @@ apps:
   accessports: "tcp:80,http:443,udp:10002"
   ipaccess: IpAccessDedicatedOrShared
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXMetricsExporter
     version: "1.0"
   imagepath: registry.mobiledgex.net:5000/mobiledgex/metrics-exporter:latest
@@ -150,6 +152,8 @@ apps:
             key: OperatorName
             optional: true
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXPrometheusAppName
     version: "1.0"
   imagepath: stable/prometheus-operator
@@ -177,6 +181,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -200,6 +206,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
@@ -108,6 +108,8 @@ apps:
   accessports: "tcp:80,http:443,udp:10002"
   ipaccess: IpAccessDedicatedOrShared
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXMetricsExporter
     version: "1.0"
   imagepath: registry.mobiledgex.net:5000/mobiledgex/metrics-exporter:latest
@@ -150,6 +152,8 @@ apps:
             key: OperatorName
             optional: true
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXPrometheusAppName
     version: "1.0"
   imagepath: stable/prometheus-operator
@@ -201,6 +205,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -224,6 +230,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus

--- a/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
@@ -176,6 +176,8 @@ apps:
   accessports: "tcp:64000"
   ipaccess: IpAccessDedicatedOrShared
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXMetricsExporter
     version: "1.0"
   imagepath: registry.mobiledgex.net:5000/mobiledgex/metrics-exporter:latest
@@ -218,6 +220,8 @@ apps:
             key: OperatorName
             optional: true
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXPrometheusAppName
     version: "1.0"
   imagepath: stable/prometheus-operator
@@ -245,6 +249,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -268,6 +274,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -291,6 +299,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -314,6 +324,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus

--- a/setup-env/e2e-tests/data/appdata_show.yml
+++ b/setup-env/e2e-tests/data/appdata_show.yml
@@ -193,6 +193,8 @@ apps:
   ipaccess: IpAccessDedicatedOrShared
 
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXMetricsExporter
     version: "1.0"
   imagepath: registry.mobiledgex.net:5000/mobiledgex/metrics-exporter:latest
@@ -235,6 +237,8 @@ apps:
             key: OperatorName
             optional: true
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXPrometheusAppName
     version: "1.0"
   imagepath: stable/prometheus-operator
@@ -362,6 +366,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -385,6 +391,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -408,6 +416,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -431,6 +441,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus

--- a/setup-env/e2e-tests/data/crm_info.yml
+++ b/setup-env/e2e-tests/data/crm_info.yml
@@ -186,6 +186,8 @@ apps:
               protocol: UDP
   deploymentgenerator: kubernetes-basic
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXMetricsExporter
     version: "1.0"
   imagepath: registry.mobiledgex.net:5000/mobiledgex/metrics-exporter:latest
@@ -253,6 +255,8 @@ apps:
             key: OperatorName
             optional: true
 - key:
+    developerkey:
+      name: MobiledgeX
     name: MEXPrometheusAppName
     version: "1.0"
   imagepath: stable/prometheus-operator
@@ -361,6 +365,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -386,6 +392,8 @@ appinstances:
     appkey:
       name: MEXMetricsExporter
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -411,6 +419,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus
@@ -436,6 +446,8 @@ appinstances:
     appkey:
       name: MEXPrometheusAppName
       version: "1.0"
+      developerkey:
+        name: MobiledgeX
     cloudletkey:
       operatorkey:
         name: tmus


### PR DESCRIPTION
435: App Update was not re-generating the kubernetes deployment manifest. Have now added a check to do so.
436: Developer name is now required for CreateApp, although we don't check if the developer exists or not. This basically just prevents a blank developer name. This prevents invalid imagepaths that include the developer name.