### PR TITLE
go 1.12 vet fix

### DIFF
--- a/protoc-gen-cmd/yaml/example_embedded_test.go
+++ b/protoc-gen-cmd/yaml/example_embedded_test.go
@@ -1,4 +1,4 @@
-package yaml_test
+package yaml
 
 import (
 	"fmt"


### PR DESCRIPTION
Ashish ran into this before with go 1.12. Error is:
```
edge-cloud> go vet ./...
# github.com/mobiledgex/edge-cloud/protoc-gen-cmd/yaml_test
protoc-gen-cmd/yaml/example_embedded_test.go:29:1: ExampleUnmarshal_embedded refers to unknown identifier: Unmarshal
```
Now that we need to move to go 1.12 for plugin support, fixing this. It is not fixed upstream. As noted here (https://golang.org/pkg/testing/), functions that start with "Example" in test packages must have names in a certain format that refer to certain funcs/etc. In this case, go vet is looking for a function called Unmarshal, which does not exist in the yaml_test package, but does exist in the yaml package. So fix is to rename the package declaration for the test file.