### PR TITLE
Add build version to docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ build-linux:
 	make -C d-match-engine linux
 
 build-docker:
-	docker build -t mobiledgex/edge-cloud:${TAG} -f docker/Dockerfile.edge-cloud ..
+	docker build --build-arg BUILD_TAG="$(shell git describe --always --dirty=+), $(shell date +'%Y-%m-%d')" \
+		-t mobiledgex/edge-cloud:${TAG} -f docker/Dockerfile.edge-cloud ..
 	docker tag mobiledgex/edge-cloud:${TAG} registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
 	docker push registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
 	for ADDLTAG in ${ADDLTAGS}; do \

--- a/docker/Dockerfile.edge-cloud
+++ b/docker/Dockerfile.edge-cloud
@@ -28,6 +28,10 @@ WORKDIR /go/src/github.com/mobiledgex/edge-cloud-infra
 RUN make
 
 FROM registry.mobiledgex.net:5000/mobiledgex/edge-cloud-base-image:v0.0.14-2-gdbcb89c
+
+# Will be overridden during build from the command line
+ARG BUILD_TAG=latest
+
 COPY --from=build /go/bin/controller /usr/local/bin
 COPY --from=build /go/bin/crmserver /usr/local/bin
 COPY --from=build /go/bin/dme-server /usr/local/bin
@@ -49,8 +53,8 @@ ADD edge-cloud/docker/bonnedgecloudtelekomde.crt /root/.mobiledgex/bonnedgecloud
 ADD edge-cloud/docker/fraedgecloudtelekomde.crt /root/.mobiledgex/fraedgecloudtelekomde.crt
 ADD edge-cloud/docker/telesec_chain.crt /root/.mobiledgex/telesec_chain.crt
 RUN chmod +x /usr/local/bin/edge-cloud-entrypoint.sh /usr/local/bin/test-edgectl.sh
-#RUN apt-get update
-#RUN apt -y install openssh-server
+
+RUN echo $BUILD_TAG >/version.txt
 
 ENTRYPOINT [ "edge-cloud-entrypoint.sh" ]
 CMD []

--- a/docker/edge-cloud-entrypoint.sh
+++ b/docker/edge-cloud-entrypoint.sh
@@ -45,6 +45,10 @@ case "$1" in
 	shift
 	test-edgectl.sh $*
 	;;
+    version)
+	shift
+	cat /version.txt
+	;;
     bash)
 	shift
 	/bin/bash $*


### PR DESCRIPTION
Add a build version consisting of the git commit hash and the timestamp to the edge-cloud image.  This can be queried by passing the "version" argument on the docker run command line.