### PR TITLE
Use the new reverse-engineered docker base image

### DIFF
--- a/setup-env/ansible/playbooks/mex_vars.yml
+++ b/setup-env/ansible/playbooks/mex_vars.yml
@@ -26,5 +26,4 @@
   - setupfile: setup.yml
   - etcd_url: https://github.com/coreos/etcd/releases/download
   - etcd_version: v3.3.8
-  - vault_token: {{ lookup('file', '~/.mobiledgex/vault.txt') }}
  

--- a/setup-env/e2e-tests/setups/mexdemo/deploy-north-eu-crms.yml
+++ b/setup-env/e2e-tests/setups/mexdemo/deploy-north-eu-crms.yml
@@ -3,6 +3,7 @@ vars:
 - vm1_external_ip: 40.114.198.180
 - vm1_internal_ip: 127.0.0.1
 - controller: mexdemo.ctrl.mobiledgex.net
+- vault_token: 0eb94cce-ab3f-33a3-bd66-0046e8743a14
 
 crms:
 - crmlocal:
@@ -22,7 +23,7 @@ crms:
     CLOUDLET_KIND: openstack
     MEX_OS_IMAGE: mobiledgex
     MEX_EXT_NETWORK: external-network-shared
-    VAULT_TOKEN: {{ vault_token }}
+    VAULT_TOKEN: "{{vault_token}}"
 
 - crmlocal:
     name: crm-berlin
@@ -41,7 +42,7 @@ crms:
     CLOUDLET_KIND: openstack
     MEX_OS_IMAGE: mobiledgex
     MEX_EXT_NETWORK: external-network-shared
-    VAULT_TOKEN: {{ vault_token }}
+    VAULT_TOKEN: "{{vault_token}}"
 
 - crmlocal:
     name: crm-frankfurt
@@ -60,7 +61,7 @@ crms:
     CLOUDLET_KIND: openstack
     MEX_OS_IMAGE: mobiledgex
     MEX_EXT_NETWORK: external-network-shared
-    VAULT_TOKEN: {{ vault_token }}
+    VAULT_TOKEN: "{{vault_token}}"
 
 - crmlocal:
     name: crm-munich
@@ -79,4 +80,4 @@ crms:
     CLOUDLET_KIND: openstack
     MEX_OS_IMAGE: mobiledgex
     MEX_EXT_NETWORK: external-network-shared
-    VAULT_TOKEN: {{ vault_token }}
+    VAULT_TOKEN: "{{vault_token}}"


### PR DESCRIPTION
Switching to the new docker base image for edge-cloud containers.  The
version number is the output of `git describe --tags` in the
edge-cloud-infra repo for the HEAD that was used to build the base
image.