### PR TITLE
EDGECLOUD-438 clean up autocluster on appinst create failure

### DIFF
--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -50,7 +50,7 @@ func TestAppInstApi(t *testing.T) {
 	// Set responder to fail. This should clean up the object after
 	// the fake crm returns a failure. If it doesn't, the next test to
 	// create all the app insts will fail.
-	responder.SetSimulateCreateFailure(true)
+	responder.SetSimulateAppCreateFailure(true)
 	for _, obj := range testutil.AppInstData {
 		err := appInstApi.CreateAppInst(&obj, &testutil.CudStreamoutAppInst{})
 		assert.NotNil(t, err, "Create app inst responder failures")
@@ -62,7 +62,7 @@ func TestAppInstApi(t *testing.T) {
 			assert.Equal(t, "Encountered failures: [crm create app inst failed]", err.Error())
 		}
 	}
-	responder.SetSimulateCreateFailure(false)
+	responder.SetSimulateAppCreateFailure(false)
 	assert.Equal(t, 0, len(appInstApi.cache.Objs))
 	assert.Equal(t, clusterInstCnt, len(clusterInstApi.cache.Objs))
 
@@ -79,11 +79,11 @@ func TestAppInstApi(t *testing.T) {
 	commonApi := testutil.NewInternalAppInstApi(&appInstApi)
 
 	// Set responder to fail delete.
-	responder.SetSimulateDeleteFailure(true)
+	responder.SetSimulateAppDeleteFailure(true)
 	obj := testutil.AppInstData[0]
 	err := appInstApi.DeleteAppInst(&obj, &testutil.CudStreamoutAppInst{})
 	assert.NotNil(t, err, "Delete AppInst responder failure")
-	responder.SetSimulateDeleteFailure(false)
+	responder.SetSimulateAppDeleteFailure(false)
 	checkAppInstState(t, commonApi, &obj, edgeproto.TrackedState_Ready)
 
 	obj = testutil.AppInstData[0]
@@ -104,8 +104,8 @@ func TestAppInstApi(t *testing.T) {
 	checkAppInstState(t, commonApi, &obj, edgeproto.TrackedState_NotPresent)
 
 	// override CRM error
-	responder.SetSimulateCreateFailure(true)
-	responder.SetSimulateDeleteFailure(true)
+	responder.SetSimulateAppCreateFailure(true)
+	responder.SetSimulateAppDeleteFailure(true)
 	obj = testutil.AppInstData[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IgnoreCRMErrors
 	err = appInstApi.CreateAppInst(&obj, &testutil.CudStreamoutAppInst{})
@@ -124,8 +124,8 @@ func TestAppInstApi(t *testing.T) {
 	obj.CrmOverride = edgeproto.CRMOverride_IgnoreCRM
 	err = appInstApi.DeleteAppInst(&obj, &testutil.CudStreamoutAppInst{})
 	assert.Nil(t, err, "ignore crm")
-	responder.SetSimulateCreateFailure(false)
-	responder.SetSimulateDeleteFailure(false)
+	responder.SetSimulateAppCreateFailure(false)
+	responder.SetSimulateAppDeleteFailure(false)
 
 	dummy.Stop()
 }

--- a/controller/clusterinst_api_test.go
+++ b/controller/clusterinst_api_test.go
@@ -44,14 +44,14 @@ func TestClusterInstApi(t *testing.T) {
 	// Set responder to fail. This should clean up the object after
 	// the fake crm returns a failure. If it doesn't, the next test to
 	// create all the cluster insts will fail.
-	responder.SetSimulateCreateFailure(true)
+	responder.SetSimulateClusterCreateFailure(true)
 	for _, obj := range testutil.ClusterInstData {
 		err := clusterInstApi.CreateClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
 		assert.NotNil(t, err, "Create cluster inst responder failures")
 		// make sure error matches responder
 		assert.Equal(t, "Encountered failures: [crm create cluster inst failed]", err.Error())
 	}
-	responder.SetSimulateCreateFailure(false)
+	responder.SetSimulateClusterCreateFailure(false)
 	assert.Equal(t, 0, len(clusterInstApi.cache.Objs))
 
 	testutil.InternalClusterInstTest(t, "cud", &clusterInstApi, testutil.ClusterInstData)
@@ -61,11 +61,11 @@ func TestClusterInstApi(t *testing.T) {
 	commonApi := testutil.NewInternalClusterInstApi(&clusterInstApi)
 
 	// Set responder to fail delete.
-	responder.SetSimulateDeleteFailure(true)
+	responder.SetSimulateClusterDeleteFailure(true)
 	obj := testutil.ClusterInstData[0]
 	err := clusterInstApi.DeleteClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
 	assert.NotNil(t, err, "Delete ClusterInst responder failure")
-	responder.SetSimulateDeleteFailure(false)
+	responder.SetSimulateClusterDeleteFailure(false)
 	checkClusterInstState(t, commonApi, &obj, edgeproto.TrackedState_Ready)
 
 	// check override of error DeleteError
@@ -85,8 +85,8 @@ func TestClusterInstApi(t *testing.T) {
 	checkClusterInstState(t, commonApi, &obj, edgeproto.TrackedState_NotPresent)
 
 	// override CRM error
-	responder.SetSimulateCreateFailure(true)
-	responder.SetSimulateDeleteFailure(true)
+	responder.SetSimulateClusterCreateFailure(true)
+	responder.SetSimulateClusterDeleteFailure(true)
 	obj = testutil.ClusterInstData[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IgnoreCRMErrors
 	err = clusterInstApi.CreateClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
@@ -105,8 +105,8 @@ func TestClusterInstApi(t *testing.T) {
 	obj.CrmOverride = edgeproto.CRMOverride_IgnoreCRM
 	err = clusterInstApi.DeleteClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
 	assert.Nil(t, err, "ignore crm")
-	responder.SetSimulateCreateFailure(false)
-	responder.SetSimulateDeleteFailure(false)
+	responder.SetSimulateClusterCreateFailure(false)
+	responder.SetSimulateClusterDeleteFailure(false)
 
 	dummy.Stop()
 }

--- a/controller/dummy_info_responder.go
+++ b/controller/dummy_info_responder.go
@@ -33,23 +33,34 @@ func NewDummyInfoResponder(appInstCache *edgeproto.AppInstCache, clusterInstCach
 }
 
 type DummyInfoResponder struct {
-	AppInstCache          *edgeproto.AppInstCache
-	AppInstInfoCache      edgeproto.AppInstInfoCache
-	ClusterInstCache      *edgeproto.ClusterInstCache
-	ClusterInstInfoCache  edgeproto.ClusterInstInfoCache
-	RecvAppInstInfo       notify.RecvAppInstInfoHandler
-	RecvClusterInstInfo   notify.RecvClusterInstInfoHandler
-	simulateCreateFailure bool
-	simulateUpdateFailure bool
-	simulateDeleteFailure bool
+	AppInstCache                 *edgeproto.AppInstCache
+	AppInstInfoCache             edgeproto.AppInstInfoCache
+	ClusterInstCache             *edgeproto.ClusterInstCache
+	ClusterInstInfoCache         edgeproto.ClusterInstInfoCache
+	RecvAppInstInfo              notify.RecvAppInstInfoHandler
+	RecvClusterInstInfo          notify.RecvClusterInstInfoHandler
+	simulateAppCreateFailure     bool
+	simulateAppUpdateFailure     bool
+	simulateAppDeleteFailure     bool
+	simulateClusterCreateFailure bool
+	simulateClusterUpdateFailure bool
+	simulateClusterDeleteFailure bool
 }
 
-func (d *DummyInfoResponder) SetSimulateCreateFailure(state bool) {
-	d.simulateCreateFailure = state
+func (d *DummyInfoResponder) SetSimulateAppCreateFailure(state bool) {
+	d.simulateAppCreateFailure = state
 }
 
-func (d *DummyInfoResponder) SetSimulateDeleteFailure(state bool) {
-	d.simulateDeleteFailure = state
+func (d *DummyInfoResponder) SetSimulateAppDeleteFailure(state bool) {
+	d.simulateAppDeleteFailure = state
+}
+
+func (d *DummyInfoResponder) SetSimulateClusterCreateFailure(state bool) {
+	d.simulateClusterCreateFailure = state
+}
+
+func (d *DummyInfoResponder) SetSimulateClusterDeleteFailure(state bool) {
+	d.simulateClusterDeleteFailure = state
 }
 
 func (d *DummyInfoResponder) runClusterInstChanged(key *edgeproto.ClusterInstKey, old *edgeproto.ClusterInst) {
@@ -72,7 +83,7 @@ func (d *DummyInfoResponder) clusterInstChanged(key *edgeproto.ClusterInstKey) {
 		time.Sleep(DummyInfoDelay)
 		d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Updating)
 		log.DebugLog(log.DebugLevelApi, "cluster inst ready", "key", key)
-		if d.simulateUpdateFailure {
+		if d.simulateClusterUpdateFailure {
 			d.ClusterInstInfoCache.SetError(key, edgeproto.TrackedState_UpdateError, "crm update cluster inst failed")
 		} else {
 			d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Ready)
@@ -84,7 +95,7 @@ func (d *DummyInfoResponder) clusterInstChanged(key *edgeproto.ClusterInstKey) {
 		d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Creating)
 		time.Sleep(DummyInfoDelay)
 		log.DebugLog(log.DebugLevelApi, "cluster inst ready", "key", key)
-		if d.simulateCreateFailure {
+		if d.simulateClusterCreateFailure {
 			d.ClusterInstInfoCache.SetError(key, edgeproto.TrackedState_CreateError, "crm create cluster inst failed")
 		} else {
 			d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Ready)
@@ -96,7 +107,7 @@ func (d *DummyInfoResponder) clusterInstChanged(key *edgeproto.ClusterInstKey) {
 		d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Deleting)
 		time.Sleep(DummyInfoDelay)
 		log.DebugLog(log.DebugLevelApi, "cluster inst deleted", "key", key)
-		if d.simulateDeleteFailure {
+		if d.simulateClusterDeleteFailure {
 			d.ClusterInstInfoCache.SetError(key, edgeproto.TrackedState_DeleteError, "crm delete cluster inst failed")
 		} else {
 			info := edgeproto.ClusterInstInfo{Key: *key}
@@ -117,7 +128,7 @@ func (d *DummyInfoResponder) appInstChanged(key *edgeproto.AppInstKey) {
 		time.Sleep(DummyInfoDelay)
 		d.AppInstInfoCache.SetState(key, edgeproto.TrackedState_Updating)
 		log.DebugLog(log.DebugLevelApi, "app inst ready", "key", key)
-		if d.simulateUpdateFailure {
+		if d.simulateAppUpdateFailure {
 			d.AppInstInfoCache.SetError(key, edgeproto.TrackedState_UpdateError, "crm update app inst failed")
 		} else {
 			d.AppInstInfoCache.SetState(key, edgeproto.TrackedState_Ready)
@@ -129,7 +140,7 @@ func (d *DummyInfoResponder) appInstChanged(key *edgeproto.AppInstKey) {
 		d.AppInstInfoCache.SetState(key, edgeproto.TrackedState_Creating)
 		time.Sleep(DummyInfoDelay)
 		log.DebugLog(log.DebugLevelApi, "app inst ready", "key", key)
-		if d.simulateCreateFailure {
+		if d.simulateAppCreateFailure {
 			d.AppInstInfoCache.SetError(key, edgeproto.TrackedState_CreateError, "crm create app inst failed")
 		} else {
 			d.AppInstInfoCache.SetState(key, edgeproto.TrackedState_Ready)
@@ -141,7 +152,7 @@ func (d *DummyInfoResponder) appInstChanged(key *edgeproto.AppInstKey) {
 		d.AppInstInfoCache.SetState(key, edgeproto.TrackedState_Deleting)
 		time.Sleep(DummyInfoDelay)
 		log.DebugLog(log.DebugLevelApi, "app inst deleted", "key", key)
-		if d.simulateDeleteFailure {
+		if d.simulateAppDeleteFailure {
 			d.AppInstInfoCache.SetError(key, edgeproto.TrackedState_DeleteError, "crm delete app inst failed")
 		} else {
 			info := edgeproto.AppInstInfo{Key: *key}


### PR DESCRIPTION
This was a bit tricky, and anyone who wants to try to use defer() to clean up on failure should take a look. The problem was the defer func was not running after checking "err", the return error value. Because I had made err a named return variable, it should have been possible to refer to it inside the defer func. The problem was that in the autocluster{} block (where defer is called), another function call to get the clusterflavorKey redefines err in the current scope. So the err checked in the defer func is not the return err, but the err allocated in the autocluster block (which was always nil). To avoid this type of issue, I named the return err value to be different from the generic "err" used everywhere, and explicitly check that value in the defer func.
I also tweaked the unit test code to be able to test for this case.