### PR TITLE
EDGECLOUD-548 Update docker base image

### DIFF
--- a/docker/Dockerfile.edge-cloud
+++ b/docker/Dockerfile.edge-cloud
@@ -29,7 +29,7 @@ ENV CGO_ENABLED=1
 WORKDIR /go/src/github.com/mobiledgex/edge-cloud-infra
 RUN make
 
-FROM registry.mobiledgex.net:5000/mobiledgex/edge-cloud-base-image:v0.0.14-2-gdbcb89c
+FROM registry.mobiledgex.net:5000/mobiledgex/edge-cloud-base-image:v0.0.14-19-g8e21a4c
 
 # Will be overridden during build from the command line
 ARG BUILD_TAG=latest


### PR DESCRIPTION
Switch to the newer base image with kubectl included.

(Had an earlier pull request for this which I had thought I had already pushed, but turned out I hadn't.)