### PR TITLE
no prune on server side of notify protocol

### DIFF
--- a/notify/dummy_notify.go
+++ b/notify/dummy_notify.go
@@ -115,11 +115,11 @@ func WaitFor(cache WaitForCache, count int) {
 	if cache == nil {
 		return
 	}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 50; i++ {
 		if cache.GetCount() == count {
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
 	}
 }
 
@@ -169,13 +169,13 @@ func (s *Client) WaitForConnect(connect uint64) {
 }
 
 func (mgr *ServerMgr) WaitServerCount(count int) {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 50; i++ {
 		mgr.mux.Lock()
 		cnt := len(mgr.table)
 		mgr.mux.Unlock()
 		if cnt == count {
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/notify/notify_client.go
+++ b/notify/notify_client.go
@@ -99,7 +99,7 @@ func (s *Client) run() {
 		s.sendrecv.sendRunning = make(chan struct{})
 		s.sendrecv.recvRunning = make(chan struct{})
 		go s.sendrecv.send(stream)
-		go s.sendrecv.recv(stream, 0)
+		go s.sendrecv.recv(stream, 0, CleanupPrune)
 		// if there is a communication error, both threads will exit
 		<-s.sendrecv.sendRunning
 		<-s.sendrecv.recvRunning

--- a/notify/notify_tree_test.go
+++ b/notify/notify_tree_test.go
@@ -26,22 +26,22 @@ const (
 // Each server node has two clients connected to it, so it is
 // a balanced binary tree.
 func TestNotifyTree(t *testing.T) {
-	log.SetDebugLevel(log.DebugLevelNotify)
+	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi)
 
 	// override retry time
 	NotifyRetryTime = 10 * time.Millisecond
 	found := false
 
 	// one top node
-	top := newNode("127.0.0.1:60002", nil, none)
+	top := newNode("top", "127.0.0.1:60002", nil, none)
 	// two mid nodes
-	mid1 := newNode("127.0.0.1:60003", []string{"127.0.0.1:60002"}, dme)
-	mid2 := newNode("127.0.0.1:60004", []string{"127.0.0.1:60002"}, crm)
+	mid1 := newNode("mid1", "127.0.0.1:60003", []string{"127.0.0.1:60002"}, dme)
+	mid2 := newNode("mid2", "127.0.0.1:60004", []string{"127.0.0.1:60002"}, crm)
 	// four low nodes
-	low11 := newNode("", []string{"127.0.0.1:60003"}, dme)
-	low12 := newNode("", []string{"127.0.0.1:60003"}, dme)
-	low21 := newNode("", []string{"127.0.0.1:60004"}, crm)
-	low22 := newNode("", []string{"127.0.0.1:60004"}, crm)
+	low11 := newNode("low11", "", []string{"127.0.0.1:60003"}, dme)
+	low12 := newNode("low12", "", []string{"127.0.0.1:60003"}, dme)
+	low21 := newNode("low21", "", []string{"127.0.0.1:60004"}, crm)
+	low22 := newNode("low22", "", []string{"127.0.0.1:60004"}, crm)
 
 	// Note that data distributed to dme and crm are different.
 
@@ -70,6 +70,7 @@ func TestNotifyTree(t *testing.T) {
 	top.handler.FlavorCache.Update(&testutil.FlavorData[0], 0)
 	top.handler.FlavorCache.Update(&testutil.FlavorData[1], 0)
 	top.handler.FlavorCache.Update(&testutil.FlavorData[2], 0)
+
 	// set ClusterInst and AppInst state to CreateRequested so they get
 	// sent to the CRM.
 	for ii, _ := range testutil.ClusterInstData {
@@ -120,9 +121,10 @@ func TestNotifyTree(t *testing.T) {
 	fmt.Println("========== stopping client")
 	low21.stopClient()
 	mid2.handler.WaitForAppInstInfo(1)
-	mid1.handler.WaitForCloudletInfo(0)
+	mid2.handler.WaitForCloudletInfo(1)
 	require.Equal(t, 1, len(mid2.handler.AppInstInfoCache.Objs), "AppInstInfos")
 	require.Equal(t, 1, len(mid2.handler.CloudletInfoCache.Objs), "CloudletInfos")
+	require.Equal(t, 0, len(mid1.handler.CloudletInfoCache.Objs), "CloudletInfos")
 	_, found = mid2.handler.AppInstInfoCache.Objs[testutil.AppInstInfoData[2].Key]
 	require.False(t, found, "disconnected AppInstInfo")
 	_, found = mid2.handler.CloudletInfoCache.Objs[testutil.CloudletInfoData[0].Key]
@@ -172,13 +174,14 @@ type node struct {
 	listenAddr string
 }
 
-func newNode(listenAddr string, connectAddrs []string, typ nodeType) *node {
+func newNode(name, listenAddr string, connectAddrs []string, typ nodeType) *node {
 	n := &node{}
 	n.handler = NewDummyHandler()
 	n.listenAddr = listenAddr
 	if listenAddr != "" {
 		n.serverMgr = &ServerMgr{}
 		n.handler.RegisterServer(n.serverMgr)
+		n.serverMgr.name = fmt.Sprintf("server %s", name)
 	}
 	if connectAddrs != nil {
 		n.client = NewClient(connectAddrs, "")
@@ -187,6 +190,7 @@ func newNode(listenAddr string, connectAddrs []string, typ nodeType) *node {
 		} else {
 			n.handler.RegisterDMEClient(n.client)
 		}
+		n.client.sendrecv.cliserv = fmt.Sprintf("client %s", name)
 	}
 	return n
 }

--- a/protoc-gen-notify/gennotify.go
+++ b/protoc-gen-notify/gennotify.go
@@ -468,13 +468,15 @@ func (s *{{.Name}}Recv) RecvAllStart() {
 {{- end}}
 }
 
-func (s *{{.Name}}Recv) RecvAllEnd() {
+func (s *{{.Name}}Recv) RecvAllEnd(cleanup Cleanup) {
 {{- if .Cache}}
 	s.Mux.Lock()
 	validKeys := s.sendAllKeys
 	s.sendAllKeys = nil
 	s.Mux.Unlock()
-	s.handler.Prune(validKeys)
+	if cleanup == CleanupPrune {
+		s.handler.Prune(validKeys)
+	}
 {{- end}}
 }
 


### PR DESCRIPTION
I noticed one of the notify unit tests was failing intermittently. I tracked it down to two issues:
1. A bug introduced when I refactored the notify code. It introduced a Prune on the server side, when the server side should only be doing a Flush.
2. The "waitfor" funcs would very infrequently not wait long enough, causing the expected counts to be off by a small amount. Increased the timeouts, prob useful especially for lower-end machines.
- Also tweaked the code so the test code could put the node name in the log output to make it easier to debug the tree test (which has 7 different "nodes" all printing notify messages).