### PR TITLE
add debug logs to mc

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -27,6 +27,13 @@ func DebugLog(lvl uint64, msg string, keysAndValues ...interface{}) {
 	slogger.Infow(msg, keysAndValues...)
 }
 
+func DebugSLog(slog *zap.SugaredLogger, lvl uint64, msg string, keysAndValues ...interface{}) {
+	if debugLevel&lvl == 0 {
+		return
+	}
+	slog.Infow(msg, keysAndValues...)
+}
+
 func InfoLog(msg string, keysAndValues ...interface{}) {
 	slogger.Infow(msg, keysAndValues...)
 }

--- a/mc/orm/postgres.go
+++ b/mc/orm/postgres.go
@@ -5,17 +5,20 @@ import (
 	"strings"
 	"time"
 
+	"github.com/casbin/casbin/model"
+	"github.com/casbin/casbin/persist"
 	gormadapter "github.com/casbin/gorm-adapter"
 	"github.com/jinzhu/gorm"
 	_ "github.com/labstack/echo"
 	_ "github.com/lib/pq"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/mc/ormapi"
+	"go.uber.org/zap"
 )
 
 var retryInterval = 10 * time.Second
 
-func InitSql(addr, username, password, dbname string) (*gorm.DB, *gormadapter.Adapter, error) {
+func InitSql(addr, username, password, dbname string) (*gorm.DB, persist.Adapter, error) {
 	hostport := strings.Split(addr, ":")
 	if len(hostport) != 2 {
 		return nil, nil, fmt.Errorf("Invalid postgres address format %s", addr)
@@ -35,7 +38,12 @@ func InitSql(addr, username, password, dbname string) (*gorm.DB, *gormadapter.Ad
 	dbSpecified := true
 	adapter := gormadapter.NewAdapter("postgres", psqlInfo, dbSpecified)
 
-	return db, adapter, nil
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+	db.SetLogger(&sqlLogger{logger.Sugar()})
+	db.LogMode(true)
+
+	return db, &adapterLogger{adapter}, nil
 }
 
 func InitData(superuser, superpass string, stop *bool, done chan struct{}) {
@@ -74,4 +82,75 @@ func InitData(superuser, superpass string, stop *bool, done chan struct{}) {
 		break
 	}
 	close(done)
+}
+
+type sqlLogger struct {
+	slog *zap.SugaredLogger
+}
+
+func (s *sqlLogger) Print(v ...interface{}) {
+	if len(v) < 1 {
+		return
+	}
+	kvs := make([]interface{}, 0)
+	msg := "sql log"
+	switch v[0] {
+	case "sql":
+		kvs = append(kvs, "sql")
+		kvs = append(kvs, v[3])
+		kvs = append(kvs, "vars")
+		kvs = append(kvs, v[4])
+		kvs = append(kvs, "rows-affected")
+		kvs = append(kvs, v[5])
+		kvs = append(kvs, "lineno")
+		kvs = append(kvs, v[1])
+		kvs = append(kvs, "took")
+		kvs = append(kvs, v[2])
+		msg = "Call sql"
+	default:
+		kvs = append(kvs, "vals")
+		kvs = append(kvs, v[2:])
+		kvs = append(kvs, "lineno")
+		kvs = append(kvs, v[1])
+	}
+	log.DebugSLog(s.slog, log.DebugLevelApi, msg, kvs...)
+}
+
+type adapterLogger struct {
+	adapter persist.Adapter
+}
+
+func (s *adapterLogger) LoadPolicy(model model.Model) error {
+	start := time.Now()
+	err := s.adapter.LoadPolicy(model)
+	log.DebugLog(log.DebugLevelApi, "Call gorm LoadPolicy", "model", model, "took", time.Since(start))
+	return err
+}
+
+func (s *adapterLogger) SavePolicy(model model.Model) error {
+	start := time.Now()
+	err := s.adapter.SavePolicy(model)
+	log.DebugLog(log.DebugLevelApi, "Call gorm SavePolicy", "model", model, "took", time.Since(start))
+	return err
+}
+
+func (s *adapterLogger) AddPolicy(sec, ptype string, rule []string) error {
+	start := time.Now()
+	err := s.adapter.AddPolicy(sec, ptype, rule)
+	log.DebugLog(log.DebugLevelApi, "Call gorm AddPolicy", "sec", sec, "ptype", ptype, "rule", rule, "took", time.Since(start))
+	return err
+}
+
+func (s *adapterLogger) RemovePolicy(sec, ptype string, rule []string) error {
+	start := time.Now()
+	err := s.adapter.RemovePolicy(sec, ptype, rule)
+	log.DebugLog(log.DebugLevelApi, "Call gorm RemovePolicy", "sec", sec, "ptype", ptype, "rule", rule, "took", time.Since(start))
+	return err
+}
+
+func (s *adapterLogger) RemoveFilteredPolicy(sec, ptype string, fieldIndex int, fieldValues ...string) error {
+	start := time.Now()
+	err := s.adapter.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...)
+	log.DebugLog(log.DebugLevelApi, "Call gorm RemoveFilteredPolicy", "sec", sec, "ptype", ptype, "fieldIndex", fieldIndex, "fieldValues", fieldValues, "took", time.Since(start))
+	return err
 }

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -105,7 +105,10 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	if gitlabToken == "" {
 		log.InfoLog("Note: No gitlab_token env var found")
 	}
-	gitlabClient = gitlab.NewClient(nil, gitlabToken)
+	httpClient := &http.Client{
+		Transport: NewGitlabTransport(),
+	}
+	gitlabClient = gitlab.NewClient(httpClient, gitlabToken)
 	if err := gitlabClient.SetBaseURL(config.GitlabAddr); err != nil {
 		return nil, fmt.Errorf("Gitlab client set base URL to %s, %s",
 			config.GitlabAddr, err.Error())


### PR DESCRIPTION
Adds debug logs to help pinpoint where delays are for MC API timeouts we are seeing on the public cloud instances.
- split MC audit log into start and end so it's clear when initial request is received; log duration
- log calls to network resources: gitlab, gorm sql, casbin sql (via gorm adapter); log duration

Example:
```
2019-03-14T16:24:28.297-0700	INFO	orm/auditlog.go:45	Audit start	{"id": 1, "method": "POST", "uri": "/api/v1/auth/org/create", "remote-ip": "127.0.0.1"}
2019-03-14T16:24:28.299-0700	INFO	log/logger.go:34	Call sql	{"sql": "INSERT INTO \"organizations\" (\"name\",\"type\",\"address\",\"phone\",\"admin_username\",\"created_at\",\"updated_at\") VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING \"organizations\".\"name\"", "vars": ["bigorg","developer","123 abc st","123-456-1234","orgman","2019-03-14T16:24:28.297534732-07:00","2019-03-14T16:24:28.297534732-07:00"], "rows-affected": 1, "lineno": "/Users/gainsley/go/src/github.com/mobiledgex/edge-cloud/mc/orm/org.go:58", "took": "1.492123ms"}
2019-03-14T16:24:28.300-0700	INFO	orm/postgres.go:140	Call gorm AddPolicy	{"sec": "g", "ptype": "g", "rule": ["bigorg::orgman", "DeveloperManager"], "took": "1.259648ms"}
2019-03-14T16:24:28.775-0700	INFO	orm/gitlab.go:99	Call gitlab	{"method": "POST", "url": "http://127.0.0.1:80/api/v4/groups", "status": "201 Created", "err": null, "took": "474.915549ms"}
2019-03-14T16:24:28.856-0700	INFO	go-gitlab/custom_attributes.go:114	Call gitlab	{"method": "PUT", "url": "http://127.0.0.1:80/api/v4/groups/52/custom_attributes/createdby", "status": "200 OK", "err": null, "took": "80.826089ms"}
2019-03-14T16:24:29.935-0700	INFO	orm/gitlab.go:184	Call gitlab	{"method": "POST", "url": "http://127.0.0.1:80/api/v4/projects", "status": "201 Created", "err": null, "took": "1.077928695s"}
2019-03-14T16:24:29.997-0700	INFO	orm/gitlab.go:197	Call gitlab	{"method": "GET", "url": "http://127.0.0.1:80/api/v4/users?username=orgman", "status": "200 OK", "err": null, "took": "62.382469ms"}
2019-03-14T16:24:30.354-0700	INFO	orm/gitlab.go:150	Call gitlab	{"method": "POST", "url": "http://127.0.0.1:80/api/v4/groups/bigorg/members", "status": "201 Created", "err": null, "took": "355.6192ms"}
2019-03-14T16:24:30.354-0700	INFO	orm/auditlog.go:97	Audit end	{"id": 1, "user": "orgman", "status": 200, "req": "{\"name\": \"bigorg\", \"type\": \"developer\", \"address\": \"123 abc st\", \"phone\": \"123-456-1234\"}", "resp": "{\"message\":\"Organization created\",\"name\":\"bigorg\"}", "took": "2.057135795s"}
```