### PR TITLE
EDGECLOUD-520 TLS for MC

### DIFF
--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -336,6 +336,14 @@ func (p *MCLocal) Start(logfile string, opts ...StartOp) error {
 		args = append(args, "--tls")
 		args = append(args, p.TLS.ServerCert)
 	}
+	if p.TLS.ServerKey != "" {
+		args = append(args, "--tlskey")
+		args = append(args, p.TLS.ServerKey)
+	}
+	if p.TLS.ClientCert != "" {
+		args = append(args, "--clientCert")
+		args = append(args, p.TLS.ClientCert)
+	}
 	options := StartOptions{}
 	options.ApplyStartOptions(opts...)
 	if options.Debug != "" {

--- a/mc/mc.go
+++ b/mc/mc.go
@@ -15,7 +15,9 @@ var sqlAddr = flag.String("sqlAddr", "127.0.0.1:5432", "Postgresql address")
 var localSql = flag.Bool("localSql", false, "Run local postgres db")
 var initSql = flag.Bool("initSql", false, "Init db when using localSql")
 var debugLevels = flag.String("d", "", fmt.Sprintf("comma separated list of %v", log.DebugLevelStrings))
-var tlsCertFile = flag.String("tls", "", "server tls cert file.  Keyfile and CA file mex-ca.crt must be in same directory")
+var tlsCertFile = flag.String("tls", "", "server tls cert file")
+var tlsKeyFile = flag.String("tlskey", "", "server tls key file")
+var clientCert = flag.String("clientCert", "", "internal tls client cert file")
 var vaultAddr = flag.String("vaultAddr", "http://127.0.0.1:8200", "Vault address")
 var localVault = flag.Bool("localVault", false, "Run local Vault")
 var ldapAddr = flag.String("ldapAddr", "127.0.0.1:9389", "LDAP listener address")
@@ -36,8 +38,10 @@ func main() {
 		InitLocal:   *initSql,
 		LocalVault:  *localVault,
 		TlsCertFile: *tlsCertFile,
+		TlsKeyFile:  *tlsKeyFile,
 		LDAPAddr:    *ldapAddr,
 		GitlabAddr:  *gitlabAddr,
+		ClientCert:  *clientCert,
 	}
 	server, err := orm.RunServer(&config)
 	if err != nil {

--- a/mc/orm/ctrl.go
+++ b/mc/orm/ctrl.go
@@ -19,7 +19,7 @@ func connectController(region string) (*grpc.ClientConn, error) {
 }
 
 func connectControllerAddr(addr string) (*grpc.ClientConn, error) {
-	dialOption, err := tls.GetTLSClientDialOption(addr, serverConfig.TlsCertFile)
+	dialOption, err := tls.GetTLSClientDialOption(addr, serverConfig.ClientCert)
 	if err != nil {
 		return nil, err
 	}

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -59,12 +59,14 @@ func TestController(t *testing.T) {
 	err = server.WaitUntilReady()
 	require.Nil(t, err, "server online")
 
+	mcClient := &ormclient.Client{}
+
 	// login as super user
-	token, err := ormclient.DoLogin(uri, DefaultSuperuser, DefaultSuperpass)
+	token, err := mcClient.DoLogin(uri, DefaultSuperuser, DefaultSuperpass)
 	require.Nil(t, err, "login as superuser")
 
 	// test controller api
-	ctrls, status, err := ormclient.ShowController(uri, token)
+	ctrls, status, err := mcClient.ShowController(uri, token)
 	require.Nil(t, err, "show controllers")
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 0, len(ctrls))
@@ -73,10 +75,10 @@ func TestController(t *testing.T) {
 		Address: ctrlAddr,
 	}
 	// create controller
-	status, err = ormclient.CreateController(uri, token, &ctrl)
+	status, err = mcClient.CreateController(uri, token, &ctrl)
 	require.Nil(t, err, "create controller")
 	require.Equal(t, http.StatusOK, status)
-	ctrls, status, err = ormclient.ShowController(uri, token)
+	ctrls, status, err = mcClient.ShowController(uri, token)
 	require.Nil(t, err, "show controllers")
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 1, len(ctrls))
@@ -84,50 +86,50 @@ func TestController(t *testing.T) {
 	require.Equal(t, ctrl.Address, ctrls[0].Address)
 
 	// create a developers
-	_, orgDev, tokenDev := testCreateUserOrg(t, uri, "dev", "developer",
+	_, orgDev, tokenDev := testCreateUserOrg(t, mcClient, uri, "dev", "developer",
 		testutil.DevData[0].Key.Name)
-	_, _, tokenDev2 := testCreateUserOrg(t, uri, "dev2", "developer",
+	_, _, tokenDev2 := testCreateUserOrg(t, mcClient, uri, "dev2", "developer",
 		testutil.DevData[3].Key.Name)
-	dev3, tokenDev3 := testCreateUser(t, uri, "dev3")
-	dev4, tokenDev4 := testCreateUser(t, uri, "dev4")
+	dev3, tokenDev3 := testCreateUser(t, mcClient, uri, "dev3")
+	dev4, tokenDev4 := testCreateUser(t, mcClient, uri, "dev4")
 	// create an operator
-	_, orgOper, tokenOper := testCreateUserOrg(t, uri, "oper", "operator",
+	_, orgOper, tokenOper := testCreateUserOrg(t, mcClient, uri, "oper", "operator",
 		testutil.OperatorData[0].Key.Name)
-	_, _, tokenOper2 := testCreateUserOrg(t, uri, "oper2", "operator",
+	_, _, tokenOper2 := testCreateUserOrg(t, mcClient, uri, "oper2", "operator",
 		testutil.OperatorData[1].Key.Name)
-	oper3, tokenOper3 := testCreateUser(t, uri, "oper3")
-	oper4, tokenOper4 := testCreateUser(t, uri, "oper4")
+	oper3, tokenOper3 := testCreateUser(t, mcClient, uri, "oper3")
+	oper4, tokenOper4 := testCreateUser(t, mcClient, uri, "oper4")
 
 	// additional users don't have access to orgs yet
-	badPermTestApp(t, uri, tokenDev3, ctrl.Region, &testutil.AppData[0])
-	badPermTestAppInst(t, uri, tokenDev3, ctrl.Region, &testutil.AppInstData[0])
-	badPermTestCloudlet(t, uri, tokenOper3, ctrl.Region, &testutil.CloudletData[0])
+	badPermTestApp(t, mcClient, uri, tokenDev3, ctrl.Region, &testutil.AppData[0])
+	badPermTestAppInst(t, mcClient, uri, tokenDev3, ctrl.Region, &testutil.AppInstData[0])
+	badPermTestCloudlet(t, mcClient, uri, tokenOper3, ctrl.Region, &testutil.CloudletData[0])
 
 	// add new users to orgs
-	testAddUserRole(t, uri, tokenDev, orgDev.Name, "DeveloperContributor", dev3.Name, Success)
-	testAddUserRole(t, uri, tokenDev, orgDev.Name, "DeveloperViewer", dev4.Name, Success)
-	testAddUserRole(t, uri, tokenOper, orgOper.Name, "OperatorContributor", oper3.Name, Success)
-	testAddUserRole(t, uri, tokenOper, orgOper.Name, "OperatorViewer", oper4.Name, Success)
+	testAddUserRole(t, mcClient, uri, tokenDev, orgDev.Name, "DeveloperContributor", dev3.Name, Success)
+	testAddUserRole(t, mcClient, uri, tokenDev, orgDev.Name, "DeveloperViewer", dev4.Name, Success)
+	testAddUserRole(t, mcClient, uri, tokenOper, orgOper.Name, "OperatorContributor", oper3.Name, Success)
+	testAddUserRole(t, mcClient, uri, tokenOper, orgOper.Name, "OperatorViewer", oper4.Name, Success)
 	// make sure dev/ops without user perms can't add new users
-	user5, _ := testCreateUser(t, uri, "user5")
-	testAddUserRole(t, uri, tokenDev3, orgDev.Name, "DeveloperViewer", user5.Name, Fail)
-	testAddUserRole(t, uri, tokenDev4, orgDev.Name, "DeveloperViewer", user5.Name, Fail)
-	testAddUserRole(t, uri, tokenOper3, orgOper.Name, "OperatorViewer", user5.Name, Fail)
-	testAddUserRole(t, uri, tokenOper4, orgOper.Name, "OperatorViewer", user5.Name, Fail)
+	user5, _ := testCreateUser(t, mcClient, uri, "user5")
+	testAddUserRole(t, mcClient, uri, tokenDev3, orgDev.Name, "DeveloperViewer", user5.Name, Fail)
+	testAddUserRole(t, mcClient, uri, tokenDev4, orgDev.Name, "DeveloperViewer", user5.Name, Fail)
+	testAddUserRole(t, mcClient, uri, tokenOper3, orgOper.Name, "OperatorViewer", user5.Name, Fail)
+	testAddUserRole(t, mcClient, uri, tokenOper4, orgOper.Name, "OperatorViewer", user5.Name, Fail)
 
 	// make sure developer and operator cannot see or modify controllers
 	ctrlNew := ormapi.Controller{
 		Region:  "Bad",
 		Address: "bad.mobiledgex.net",
 	}
-	status, err = ormclient.CreateController(uri, tokenDev, &ctrlNew)
+	status, err = mcClient.CreateController(uri, tokenDev, &ctrlNew)
 	require.Equal(t, http.StatusForbidden, status)
-	status, err = ormclient.CreateController(uri, tokenOper, &ctrlNew)
+	status, err = mcClient.CreateController(uri, tokenOper, &ctrlNew)
 	require.Equal(t, http.StatusForbidden, status)
-	ctrls, status, err = ormclient.ShowController(uri, tokenDev)
+	ctrls, status, err = mcClient.ShowController(uri, tokenDev)
 	require.Equal(t, http.StatusForbidden, status)
 	require.Equal(t, 0, len(ctrls))
-	ctrls, status, err = ormclient.ShowController(uri, tokenOper)
+	ctrls, status, err = mcClient.ShowController(uri, tokenOper)
 	require.Equal(t, http.StatusForbidden, status)
 	require.Equal(t, 0, len(ctrls))
 
@@ -135,65 +137,65 @@ func TestController(t *testing.T) {
 	setClusterInstDev(orgDev.Name, testutil.ClusterInstData)
 
 	// make sure operator cannot create apps, appinsts, clusters, etc
-	badPermTestApp(t, uri, tokenOper, ctrl.Region, &testutil.AppData[0])
-	badPermTestAppInst(t, uri, tokenOper, ctrl.Region, &testutil.AppInstData[0])
-	badPermTestClusterInst(t, uri, tokenOper, ctrl.Region, &testutil.ClusterInstData[0])
-	badPermTestApp(t, uri, tokenOper2, ctrl.Region, &testutil.AppData[0])
-	badPermTestAppInst(t, uri, tokenOper2, ctrl.Region, &testutil.AppInstData[0])
-	badPermTestClusterInst(t, uri, tokenOper2, ctrl.Region, &testutil.ClusterInstData[0])
+	badPermTestApp(t, mcClient, uri, tokenOper, ctrl.Region, &testutil.AppData[0])
+	badPermTestAppInst(t, mcClient, uri, tokenOper, ctrl.Region, &testutil.AppInstData[0])
+	badPermTestClusterInst(t, mcClient, uri, tokenOper, ctrl.Region, &testutil.ClusterInstData[0])
+	badPermTestApp(t, mcClient, uri, tokenOper2, ctrl.Region, &testutil.AppData[0])
+	badPermTestAppInst(t, mcClient, uri, tokenOper2, ctrl.Region, &testutil.AppInstData[0])
+	badPermTestClusterInst(t, mcClient, uri, tokenOper2, ctrl.Region, &testutil.ClusterInstData[0])
 	// make sure developer cannot create cloudlet
-	badPermTestCloudlet(t, uri, tokenDev, ctrl.Region, &testutil.CloudletData[0])
-	badPermTestCloudlet(t, uri, tokenDev2, ctrl.Region, &testutil.CloudletData[0])
+	badPermTestCloudlet(t, mcClient, uri, tokenDev, ctrl.Region, &testutil.CloudletData[0])
+	badPermTestCloudlet(t, mcClient, uri, tokenDev2, ctrl.Region, &testutil.CloudletData[0])
 
 	// test operators can modify their own objs but not each other's
-	permTestCloudlet(t, uri, tokenOper, tokenOper2, ctrl.Region,
+	permTestCloudlet(t, mcClient, uri, tokenOper, tokenOper2, ctrl.Region,
 		&testutil.CloudletData[0], &testutil.CloudletData[2])
 	// test developers can modify their own objs but not each other's
-	permTestApp(t, uri, tokenDev, tokenDev2, ctrl.Region,
+	permTestApp(t, mcClient, uri, tokenDev, tokenDev2, ctrl.Region,
 		&testutil.AppData[0], &testutil.AppData[5])
-	permTestAppInst(t, uri, tokenDev, tokenDev2, ctrl.Region,
+	permTestAppInst(t, mcClient, uri, tokenDev, tokenDev2, ctrl.Region,
 		&testutil.AppInstData[0], &testutil.AppInstData[5])
 	// test users with different roles
-	goodPermTestApp(t, uri, tokenDev3, ctrl.Region, &testutil.AppData[0])
-	goodPermTestAppInst(t, uri, tokenDev3, ctrl.Region, &testutil.AppInstData[0])
+	goodPermTestApp(t, mcClient, uri, tokenDev3, ctrl.Region, &testutil.AppData[0])
+	goodPermTestAppInst(t, mcClient, uri, tokenDev3, ctrl.Region, &testutil.AppInstData[0])
 	// test users with different roles
-	goodPermTestCloudlet(t, uri, tokenOper3, ctrl.Region, &testutil.CloudletData[0])
-	goodPermTestClusterInst(t, uri, tokenDev, ctrl.Region, &testutil.ClusterInstData[0])
-	badPermTestClusterInst(t, uri, tokenDev2, ctrl.Region, &testutil.ClusterInstData[0])
+	goodPermTestCloudlet(t, mcClient, uri, tokenOper3, ctrl.Region, &testutil.CloudletData[0])
+	goodPermTestClusterInst(t, mcClient, uri, tokenDev, ctrl.Region, &testutil.ClusterInstData[0])
+	badPermTestClusterInst(t, mcClient, uri, tokenDev2, ctrl.Region, &testutil.ClusterInstData[0])
 
 	// remove users from roles, test that they can't modify anything anymore
-	testRemoveUserRole(t, uri, tokenDev, orgDev.Name, "DeveloperContributor", dev3.Name, Success)
-	badPermTestApp(t, uri, tokenDev3, ctrl.Region, &testutil.AppData[0])
-	badPermTestAppInst(t, uri, tokenDev3, ctrl.Region, &testutil.AppInstData[0])
-	testRemoveUserRole(t, uri, tokenOper, orgOper.Name, "OperatorContributor", oper3.Name, Success)
-	badPermTestCloudlet(t, uri, tokenOper3, ctrl.Region, &testutil.CloudletData[0])
+	testRemoveUserRole(t, mcClient, uri, tokenDev, orgDev.Name, "DeveloperContributor", dev3.Name, Success)
+	badPermTestApp(t, mcClient, uri, tokenDev3, ctrl.Region, &testutil.AppData[0])
+	badPermTestAppInst(t, mcClient, uri, tokenDev3, ctrl.Region, &testutil.AppInstData[0])
+	testRemoveUserRole(t, mcClient, uri, tokenOper, orgOper.Name, "OperatorContributor", oper3.Name, Success)
+	badPermTestCloudlet(t, mcClient, uri, tokenOper3, ctrl.Region, &testutil.CloudletData[0])
 
 	// delete controller
-	status, err = ormclient.DeleteController(uri, token, &ctrl)
+	status, err = mcClient.DeleteController(uri, token, &ctrl)
 	require.Nil(t, err, "delete controller")
 	require.Equal(t, http.StatusOK, status)
-	ctrls, status, err = ormclient.ShowController(uri, token)
+	ctrls, status, err = mcClient.ShowController(uri, token)
 	require.Nil(t, err, "show controllers")
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 0, len(ctrls))
 }
 
-func testCreateUser(t *testing.T, uri, name string) (*ormapi.User, string) {
+func testCreateUser(t *testing.T, mcClient *ormclient.Client, uri, name string) (*ormapi.User, string) {
 	user := ormapi.User{
 		Name:     name,
 		Email:    name + "@gmail.com",
 		Passhash: name + "-password",
 	}
-	status, err := ormclient.CreateUser(uri, &user)
+	status, err := mcClient.CreateUser(uri, &user)
 	require.Nil(t, err, "create user ", name)
 	require.Equal(t, http.StatusOK, status)
 	// login
-	token, err := ormclient.DoLogin(uri, user.Name, user.Passhash)
+	token, err := mcClient.DoLogin(uri, user.Name, user.Passhash)
 	require.Nil(t, err, "login as ", name)
 	return &user, token
 }
 
-func testCreateOrg(t *testing.T, uri, token, orgType, orgName string) *ormapi.Organization {
+func testCreateOrg(t *testing.T, mcClient *ormclient.Client, uri, token, orgType, orgName string) *ormapi.Organization {
 	// create org
 	org := ormapi.Organization{
 		Type:    orgType,
@@ -201,25 +203,25 @@ func testCreateOrg(t *testing.T, uri, token, orgType, orgName string) *ormapi.Or
 		Address: orgName,
 		Phone:   "123-123-1234",
 	}
-	status, err := ormclient.CreateOrg(uri, token, &org)
+	status, err := mcClient.CreateOrg(uri, token, &org)
 	require.Nil(t, err, "create org ", orgName)
 	require.Equal(t, http.StatusOK, status)
 	return &org
 }
 
-func testCreateUserOrg(t *testing.T, uri, name, orgType, orgName string) (*ormapi.User, *ormapi.Organization, string) {
-	user, token := testCreateUser(t, uri, name)
-	org := testCreateOrg(t, uri, token, orgType, orgName)
+func testCreateUserOrg(t *testing.T, mcClient *ormclient.Client, uri, name, orgType, orgName string) (*ormapi.User, *ormapi.Organization, string) {
+	user, token := testCreateUser(t, mcClient, uri, name)
+	org := testCreateOrg(t, mcClient, uri, token, orgType, orgName)
 	return user, org, token
 }
 
-func testAddUserRole(t *testing.T, uri, token, org, role, username string, success bool) {
+func testAddUserRole(t *testing.T, mcClient *ormclient.Client, uri, token, org, role, username string, success bool) {
 	roleArg := ormapi.Role{
 		Username: username,
 		Org:      org,
 		Role:     role,
 	}
-	status, err := ormclient.AddUserRole(uri, token, &roleArg)
+	status, err := mcClient.AddUserRole(uri, token, &roleArg)
 	if success {
 		require.Nil(t, err, "add user role")
 		require.Equal(t, http.StatusOK, status)
@@ -228,13 +230,13 @@ func testAddUserRole(t *testing.T, uri, token, org, role, username string, succe
 	}
 }
 
-func testRemoveUserRole(t *testing.T, uri, token, org, role, username string, success bool) {
+func testRemoveUserRole(t *testing.T, mcClient *ormclient.Client, uri, token, org, role, username string, success bool) {
 	roleArg := ormapi.Role{
 		Username: username,
 		Org:      org,
 		Role:     role,
 	}
-	status, err := ormclient.RemoveUserRole(uri, token, &roleArg)
+	status, err := mcClient.RemoveUserRole(uri, token, &roleArg)
 	require.Nil(t, err, "remove user role")
 	require.Equal(t, http.StatusOK, status)
 	if success {

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -38,11 +38,13 @@ func TestServer(t *testing.T) {
 	err = server.WaitUntilReady()
 	require.Nil(t, err, "server online")
 
+	mcClient := &ormclient.Client{}
+
 	// login as super user
-	token, err := ormclient.DoLogin(uri, DefaultSuperuser, DefaultSuperpass)
+	token, err := mcClient.DoLogin(uri, DefaultSuperuser, DefaultSuperpass)
 	require.Nil(t, err, "login as superuser")
 
-	super, status, err := showCurrentUser(uri, token)
+	super, status, err := showCurrentUser(mcClient, uri, token)
 	require.Nil(t, err, "show super")
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, DefaultSuperuser, super.Name, "super user name")
@@ -50,7 +52,7 @@ func TestServer(t *testing.T) {
 	require.Equal(t, "", super.Salt, "empty salt")
 	require.Equal(t, 0, super.Iter, "empty iter")
 
-	roleAssignments, status, err := ormclient.ShowRoleAssignment(uri, token)
+	roleAssignments, status, err := mcClient.ShowRoleAssignment(uri, token)
 	require.Nil(t, err, "show roles")
 	require.Equal(t, http.StatusOK, status, "show role status")
 	require.Equal(t, 1, len(roleAssignments), "num role assignments")
@@ -58,7 +60,7 @@ func TestServer(t *testing.T) {
 	require.Equal(t, super.Name, roleAssignments[0].Username)
 
 	// show users - only super user at this point
-	users, status, err := ormclient.ShowUsers(uri, token, "")
+	users, status, err := mcClient.ShowUsers(uri, token, "")
 	require.Equal(t, http.StatusOK, status, "show user status")
 	require.Equal(t, 1, len(users))
 	require.Equal(t, DefaultSuperuser, users[0].Name, "super user name")
@@ -66,11 +68,11 @@ func TestServer(t *testing.T) {
 	require.Equal(t, "", users[0].Salt, "empty salt")
 	require.Equal(t, 0, users[0].Iter, "empty iter")
 
-	policies, status, err := showRolePerms(uri, token)
+	policies, status, err := showRolePerms(mcClient, uri, token)
 	require.Nil(t, err, "show role perms err")
 	require.Equal(t, http.StatusOK, status, "show role perms status")
 	require.Equal(t, 82, len(policies), "number of role perms")
-	roles, status, err := showRoles(uri, token)
+	roles, status, err := showRoles(mcClient, uri, token)
 	require.Nil(t, err, "show roles err")
 	require.Equal(t, http.StatusOK, status, "show roles status")
 	require.Equal(t, 9, len(roles), "number of roles")
@@ -81,11 +83,11 @@ func TestServer(t *testing.T) {
 		Email:    "misterx@gmail.com",
 		Passhash: "misterx-password",
 	}
-	status, err = ormclient.CreateUser(uri, &user1)
+	status, err = mcClient.CreateUser(uri, &user1)
 	require.Nil(t, err, "create user")
 	require.Equal(t, http.StatusOK, status, "create user status")
 	// login as new user1
-	tokenMisterX, err := ormclient.DoLogin(uri, user1.Name, user1.Passhash)
+	tokenMisterX, err := mcClient.DoLogin(uri, user1.Name, user1.Passhash)
 	require.Nil(t, err, "login as mister X")
 	// create an Organization
 	org1 := ormapi.Organization{
@@ -94,7 +96,7 @@ func TestServer(t *testing.T) {
 		Address: "123 X Way",
 		Phone:   "123-123-1234",
 	}
-	status, err = ormclient.CreateOrg(uri, tokenMisterX, &org1)
+	status, err = mcClient.CreateOrg(uri, tokenMisterX, &org1)
 	require.Nil(t, err, "create org")
 	require.Equal(t, http.StatusOK, status, "create org status")
 
@@ -104,11 +106,11 @@ func TestServer(t *testing.T) {
 		Email:    "mistery@gmail.com",
 		Passhash: "mistery-password",
 	}
-	status, err = ormclient.CreateUser(uri, &user2)
+	status, err = mcClient.CreateUser(uri, &user2)
 	require.Nil(t, err, "create user")
 	require.Equal(t, http.StatusOK, status, "create user status")
 	// login as new user2
-	tokenMisterY, err := ormclient.DoLogin(uri, user2.Name, user2.Passhash)
+	tokenMisterY, err := mcClient.DoLogin(uri, user2.Name, user2.Passhash)
 	require.Nil(t, err, "login as mister Y")
 	// create an Organization
 	org2 := ormapi.Organization{
@@ -117,127 +119,127 @@ func TestServer(t *testing.T) {
 		Address: "123 Y Way",
 		Phone:   "123-321-1234",
 	}
-	status, err = ormclient.CreateOrg(uri, tokenMisterY, &org2)
+	status, err = mcClient.CreateOrg(uri, tokenMisterY, &org2)
 	require.Nil(t, err, "create org")
 	require.Equal(t, http.StatusOK, status, "create org status")
 
 	// check org membership as mister x
-	orgs, status, err := ormclient.ShowOrgs(uri, tokenMisterX)
+	orgs, status, err := mcClient.ShowOrgs(uri, tokenMisterX)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 1, len(orgs))
 	require.Equal(t, org1.Name, orgs[0].Name)
 	require.Equal(t, org1.Type, orgs[0].Type)
 	// check org membership as mister y
-	orgs, status, err = ormclient.ShowOrgs(uri, tokenMisterY)
+	orgs, status, err = mcClient.ShowOrgs(uri, tokenMisterY)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 1, len(orgs))
 	require.Equal(t, org2.Name, orgs[0].Name)
 	require.Equal(t, org2.Type, orgs[0].Type)
 	// super user should be able to show all orgs
-	orgs, status, err = ormclient.ShowOrgs(uri, token)
+	orgs, status, err = mcClient.ShowOrgs(uri, token)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 2, len(orgs))
 
 	// check role assignments as mister x
-	roleAssignments, status, err = ormclient.ShowRoleAssignment(uri, tokenMisterX)
+	roleAssignments, status, err = mcClient.ShowRoleAssignment(uri, tokenMisterX)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 1, len(roleAssignments))
 	require.Equal(t, user1.Name, roleAssignments[0].Username)
 	// check role assignments as mister y
-	roleAssignments, status, err = ormclient.ShowRoleAssignment(uri, tokenMisterY)
+	roleAssignments, status, err = mcClient.ShowRoleAssignment(uri, tokenMisterY)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 1, len(roleAssignments))
 	require.Equal(t, user2.Name, roleAssignments[0].Username)
 	// super user should be able to see all role assignments
-	roleAssignments, status, err = ormclient.ShowRoleAssignment(uri, token)
+	roleAssignments, status, err = mcClient.ShowRoleAssignment(uri, token)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 3, len(roleAssignments))
 
 	// show org users as mister x
-	users, status, err = ormclient.ShowUsers(uri, tokenMisterX, org1.Name)
+	users, status, err = mcClient.ShowUsers(uri, tokenMisterX, org1.Name)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 1, len(users))
 	require.Equal(t, user1.Name, users[0].Name)
 	// show org users as mister y
-	users, status, err = ormclient.ShowUsers(uri, tokenMisterY, org2.Name)
+	users, status, err = mcClient.ShowUsers(uri, tokenMisterY, org2.Name)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 1, len(users))
 	require.Equal(t, user2.Name, users[0].Name)
 	// super user can see all users with org ID = 0
-	users, status, err = ormclient.ShowUsers(uri, token, "")
+	users, status, err = mcClient.ShowUsers(uri, token, "")
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 3, len(users))
 
 	// check that x and y cannot see each other's org users
-	users, status, err = ormclient.ShowUsers(uri, tokenMisterX, org2.Name)
+	users, status, err = mcClient.ShowUsers(uri, tokenMisterX, org2.Name)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
-	users, status, err = ormclient.ShowUsers(uri, tokenMisterY, org1.Name)
+	users, status, err = mcClient.ShowUsers(uri, tokenMisterY, org1.Name)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
-	users, status, err = ormclient.ShowUsers(uri, tokenMisterX, "foobar")
+	users, status, err = mcClient.ShowUsers(uri, tokenMisterX, "foobar")
 	require.Nil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 
 	// check that x and y cannot delete each other's orgs
-	status, err = ormclient.DeleteOrg(uri, tokenMisterX, &org2)
+	status, err = mcClient.DeleteOrg(uri, tokenMisterX, &org2)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
-	status, err = ormclient.DeleteOrg(uri, tokenMisterY, &org1)
+	status, err = mcClient.DeleteOrg(uri, tokenMisterY, &org1)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 
 	// delete orgs
-	status, err = ormclient.DeleteOrg(uri, tokenMisterX, &org1)
+	status, err = mcClient.DeleteOrg(uri, tokenMisterX, &org1)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	status, err = ormclient.DeleteOrg(uri, tokenMisterY, &org2)
+	status, err = mcClient.DeleteOrg(uri, tokenMisterY, &org2)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	// delete users
-	status, err = ormclient.DeleteUser(uri, tokenMisterX, &user1)
+	status, err = mcClient.DeleteUser(uri, tokenMisterX, &user1)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	status, err = ormclient.DeleteUser(uri, tokenMisterY, &user2)
+	status, err = mcClient.DeleteUser(uri, tokenMisterY, &user2)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 
 	// check orgs are gone
-	orgs, status, err = ormclient.ShowOrgs(uri, token)
+	orgs, status, err = mcClient.ShowOrgs(uri, token)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 0, len(orgs))
 	// check users are gone
-	users, status, err = ormclient.ShowUsers(uri, token, "")
+	users, status, err = mcClient.ShowUsers(uri, token, "")
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 1, len(users))
 }
 
-func showCurrentUser(uri, token string) (*ormapi.User, int, error) {
+func showCurrentUser(mcClient *ormclient.Client, uri, token string) (*ormapi.User, int, error) {
 	user := ormapi.User{}
-	status, err := ormclient.PostJson(uri+"/auth/user/current", token, nil, &user)
+	status, err := mcClient.PostJson(uri+"/auth/user/current", token, nil, &user)
 	return &user, status, err
 }
 
-func showRolePerms(uri, token string) ([]ormapi.RolePerm, int, error) {
+func showRolePerms(mcClient *ormclient.Client, uri, token string) ([]ormapi.RolePerm, int, error) {
 	perms := []ormapi.RolePerm{}
-	status, err := ormclient.PostJson(uri+"/auth/role/perms/show", token, nil, &perms)
+	status, err := mcClient.PostJson(uri+"/auth/role/perms/show", token, nil, &perms)
 	return perms, status, err
 }
 
-func showRoles(uri, token string) ([]string, int, error) {
+func showRoles(mcClient *ormclient.Client, uri, token string) ([]string, int, error) {
 	roles := []string{}
-	status, err := ormclient.PostJson(uri+"/auth/role/show", token, nil, &roles)
+	status, err := mcClient.PostJson(uri+"/auth/role/show", token, nil, &roles)
 	return roles, status, err
 }
 

--- a/mc/ormclient/rest_client.go
+++ b/mc/ormclient/rest_client.go
@@ -2,6 +2,7 @@ package ormclient
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,13 +11,17 @@ import (
 	"github.com/mobiledgex/edge-cloud/mc/ormapi"
 )
 
-func DoLogin(uri, user, pass string) (string, error) {
+type Client struct {
+	SkipVerify bool
+}
+
+func (s *Client) DoLogin(uri, user, pass string) (string, error) {
 	login := ormapi.UserLogin{
 		Username: user,
 		Password: pass,
 	}
 	result := make(map[string]interface{})
-	status, err := PostJson(uri+"/login", "", &login, &result)
+	status, err := s.PostJson(uri+"/login", "", &login, &result)
 	if err != nil {
 		return "", fmt.Errorf("login error, %s", err.Error())
 	}
@@ -34,86 +39,86 @@ func DoLogin(uri, user, pass string) (string, error) {
 	return token, nil
 }
 
-func CreateUser(uri string, user *ormapi.User) (int, error) {
-	return PostJson(uri+"/usercreate", "", user, nil)
+func (s *Client) CreateUser(uri string, user *ormapi.User) (int, error) {
+	return s.PostJson(uri+"/usercreate", "", user, nil)
 }
 
-func DeleteUser(uri, token string, user *ormapi.User) (int, error) {
-	return PostJson(uri+"/auth/user/delete", token, user, nil)
+func (s *Client) DeleteUser(uri, token string, user *ormapi.User) (int, error) {
+	return s.PostJson(uri+"/auth/user/delete", token, user, nil)
 }
 
-func ShowUsers(uri, token, org string) ([]ormapi.User, int, error) {
+func (s *Client) ShowUsers(uri, token, org string) ([]ormapi.User, int, error) {
 	users := []ormapi.User{}
 	in := ormapi.Organization{Name: org}
-	status, err := PostJson(uri+"/auth/user/show", token, &in, &users)
+	status, err := s.PostJson(uri+"/auth/user/show", token, &in, &users)
 	return users, status, err
 }
 
-func CreateController(uri, token string, ctrl *ormapi.Controller) (int, error) {
-	return PostJson(uri+"/auth/controller/create", token, ctrl, nil)
+func (s *Client) CreateController(uri, token string, ctrl *ormapi.Controller) (int, error) {
+	return s.PostJson(uri+"/auth/controller/create", token, ctrl, nil)
 }
 
-func DeleteController(uri, token string, ctrl *ormapi.Controller) (int, error) {
-	return PostJson(uri+"/auth/controller/delete", token, ctrl, nil)
+func (s *Client) DeleteController(uri, token string, ctrl *ormapi.Controller) (int, error) {
+	return s.PostJson(uri+"/auth/controller/delete", token, ctrl, nil)
 }
 
-func ShowController(uri, token string) ([]ormapi.Controller, int, error) {
+func (s *Client) ShowController(uri, token string) ([]ormapi.Controller, int, error) {
 	ctrls := []ormapi.Controller{}
-	status, err := PostJson(uri+"/auth/controller/show", token, nil, &ctrls)
+	status, err := s.PostJson(uri+"/auth/controller/show", token, nil, &ctrls)
 	return ctrls, status, err
 }
 
-func CreateOrg(uri, token string, org *ormapi.Organization) (int, error) {
-	return PostJson(uri+"/auth/org/create", token, org, nil)
+func (s *Client) CreateOrg(uri, token string, org *ormapi.Organization) (int, error) {
+	return s.PostJson(uri+"/auth/org/create", token, org, nil)
 }
 
-func DeleteOrg(uri, token string, org *ormapi.Organization) (int, error) {
-	return PostJson(uri+"/auth/org/delete", token, org, nil)
+func (s *Client) DeleteOrg(uri, token string, org *ormapi.Organization) (int, error) {
+	return s.PostJson(uri+"/auth/org/delete", token, org, nil)
 }
 
-func ShowOrgs(uri, token string) ([]ormapi.Organization, int, error) {
+func (s *Client) ShowOrgs(uri, token string) ([]ormapi.Organization, int, error) {
 	orgs := []ormapi.Organization{}
-	status, err := PostJson(uri+"/auth/org/show", token, nil, &orgs)
+	status, err := s.PostJson(uri+"/auth/org/show", token, nil, &orgs)
 	return orgs, status, err
 }
 
-func AddUserRole(uri, token string, role *ormapi.Role) (int, error) {
-	return PostJson(uri+"/auth/role/adduser", token, role, nil)
+func (s *Client) AddUserRole(uri, token string, role *ormapi.Role) (int, error) {
+	return s.PostJson(uri+"/auth/role/adduser", token, role, nil)
 }
 
-func RemoveUserRole(uri, token string, role *ormapi.Role) (int, error) {
-	return PostJson(uri+"/auth/role/removeuser", token, role, nil)
+func (s *Client) RemoveUserRole(uri, token string, role *ormapi.Role) (int, error) {
+	return s.PostJson(uri+"/auth/role/removeuser", token, role, nil)
 }
 
-func ShowRoleAssignment(uri, token string) ([]ormapi.Role, int, error) {
+func (s *Client) ShowRoleAssignment(uri, token string) ([]ormapi.Role, int, error) {
 	roles := []ormapi.Role{}
-	status, err := PostJson(uri+"/auth/role/assignment/show", token, nil, &roles)
+	status, err := s.PostJson(uri+"/auth/role/assignment/show", token, nil, &roles)
 	return roles, status, err
 }
 
-func CreateData(uri, token string, data *ormapi.AllData, cb func(res *ormapi.Result)) (int, error) {
+func (s *Client) CreateData(uri, token string, data *ormapi.AllData, cb func(res *ormapi.Result)) (int, error) {
 	res := ormapi.Result{}
-	status, err := PostJsonStreamOut(uri+"/auth/data/create", token, data, &res, func() {
+	status, err := s.PostJsonStreamOut(uri+"/auth/data/create", token, data, &res, func() {
 		cb(&res)
 	})
 	return status, err
 }
 
-func DeleteData(uri, token string, data *ormapi.AllData, cb func(res *ormapi.Result)) (int, error) {
+func (s *Client) DeleteData(uri, token string, data *ormapi.AllData, cb func(res *ormapi.Result)) (int, error) {
 	res := ormapi.Result{}
-	status, err := PostJsonStreamOut(uri+"/auth/data/delete", token, data, &res, func() {
+	status, err := s.PostJsonStreamOut(uri+"/auth/data/delete", token, data, &res, func() {
 		cb(&res)
 	})
 	return status, err
 }
 
-func ShowData(uri, token string) (*ormapi.AllData, int, error) {
+func (s *Client) ShowData(uri, token string) (*ormapi.AllData, int, error) {
 	data := ormapi.AllData{}
-	status, err := PostJson(uri+"/auth/data/show", token, nil, &data)
+	status, err := s.PostJson(uri+"/auth/data/show", token, nil, &data)
 	return &data, status, err
 }
 
-func PostJsonSend(uri, token string, reqData interface{}) (*http.Response, error) {
+func (s *Client) PostJsonSend(uri, token string, reqData interface{}) (*http.Response, error) {
 	var body io.Reader
 	if reqData != nil {
 		out, err := json.Marshal(reqData)
@@ -124,6 +129,7 @@ func PostJsonSend(uri, token string, reqData interface{}) (*http.Response, error
 	} else {
 		body = nil
 	}
+
 	req, err := http.NewRequest("POST", uri, body)
 	if err != nil {
 		return nil, fmt.Errorf("post %s http req failed, %s", uri, err.Error())
@@ -132,12 +138,17 @@ func PostJsonSend(uri, token string, reqData interface{}) (*http.Response, error
 	if token != "" {
 		req.Header.Add("Authorization", "Bearer "+token)
 	}
-	client := &http.Client{}
+	tlsConfig := &tls.Config{}
+	if s.SkipVerify {
+		tlsConfig.InsecureSkipVerify = true
+	}
+	tr := &http.Transport{TLSClientConfig: tlsConfig}
+	client := &http.Client{Transport: tr}
 	return client.Do(req)
 }
 
-func PostJson(uri, token string, reqData interface{}, replyData interface{}) (int, error) {
-	resp, err := PostJsonSend(uri, token, reqData)
+func (s *Client) PostJson(uri, token string, reqData interface{}, replyData interface{}) (int, error) {
+	resp, err := s.PostJsonSend(uri, token, reqData)
 	if err != nil {
 		return 0, fmt.Errorf("post %s client do failed, %s", uri, err.Error())
 	}
@@ -151,8 +162,8 @@ func PostJson(uri, token string, reqData interface{}, replyData interface{}) (in
 	return resp.StatusCode, nil
 }
 
-func PostJsonStreamOut(uri, token string, reqData interface{}, replyData interface{}, replyReady func()) (int, error) {
-	resp, err := PostJsonSend(uri, token, reqData)
+func (s *Client) PostJsonStreamOut(uri, token string, reqData interface{}, replyData interface{}, replyReady func()) (int, error) {
+	resp, err := s.PostJsonSend(uri, token, reqData)
 	if err != nil {
 		return 0, fmt.Errorf("post %s client do failed, %s", uri, err.Error())
 	}

--- a/protoc-gen-mc2/genmc2.go
+++ b/protoc-gen-mc2/genmc2.go
@@ -346,16 +346,16 @@ func {{.MethodName}}Obj(rc *RegionContext, obj *edgeproto.{{.InName}}) ([]edgepr
 `
 
 var tmplMethodTest = `
-func test{{.MethodName}}(uri, token, region string, in *edgeproto.{{.InName}}) (int, error) {
+func test{{.MethodName}}(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.{{.InName}}) (int, error) {
 	dat := &Region{{.InName}}{}
 	dat.Region = region
 	dat.{{.InName}} = *in
 {{- if .Outstream}}
 	out := edgeproto.{{.OutName}}{}
-	status, err := ormclient.PostJsonStreamOut(uri+"/auth/ctrl/{{.MethodName}}", token, dat, &out, nil)
+	status, err := mcClient.PostJsonStreamOut(uri+"/auth/ctrl/{{.MethodName}}", token, dat, &out, nil)
 {{- else}}
 	out := edgeproto.{{.OutName}}{}
-	status, err := ormclient.PostJson(uri+"/auth/ctrl/{{.MethodName}}", token, dat, &out)
+	status, err := mcClient.PostJson(uri+"/auth/ctrl/{{.MethodName}}", token, dat, &out)
 {{- end}}
 	return status, err
 }
@@ -382,49 +382,49 @@ type msgArgs struct {
 var tmplMessageTest = `
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTest{{.Message}}(t *testing.T, uri, token, region string, obj *edgeproto.{{.Message}}) {
-	status, err := testCreate{{.Message}}(uri, token, region, obj)
+func badPermTest{{.Message}}(t *testing.T, mcClient *ormclient.Client, uri, token, region string, obj *edgeproto.{{.Message}}) {
+	status, err := testCreate{{.Message}}(mcClient, uri, token, region, obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
-	status, err = testUpdate{{.Message}}(uri, token, region, obj)
+	status, err = testUpdate{{.Message}}(mcClient, uri, token, region, obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
-	status, err = testDelete{{.Message}}(uri, token, region, obj)
+	status, err = testDelete{{.Message}}(mcClient, uri, token, region, obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 	// show is allowed but won't show anything
-	status, err = testShow{{.Message}}(uri, token, region, obj)
+	status, err = testShow{{.Message}}(mcClient, uri, token, region, obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTest{{.Message}}(t *testing.T, uri, token, region string, obj *edgeproto.{{.Message}}) {
-	status, err := testCreate{{.Message}}(uri, token, region, obj)
+func goodPermTest{{.Message}}(t *testing.T, mcClient *ormclient.Client, uri, token, region string, obj *edgeproto.{{.Message}}) {
+	status, err := testCreate{{.Message}}(mcClient, uri, token, region, obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	status, err = testUpdate{{.Message}}(uri, token, region, obj)
+	status, err = testUpdate{{.Message}}(mcClient, uri, token, region, obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	status, err = testDelete{{.Message}}(uri, token, region, obj)
+	status, err = testDelete{{.Message}}(mcClient, uri, token, region, obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	status, err = testShow{{.Message}}(uri, token, region, obj)
+	status, err = testShow{{.Message}}(mcClient, uri, token, region, obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 
 	// make sure region check works
-	status, err = testCreate{{.Message}}(uri, token, "bad region", obj)
+	status, err = testCreate{{.Message}}(mcClient, uri, token, "bad region", obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusBadRequest, status)
-	status, err = testUpdate{{.Message}}(uri, token, "bad region", obj)
+	status, err = testUpdate{{.Message}}(mcClient, uri, token, "bad region", obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusBadRequest, status)
-	status, err = testDelete{{.Message}}(uri, token, "bad region", obj)
+	status, err = testDelete{{.Message}}(mcClient, uri, token, "bad region", obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusBadRequest, status)
-	status, err = testShow{{.Message}}(uri, token, "bad region", obj)
+	status, err = testShow{{.Message}}(mcClient, uri, token, "bad region", obj)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusBadRequest, status)
 }
@@ -432,11 +432,11 @@ func goodPermTest{{.Message}}(t *testing.T, uri, token, region string, obj *edge
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTest{{.Message}}(t *testing.T, uri, token1, token2, region string, obj1, obj2 *edgeproto.{{.Message}}) {
-	badPermTest{{.Message}}(t, uri, token1, region, obj2)
-	badPermTest{{.Message}}(t, uri, token2, region, obj1)
-	goodPermTest{{.Message}}(t, uri, token1, region, obj1)
-	goodPermTest{{.Message}}(t, uri, token2, region, obj2)
+func permTest{{.Message}}(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region string, obj1, obj2 *edgeproto.{{.Message}}) {
+	badPermTest{{.Message}}(t, mcClient, uri, token1, region, obj2)
+	badPermTest{{.Message}}(t, mcClient, uri, token2, region, obj1)
+	goodPermTest{{.Message}}(t, mcClient, uri, token1, region, obj1)
+	goodPermTest{{.Message}}(t, mcClient, uri, token2, region, obj2)
 }
 `
 

--- a/setup-env/e2e-tests/setups/local_multi.yml
+++ b/setup-env/e2e-tests/setups/local_multi.yml
@@ -258,6 +258,7 @@ mcs:
     vaultaddr: "http://127.0.0.1:8200"
     tls:
        servercert: "{{tlsoutdir}}/mex-server.crt"
+       serverkey: "{{tlsoutdir}}/mex-server.key"
        clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
 


### PR DESCRIPTION
Changes for the MC to use certs. Please review since Wonho says this is blocking the UI team.

The tls and tlskey options should be used for server certs for the UI connecting to MC.
The clientCert option should be used for certs for the MC connecting to country controllers.

In the end I think both the above communication channels are our within our internal network and will be our hard-coded certs (for now), eventually replaced with certs from an internal PKI by Vault.

Most of the changes are to update the test functions to object funcs so we can configure the client to use TLS or not.