### PR TITLE
fix DIND

### DIFF
--- a/cloud-resource-manager/platform/dind/dind.go
+++ b/cloud-resource-manager/platform/dind/dind.go
@@ -21,7 +21,19 @@ func (s *Platform) Init(key *edgeproto.CloudletKey) error {
 }
 
 func (s *Platform) GatherCloudletInfo(info *edgeproto.CloudletInfo) error {
-	return GetLimits(info)
+	err := GetLimits(info)
+	if err != nil {
+		return err
+	}
+	info.Flavors = []*edgeproto.FlavorInfo{
+		&edgeproto.FlavorInfo{
+			Name:  "DINDFlavor",
+			Vcpus: uint64(info.OsMaxVcores),
+			Ram:   uint64(info.OsMaxRam),
+			Disk:  uint64(500),
+		},
+	}
+	return nil
 }
 
 func (s *Platform) GetPlatformClient() pc.PlatformClient {

--- a/setup-env/ansible/playbooks/cloudlet_standalone_deploy.yml
+++ b/setup-env/ansible/playbooks/cloudlet_standalone_deploy.yml
@@ -68,10 +68,11 @@
      group: root
      mode: 0755
 
-  #- name: start mexosagent 
-  #  service:
-  #     name: mexosagent
-  #     state: started
+#  - name: start mexosagent 
+#    service:
+#       enabled: yes
+#       name: mexosagent
+#       state: started
 
   - name: copy crm binary
     copy:
@@ -79,14 +80,21 @@
        dest: "{{ remote_bin_path }}"
        mode: 0755 
 
+  - name: copy crmserver.service template
+    template:
+       src: templates/crmserver.j2
+       dest: "{{ crmserver_remote_svc }}"
+
   - name: show CRM startup variables
     debug:
        var: crm
 
-  - name: start up crmserver process
-    shell: "nohup {{ crm_remote_bin }} --apiAddr 0.0.0.0:37001 --notifyAddrs {{ crm.ctrladdr }} --cloudletKey '{{ crm.cloudletkey }}' --tls {{ remote_tls_path }}/mex-server.crt  --d api,notify,mexos > {{ remote_log_path }}/{{ crm.name }}.log 2>&1 &"
-    environment:
-      CLOUDLET_KIND: dind
-      NETWORK_SCHEME: publicip
-      MEXENV_URL: https://vault.mobiledgex.net/v1/secret/data/cloudlet/openstack/mexenv.json
+  - name: systemctl daemon-reload
+    command: systemctl daemon-reload
+
+  - name: start crmserver
+    service: 
+       enabled: yes
+       name: crmserver
+       state: restarted
 

--- a/setup-env/ansible/playbooks/mex_vars.yml
+++ b/setup-env/ansible/playbooks/mex_vars.yml
@@ -3,9 +3,12 @@
   - tlsoutdir: "{{ gopath }}/src/github.com/mobiledgex/edge-cloud/tls/out"
   - server_to_path:
       Linux_x86_64: "{{ gopath }}/bin/linux_amd64"
+      Linux_aarch64: "{{ gopath }}/bin/linux_arm64"
       Darwin_x86_64: "{{ gopath }}/bin"
   - mexosagent_local_svc: "{{ gopath }}/src/github.com/mobiledgex/edge-cloud-infra/openstack-tenant/agent/mexosagent.service" 
   - mexosagent_remote_svc: "/etc/systemd/system/mexosagent.service"
+  - crmserver_remote_svc:  "/etc/systemd/system/crmserver.service"
+  - vault_token: "0eb94cce-ab3f-33a3-bd66-0046e8743a14"
   - servertype: "{{ ansible_system }}_{{ ansible_architecture }}"
   - local_binpath: "{{ server_to_path[servertype] }}"
   - controller_bin: "{{ local_binpath }}/controller"

--- a/setup-env/ansible/playbooks/templates/crmserver.j2
+++ b/setup-env/ansible/playbooks/templates/crmserver.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=CRM Service
+Wants=network.target
+After=network.target
+
+[Service]
+ExecStart=/bin/bash -ce "exec /usr/local/bin/crmserver --apiAddr 0.0.0.0:37001 --notifyAddrs {{ crm.ctrladdr }} --cloudletKey '{\"operator_key\":{\"name\":\"{{ crm.operator }}\"},\"name\":\"{{ crm.cloudlet }}\"}' --tls {{ remote_tls_path }}/mex-server.crt --platform mexdind --d api,notify,mexos >> {{ remote_log_path }}/{{ crm.name }}.log 2>&1"
+WorkingDirectory=/root
+Restart=always
+User=root
+Environment=MEX_NETWORK_SCHEME=publicip
+Environment=MEXENV_URL=https://vault.mobiledgex.net/v1/secret/data/cloudlet/openstack/mexenv.json
+Environment=VAULT_TOKEN={{ vault_token }}
+Environment=MEX_NETWORK_SCHEME=privateip
+[Install]
+WantedBy=multi-user.target
+Alias=crmserver

--- a/setup-env/ansible/standalone-inventory.yml
+++ b/setup-env/ansible/standalone-inventory.yml
@@ -2,13 +2,13 @@
 
 mexservers:
    hosts:
-       90.84.194.49
+       90.84.192.21
    vars:
       ansible_ssh_private_key_file: ~/.mobiledgex/id_rsa_mex
       ansible_ssh_user: cloud
-
       crm:
         name: orange-crm1
         ctrladdr: mexdemo.ctrl.mobiledgex.net:37001
-        cloudletkey: '{"operator_key":{"name":"Orange"},"name":"west-eu"}'
+        operator: Orange
+        cloudlet: west-eu
 


### PR DESCRIPTION
- After recent flavor changes, dind does not work due to "no suitable platform flavor found".  Fix is to update info.Flavors for dind.  Note I suspect GCP is still broken.

- Update ansible playbooks for dind; some tweaks were needed for new startup variables anyway but I decided to change the process based startup to use a service instead of a nohup so it can survive reboots.   It may change to docker at some point anyway.  