### PR TITLE
deployment tweaks for heat

### DIFF
--- a/docker/Dockerfile.edge-cloud
+++ b/docker/Dockerfile.edge-cloud
@@ -25,7 +25,9 @@ ENV CGO_ENABLED=0
 RUN make
 
 FROM registry.mobiledgex.net:5000/mobiledgex/openstack-kubectl-gcloud-az
-
+RUN apt-get -y update
+RUN apt-get -y install python-pip
+RUN pip install python-heatclient
 COPY --from=build /go/bin/controller /usr/local/bin
 COPY --from=build /go/bin/crmserver /usr/local/bin
 COPY --from=build /go/bin/dme-server /usr/local/bin

--- a/setup-env/ansible/playbooks/mex_start.yml
+++ b/setup-env/ansible/playbooks/mex_start.yml
@@ -123,11 +123,18 @@
   - name: set the docker creds
     set_fact: mex_docker_reg_pass="{{ lookup('env','MEX_DOCKER_REG_PASS') }}"
 
+  - name: make crm env file
+    copy: content="{{ item.envvars|to_nice_yaml|regex_replace(':\\s', '=') }}" dest="{{remote_log_path}}/{{item.crmlocal.name}}.env"
+    when: item.dockerimage != "" 
+    with_items:
+      - "{{crms}}"
+
   - name: docker login to mex repo
     docker_login:
       registry: registry.mobiledgex.net:5000
       username: mobiledgex
       password: "{{mex_docker_reg_pass}}"
+
 
   - name: set tls option
     set_fact:
@@ -147,6 +154,7 @@
       command: "crmserver --apiAddr {{ item.crmlocal.apiaddr }} --notifyAddrs {{ item.crmlocal.notifyaddrs }} --cloudletKey '{{ item.crmlocal.cloudletkey }}' {{ tlsopt }} --fakecloudlet={{ item.crmlocal.fakecloudlet }} --d api,notify,mexos"
       network_mode: host
       restart_policy: unless-stopped
+      env_file: "{{remote_log_path}}/{{item.crmlocal.name}}.env"
     when: item.hostname == inventory_hostname and item.dockerimage != ""
     with_items:
        -  "{{ crms }}"

--- a/setup-env/e2e-tests/setups/mexdemo/deploy-north-eu-crms.yml
+++ b/setup-env/e2e-tests/setups/mexdemo/deploy-north-eu-crms.yml
@@ -1,0 +1,25 @@
+## Replace the IPs below as needed with the values for your system
+vars:
+- vm1_external_ip: 40.114.198.180
+- vm1_internal_ip: 127.0.0.1
+- controller: mexdemo.ctrl.mobiledgex.net
+
+crms:
+- crmlocal:
+    name: crm-hamburg
+    apiaddr: "0.0.0.0:55091"
+    notifyaddrs: "{{controller}}:37001"
+    cloudletkey: '{"operator_key":{"name":"TDG"},"name":"hamburg-mexdemo"}'
+    fakecloudlet: false
+    tls:
+       servercert: "{{tlsoutdir}}/mex-server.crt"
+       clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "{{vm1_external_ip}}"
+  dockerimage: registry.mobiledgex.net:5000/mobiledgex/edge-cloud:jlm0313
+  envvars:
+    OPENRC_URL: https://vault.mobiledgex.net/v1/secret/data/cloudlet/openstack/hamburg/openrc.json
+    MEXENV_URL: https://vault.mobiledgex.net/v1/secret/data/cloudlet/openstack/mexenv.json
+    CLOUDLET_KIND: openstack
+    MEX_OS_IMAGE: mobiledgex
+    MEX_EXT_NETWORK: external-network-shared
+

--- a/setup-env/util/util.go
+++ b/setup-env/util/util.go
@@ -333,10 +333,15 @@ func ConnectCrm(p *process.CrmLocal, c chan ReturnCodeWithText) {
 	api.Close()
 	// check that controller sees crm online (has received cloudletinfo),
 	// which is required before create clusterinst/appinst will work.
-	err = checkCloudletState(p, 10*time.Second)
-	if err != nil {
-		c <- ReturnCodeWithText{false, "Ok connect to " + p.Name + " but " + err.Error()}
+	if len(Deployment.Controllers) > 0 {
+		err = checkCloudletState(p, 10*time.Second)
+		if err != nil {
+			c <- ReturnCodeWithText{false, "Ok connect to " + p.Name + " but " + err.Error()}
+		} else {
+			c <- ReturnCodeWithText{true, "OK connect to " + p.Name}
+		}
 	} else {
+		// this is a CRM only test
 		c <- ReturnCodeWithText{true, "OK connect to " + p.Name}
 	}
 }


### PR DESCRIPTION
- update edge-cloud image for heat
- update ansible playbook for remote deploy with env variables
- create e2e setupfile for remote deploy of CRM in North Europe  I will add the other CRMs to this later
- e2e tweak to allow CRM test to pass when there is no controller.  this is used in deploy-only test of CRM