### PR TITLE
EDGECLOUD-476 mc occasional timeout

### DIFF
--- a/mc/mc.go
+++ b/mc/mc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/mc/orm"
@@ -22,6 +23,7 @@ var vaultAddr = flag.String("vaultAddr", "http://127.0.0.1:8200", "Vault address
 var localVault = flag.Bool("localVault", false, "Run local Vault")
 var ldapAddr = flag.String("ldapAddr", "127.0.0.1:9389", "LDAP listener address")
 var gitlabAddr = flag.String("gitlabAddr", "http://127.0.0.1:80", "Gitlab server address")
+var pingInterval = flag.Duration("pingInterval", 20*time.Second, "SQL database ping keep-alive interval")
 
 var sigChan chan os.Signal
 
@@ -31,17 +33,18 @@ func main() {
 	sigChan = make(chan os.Signal, 1)
 
 	config := orm.ServerConfig{
-		ServAddr:    *addr,
-		SqlAddr:     *sqlAddr,
-		VaultAddr:   *vaultAddr,
-		RunLocal:    *localSql,
-		InitLocal:   *initSql,
-		LocalVault:  *localVault,
-		TlsCertFile: *tlsCertFile,
-		TlsKeyFile:  *tlsKeyFile,
-		LDAPAddr:    *ldapAddr,
-		GitlabAddr:  *gitlabAddr,
-		ClientCert:  *clientCert,
+		ServAddr:     *addr,
+		SqlAddr:      *sqlAddr,
+		VaultAddr:    *vaultAddr,
+		RunLocal:     *localSql,
+		InitLocal:    *initSql,
+		LocalVault:   *localVault,
+		TlsCertFile:  *tlsCertFile,
+		TlsKeyFile:   *tlsKeyFile,
+		LDAPAddr:     *ldapAddr,
+		GitlabAddr:   *gitlabAddr,
+		ClientCert:   *clientCert,
+		PingInterval: *pingInterval,
 	}
 	server, err := orm.RunServer(&config)
 	if err != nil {

--- a/mc/orm/postgres.go
+++ b/mc/orm/postgres.go
@@ -46,7 +46,7 @@ func InitSql(addr, username, password, dbname string) (*gorm.DB, persist.Adapter
 	return db, &adapterLogger{adapter}, nil
 }
 
-func InitData(superuser, superpass string, stop *bool, done chan struct{}) {
+func InitData(superuser, superpass string, pingInterval time.Duration, stop *bool, done chan struct{}) {
 	if db == nil {
 		log.FatalLog("db not initialized")
 	}
@@ -81,6 +81,12 @@ func InitData(superuser, superpass string, stop *bool, done chan struct{}) {
 		log.DebugLog(log.DebugLevelApi, "init data done")
 		break
 	}
+	go func() {
+		for {
+			time.Sleep(pingInterval)
+			db.DB().Ping()
+		}
+	}()
 	close(done)
 }
 

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -40,6 +40,7 @@ type ServerConfig struct {
 	LDAPAddr      string
 	GitlabAddr    string
 	ClientCert    string
+	PingInterval  time.Duration
 }
 
 var DefaultDBUser = "mcuser"
@@ -149,7 +150,7 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	server.db = db
 
 	server.initDataDone = make(chan struct{}, 1)
-	go InitData(superuser, superpass, &server.stopInitData, server.initDataDone)
+	go InitData(superuser, superpass, config.PingInterval, &server.stopInitData, server.initDataDone)
 
 	e := echo.New()
 	e.HideBanner = true


### PR DESCRIPTION
Debugging on the MC container, what happens during the timeout is the MC is trying to connect to the postgres server, but fails to connect. However, what it’s doing is using a persistent connection that’s already been opened. So it’s likely that there is some NAT/FW outbound rule that was instantiated on tcp syn that allows packets back in on the outbound client port, but that rule times out after a period of inactivity. A new request to the MC triggers a new connection (tcp syn) to postgres (because the previous one failed) and works fine.

Looking online, it looks like others have had to add keep-alives to maintain the database’s persistent connections.