### PR TITLE
Removed ipacess from appinst in the dind yml file

### DIFF
--- a/setup-env/e2e-tests/data/appdata_dind.yml
+++ b/setup-env/e2e-tests/data/appdata_dind.yml
@@ -84,7 +84,6 @@ apps:
   cluster:
     name: AppCluster
   accessports: "tcp:7777"
-  ipaccess: IpAccessDedicatedOrShared
   androidpackagename: com.mobiledgex.sdkdemo
   permitsplatformapps: true
 
@@ -102,7 +101,6 @@ apps:
   cluster:
     name: AppCluster
   accessports: "tcp:8008"
-  ipaccess: IpAccessDedicatedOrShared
   androidpackagename: com.mobiledgex.facedemo
   permitsplatformapps: true
 


### PR DESCRIPTION
removed the ipaccess field from the App/AppInst in the dind yml file to keep in line with:
https://github.com/mobiledgex/edge-cloud/pull/363