### PR TITLE
EDGECLOUD-495 allow MC login via email or username

### DIFF
--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -50,7 +50,14 @@ func Login(c echo.Context) error {
 	}
 	user := ormapi.User{}
 	lookup := ormapi.User{Name: login.Username}
-	err := db.Where(&lookup).First(&user).Error
+	res := db.Where(&lookup).First(&user)
+	if res.RecordNotFound() {
+		// try look-up by email
+		lookup.Name = ""
+		lookup.Email = login.Username
+		res = db.Where(&lookup).First(&user)
+	}
+	err := res.Error
 	if err != nil {
 		log.DebugLog(log.DebugLevelApi, "user lookup failed", "lookup", lookup, "err", err)
 		time.Sleep(BadAuthDelay)


### PR DESCRIPTION
This change allows user to login via either username or email. Both username and email are unique ids within all user records. Username remains the unique id passed around in the JWT.