### PR TITLE
cleanup fixes for appinst

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -271,7 +271,12 @@ func (cd *ControllerData) appInstChanged(key *edgeproto.AppInstKey, old *edgepro
 			if err != nil {
 				errstr := fmt.Sprintf("Create App Inst failed: %s", err)
 				cd.appInstInfoError(key, edgeproto.TrackedState_CreateError, errstr)
-				log.DebugLog(log.DebugLevelMexos, "can't create app inst", "error", errstr, "key", key)
+				log.InfoLog("can't create app inst", "error", errstr, "key", key)
+				log.DebugLog(log.DebugLevelMexos, "cleaning up failed appinst", "key", key)
+				derr := cd.platform.DeleteAppInst(&clusterInst, &app, &appInst, names)
+				if derr != nil {
+					log.InfoLog("can't cleanup app inst", "error", errstr, "key", key)
+				}
 				return
 			}
 			log.DebugLog(log.DebugLevelMexos, "created docker app inst", "appisnt", appInst, "clusterinst", clusterInst)

--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -2,6 +2,7 @@ package k8smgmt
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
@@ -36,10 +37,15 @@ func CreateAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.Ap
 }
 
 func DeleteAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.App, appInst *edgeproto.AppInst) error {
+	log.DebugLog(log.DebugLevelMexos, "deleting app", "name", names.AppName)
 	cmd := fmt.Sprintf("%s kubectl delete -f %s.yaml", names.KconfEnv, names.AppName)
 	out, err := client.Output(cmd)
 	if err != nil {
-		return fmt.Errorf("error deleting kuberknetes app, %s, %s, %s, %v", names.AppName, cmd, out, err)
+		if strings.Contains(string(out), "not found") {
+			log.DebugLog(log.DebugLevelMexos, "app not found, cannot delete", "name", names.AppName)
+		} else {
+			return fmt.Errorf("error deleting kuberknetes app, %s, %s, %s, %v", names.AppName, cmd, out, err)
+		}
 	}
 	log.DebugLog(log.DebugLevelMexos, "deleted deployment", "name", names.AppName)
 	return nil


### PR DESCRIPTION
Related to EDGEDCLOUD-208; there is also an edge-cloud-infra portion.

Included here:
- If CreateAppInst fails, attempt to perform a delete.  
- In DeleteAppInst, ignore errors if the app is already gone. If someone deleted it manually for example, this will be the case. We still need to continue cleanup of other things such as the proxy when this happens.


 