### PR TITLE
EDGECLOUD-492 - fix csharp and unity parseToken, and samples

### DIFF
--- a/edge-mvp/csharp/rest/MatchingEngineSDK.sln
+++ b/edge-mvp/csharp/rest/MatchingEngineSDK.sln
@@ -22,6 +22,10 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 1.3.5.5
+		version = 1.3.5.6
+		Policies = $0
+		$0.DotNetNamingPolicy = $1
+		$1.DirectoryNamespaceAssociation = PrefixedHierarchical
+		$0.VersionControlPolicy = $2
 	EndGlobalSection
 EndGlobal

--- a/edge-mvp/csharp/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/edge-mvp/csharp/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -181,9 +181,16 @@ namespace DistributedMatchEngine
       foreach (string keyValueStr in parameters)
       {
         string[] keyValue = keyValueStr.Split('=');
+        int pos = keyValue[0].Length + 1; // step over '='
+        if (pos >= keyValueStr.Length)
+        {
+          return null;
+        }
+
+        string value = keyValueStr.Substring(pos, keyValueStr.Length - pos);
         if (keyValue[0].Equals("dt-id"))
         {
-          return keyValue[1] + "="; // Have to keep it for some reason?
+          return value;
         }
       }
 

--- a/edge-mvp/csharp/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/edge-mvp/csharp/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>1.3.5.5</ReleaseVersion>
+    <ReleaseVersion>1.3.5.6</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.3.5.5</PackageVersion>
+    <PackageVersion>1.3.5.6</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineRestSDKLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>1.3.5.4</AssemblyVersion>
-    <FileVersion>1.3.5.4</FileVersion>
+    <AssemblyVersion>1.3.5.6</AssemblyVersion>
+    <FileVersion>1.3.5.6</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,9 +29,5 @@
   <ItemGroup>
     <Compile Remove="AppPort.cs" />
     <Compile Remove=":Users:garnerlee:go:src:github.com:mobiledgex:edge-cloud:edge-mvp:unity:MatchingEngineSDK:MatchingEngineSDKLibrary:AppPort.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="MobiledgeX.MatchingEngineSDKRest.1.3.1.nupkg" />
-    <None Remove="MobiledgeX.MatchingEngineSDKRestLibrary.1.3.1.nupkg" />
   </ItemGroup>
 </Project>

--- a/edge-mvp/csharp/rest/RestSample/RestSample.cs
+++ b/edge-mvp/csharp/rest/RestSample/RestSample.cs
@@ -43,7 +43,7 @@ namespace RestSample
         var registerClientReply = await me.RegisterClient(host, port, registerClientRequest);
         Console.WriteLine("Reply: Session Cookie: " + registerClientReply.SessionCookie);
 
-        // Do Verify and FindCloudlet in parallel tasks:
+        // Do Verify and FindCloudlet in concurrent tasks:
         var loc = await locTask;
 
         var verifyLocationRequest = me.CreateVerifyLocationRequest(carrierName, loc);

--- a/edge-mvp/csharp/rest/RestSample/RestSample.csproj
+++ b/edge-mvp/csharp/rest/RestSample/RestSample.csproj
@@ -4,10 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>1.3.5.5</ReleaseVersion>
+    <ReleaseVersion>1.3.5.6</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.3.5.5" />
+    <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.3.5.6" />
   </ItemGroup>
 </Project>

--- a/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -165,9 +165,16 @@ namespace DistributedMatchEngine
       foreach (string keyValueStr in parameters)
       {
         string[] keyValue = keyValueStr.Split('=');
+        int pos = keyValue[0].Length + 1; // step over '='
+        if (pos >= keyValueStr.Length)
+        {
+          return null;
+        }
+
+        string value = keyValueStr.Substring(pos, keyValueStr.Length - pos);
         if (keyValue[0].Equals("dt-id"))
         {
-          return keyValue[1] + "="; // Have to keep it for some reason?
+          return value;
         }
       }
 

--- a/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>1.3.5.5</ReleaseVersion>
+    <ReleaseVersion>1.3.5.6</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.3.5.5</PackageVersion>
+    <PackageVersion>1.3.5.6</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Library for Unity</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -27,9 +27,5 @@
   <ItemGroup>
     <Compile Remove="AppPort.cs" />
     <Compile Remove=":Users:garnerlee:go:src:github.com:mobiledgex:edge-cloud:edge-mvp:unity:MatchingEngineSDK:MatchingEngineSDKLibrary:AppPort.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="MobiledgeX.MatchingEngineSDKRest.1.3.1.nupkg" />
