### PR TITLE
Cicd timeout

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     options {
-        timeout(time: 20, unit: 'MINUTES')
+        timeout(time: 30, unit: 'MINUTES')
     }
     agent any
     stages {
@@ -39,7 +39,7 @@ make
         }
         stage('Test') {
             options {
-                timeout(time: 15, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES')
             }
             steps {
                 lock('testbed') {


### PR DESCRIPTION
Adding some fairly generous timeouts to the CI jobs to make sure a stuck test does not hold up everything else.

A longer term fix is to make the tests run inside their own docker containers so that we don't need to lock up the entire VM for a test run.  Until this is in place, the timeouts should help avoid CI jobs getting blocked indefinitely.