### PR TITLE
Fix for findcloudlet e2e tests

### DIFF
--- a/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet1.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet1.yml
@@ -1,5 +1,5 @@
 status: FIND_FOUND
-fqdn: acmeappcosomeapplication110.smallcluster.tmus-cloud-1.tmus.mobiledgex.net
+fqdn: smallcluster.tmus-cloud-1.tmus.mobiledgex.net
 ports:
 - proto: LProtoTCP
   internalport: 80


### PR DESCRIPTION
Pretty sure the fqdn prefix here should be the dedicated lb fqdn since the one with specified to have dedicated ip access is the cluster, not the app