-    <None Remove="MobiledgeX.MatchingEngineSDKRestLibrary.1.3.1.nupkg" />
   </ItemGroup>
 </Project>

--- a/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.cs
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using DistributedMatchEngine;
 
@@ -7,12 +7,12 @@ namespace RestSample
   class Program
   {
     static string carrierName = "tdg";
-    static string appName = "EmptyMatchEngineApp";
-    static string devName = "EmptyMatchEngineApp";
+    static string devName = "MobiledgeX";
+    static string appName = "MobiledgeX SDK Demo";
     static string appVers = "1.0";
     static string developerAuthToken = "";
 
-    static string host = "TDG.dme.mobiledgex.net";
+    static string host = "mexdemo.dme.mobiledgex.net";
     static UInt32 port = 38001;
 
     // Get the ephemerial carriername from device specific properties.
@@ -38,13 +38,13 @@ namespace RestSample
         // LocationService.
         var locTask = Util.GetLocationFromDevice();
 
-        var registerClientRequest = me.CreateRegisterClientRequest(carrierName, appName, devName, appVers, developerAuthToken);
+        var registerClientRequest = me.CreateRegisterClientRequest(carrierName, devName, appName, appVers, developerAuthToken);
 
         // Await synchronously.
         var registerClientReply = await me.RegisterClient(host, port, registerClientRequest);
         Console.WriteLine("Reply: Session Cookie: " + registerClientReply.SessionCookie);
 
-        // Do Verify and FindCloudlet in parallel tasks:
+        // Do Verify and FindCloudlet in concurrent tasks:
         var loc = await locTask;
 
         var verifyLocationRequest = me.CreateVerifyLocationRequest(carrierName, loc);
@@ -54,21 +54,37 @@ namespace RestSample
 
         // Async:
         var findCloudletTask = me.FindCloudlet(host, port, findCloudletRequest);
-        var verfiyLocationTask = me.VerifyLocation(host, port, verifyLocationRequest);
-
-
         var getLocationTask = me.GetLocation(host, port, getLocationRequest);
 
         // Awaits:
         var findCloudletReply = await findCloudletTask;
         Console.WriteLine("FindCloudlet Reply: " + findCloudletReply.status);
+        Console.WriteLine("FindCloudlet:" +
+                " Ver: " + findCloudletReply.Ver +
+                ", FQDN: " + findCloudletReply.FQDN +
+                ", cloudlet_location: " +
+                " long: " + findCloudletReply.cloudlet_location.longitude +
+                ", lat: " + findCloudletReply.cloudlet_location.latitude);
+        // App Ports:
+        foreach (AppPort p in findCloudletReply.ports)
+        {
+          Console.WriteLine("Port: FQDN_prefix: " + p.FQDN_prefix +
+                ", protocol: " + p.proto +
+                ", public_port: " + p.public_port +
+                ", internal_port: " + p.internal_port +
+                ", public_path: " + p.public_path);
+        }
 
-        var verifyLocationReply = await verfiyLocationTask;
-        Console.WriteLine("VerifyLocation Reply: " + verifyLocationReply.gps_location_status);
 
+
+        // A MobiledgeX enabled carrier is required for these two APIs:
         var getLocationReply = await getLocationTask;
         var location = getLocationReply.NetworkLocation;
         Console.WriteLine("GetLocationReply: longitude: " + location.longitude + ", latitude: " + location.latitude);
+
+        Console.WriteLine("VerifyLocation() may timeout, due to reachability of carrier verification servers from your network.");
+        var verifyLocationReply = await me.VerifyLocation(host, port, verifyLocationRequest);
+        Console.WriteLine("VerifyLocation Reply: " + verifyLocationReply.gps_location_status);
       }
       catch (InvalidTokenServerTokenException itste)
       {


### PR DESCRIPTION
- Fixes token parsing. Policy is now to keep base64 string as-is.
- Side: updated unity sample registration info.
- Visual Studio project files updated to 1.3.5.6.
- Side: EOL chars.