### PR TITLE
CRM plugin support in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-linux:
 	make -C d-match-engine linux
 
 build-docker:
-	docker build -t mobiledgex/edge-cloud:${TAG} -f docker/Dockerfile.edge-cloud .
+	docker build -t mobiledgex/edge-cloud:${TAG} -f docker/Dockerfile.edge-cloud ..
 	docker tag mobiledgex/edge-cloud:${TAG} registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
 	docker push registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
 	for ADDLTAG in ${ADDLTAGS}; do \

--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -162,7 +162,7 @@ func getPlatform(plat string) (pf.Platform, error) {
 	log.DebugLog(log.DebugLevelMexos, "Loading plugin", "plugin", *solib)
 	plug, err := plugin.Open(*solib)
 	if err != nil {
-		log.FatalLog("failed to load plugin", "plugin", *solib)
+		log.FatalLog("failed to load plugin", "plugin", *solib, "error", err)
 	}
 	sym, err := plug.Lookup("GetPlatform")
 	if err != nil {

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -16,7 +16,7 @@ ENV GOVERS 1.12.1
 ENV PROTOCVERS 3.6.0
 
 RUN apt-get update
-RUN apt-get install -y wget curl unzip  make git
+RUN apt-get install -y wget curl unzip  make git build-essential
 RUN wget --quiet https://dl.google.com/go/go${GOVERS}.linux-amd64.tar.gz
 RUN tar xf go${GOVERS}.linux-amd64.tar.gz
 RUN mv go/* /usr/local/

--- a/docker/Dockerfile.edge-cloud
+++ b/docker/Dockerfile.edge-cloud
@@ -12,16 +12,19 @@
 
 FROM registry.mobiledgex.net:5000/mobiledgex/build:go1.12.1 AS build
 
-WORKDIR /go/src/github.com/mobiledgex/edge-cloud/
 ENV GOPATH=/go
 ENV PATH="/go/bin:${PATH}"
-COPY . .
+WORKDIR /go/src/github.com/mobiledgex
+COPY edge-cloud edge-cloud
+COPY edge-cloud-infra edge-cloud-infra
+WORKDIR /go/src/github.com/mobiledgex/edge-cloud
 RUN go get github.com/grpc-ecosystem/grpc-gateway; exit 0
 RUN go get github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc; exit 0
 RUN go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger; exit 0
 RUN make tools
 RUN make clean
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
+WORKDIR /go/src/github.com/mobiledgex/edge-cloud-infra
 RUN make
 
 FROM registry.mobiledgex.net:5000/mobiledgex/edge-cloud-base-image:v0.0.14-2-gdbcb89c
@@ -33,17 +36,18 @@ COPY --from=build /go/bin/edgectl /usr/local/bin
 COPY --from=build /go/bin/tok-srv-sim /usr/local/bin
 COPY --from=build /go/bin/loc-api-sim /usr/local/bin
 COPY --from=build /go/bin/mc /usr/local/bin
+COPY --from=build /go/plugins /plugins
 
-ADD docker/mex-docker.env /root/mex-docker.env
-ADD docker/edge-cloud-entrypoint.sh /usr/local/bin
-ADD docker/test-edgectl.sh /usr/local/bin
-ADD tls/out/mex-ca.crt /root/tls/mex-ca.crt
-ADD tls/out/mex-server.crt /root/tls/mex-server.crt
-ADD tls/out/mex-server.key /root/tls/mex-server.key
-ADD docker/beredgecloudtelekomde.crt /root/.mobiledgex/beredgecloudtelekomde.crt
-ADD docker/bonnedgecloudtelekomde.crt /root/.mobiledgex/bonnedgecloudtelekomde.crt
-ADD docker/fraedgecloudtelekomde.crt /root/.mobiledgex/fraedgecloudtelekomde.crt
-ADD docker/telesec_chain.crt /root/.mobiledgex/telesec_chain.crt
+ADD edge-cloud/docker/mex-docker.env /root/mex-docker.env
+ADD edge-cloud/docker/edge-cloud-entrypoint.sh /usr/local/bin
+ADD edge-cloud/docker/test-edgectl.sh /usr/local/bin
+ADD edge-cloud/tls/out/mex-ca.crt /root/tls/mex-ca.crt
+ADD edge-cloud/tls/out/mex-server.crt /root/tls/mex-server.crt
+ADD edge-cloud/tls/out/mex-server.key /root/tls/mex-server.key
+ADD edge-cloud/docker/beredgecloudtelekomde.crt /root/.mobiledgex/beredgecloudtelekomde.crt
+ADD edge-cloud/docker/bonnedgecloudtelekomde.crt /root/.mobiledgex/bonnedgecloudtelekomde.crt
+ADD edge-cloud/docker/fraedgecloudtelekomde.crt /root/.mobiledgex/fraedgecloudtelekomde.crt
+ADD edge-cloud/docker/telesec_chain.crt /root/.mobiledgex/telesec_chain.crt
 RUN chmod +x /usr/local/bin/edge-cloud-entrypoint.sh /usr/local/bin/test-edgectl.sh
 #RUN apt-get update
 #RUN apt -y install openssh-server


### PR DESCRIPTION
* Docker builds (as with regular builds now) depend on both the edge-cloud and edge-cloud-infra repos, and so the docker build context now needs to be the parent directory of both these repos.
* Plugin compilation requires gcc, and so the Docker build image needs an update to include the build-essential package
* Docker binaries now need to be dynamically linked (with CGO_ENABLED) to support plugin loading