### PR TITLE
add platform client to clusterinst

### DIFF
--- a/cloud-resource-manager/crmutil/exec.go
+++ b/cloud-resource-manager/crmutil/exec.go
@@ -65,7 +65,7 @@ func (cd *ControllerData) ProcessExecReq(req *edgeproto.ExecRequest) error {
 		return err
 	}
 
-	run.client, err = cd.platform.GetPlatformClient()
+	run.client, err = cd.platform.GetPlatformClient(&clusterInst)
 	if err != nil {
 		return err
 	}

--- a/cloud-resource-manager/k8smgmt/kubenames.go
+++ b/cloud-resource-manager/k8smgmt/kubenames.go
@@ -34,7 +34,11 @@ func GetK8sNodeNameSuffix(clusterInst *edgeproto.ClusterInst) string {
 	cloudletName := clusterInst.Key.CloudletKey.Name
 	clusterName := clusterInst.Key.ClusterKey.Name
 	devName := clusterInst.Key.Developer
-	return NormalizeName(cloudletName + "-" + clusterName + "-" + devName)
+	if devName != "" {
+		return NormalizeName(cloudletName + "-" + clusterName + "-" + devName)
+	}
+	return NormalizeName(cloudletName + "-" + clusterName)
+
 }
 
 func NormalizeName(name string) string {

--- a/cloud-resource-manager/platform/dind/dind-appinst.go
+++ b/cloud-resource-manager/platform/dind/dind-appinst.go
@@ -62,7 +62,7 @@ func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 }
 
 func (s *Platform) GetAppInstRuntime(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst) (*edgeproto.AppInstRuntime, error) {
-	client, err := s.GetPlatformClient()
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return nil, err
 	}

--- a/cloud-resource-manager/platform/dind/dind.go
+++ b/cloud-resource-manager/platform/dind/dind.go
@@ -36,6 +36,6 @@ func (s *Platform) GatherCloudletInfo(info *edgeproto.CloudletInfo) error {
 	return nil
 }
 
-func (s *Platform) GetPlatformClient() (pc.PlatformClient, error) {
+func (s *Platform) GetPlatformClient(clusterInst *edgeproto.ClusterInst) (pc.PlatformClient, error) {
 	return &pc.LocalClient{}, nil
 }

--- a/cloud-resource-manager/platform/fake/fake.go
+++ b/cloud-resource-manager/platform/fake/fake.go
@@ -56,7 +56,7 @@ func (s *Platform) GetAppInstRuntime(clusterInst *edgeproto.ClusterInst, app *ed
 	return &edgeproto.AppInstRuntime{}, nil
 }
 
-func (s *Platform) GetPlatformClient() (pc.PlatformClient, error) {
+func (s *Platform) GetPlatformClient(clusterInst *edgeproto.ClusterInst) (pc.PlatformClient, error) {
 	return &pc.LocalClient{}, nil
 }
 

--- a/cloud-resource-manager/platform/platform.go
+++ b/cloud-resource-manager/platform/platform.go
@@ -25,7 +25,7 @@ type Platform interface {
 	// Get AppInst runtime information
 	GetAppInstRuntime(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst) (*edgeproto.AppInstRuntime, error)
 	// Get the Platform Client to run commands against
-	GetPlatformClient() (pc.PlatformClient, error)
+	GetPlatformClient(clusterInst *edgeproto.ClusterInst) (pc.PlatformClient, error)
 	// Get the command to pass to PlatformClient for the container command
 	GetContainerCommand(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, req *edgeproto.ExecRequest) (string, error)
 }


### PR DESCRIPTION
- add cluster instance to GetPlatformClient.  This is part of a 2 part change including infra.  This is to allow dedicated clusters to do shell access.  Also avoids bugs in dedicated lb cases because the logic to deal with the dedicated root lb is inside GetPlatformClient now rather than outside.  
- update GetK8sNodeNameSuffix to avoid adding a blank dash if there is no developer name, otherwise existing clusterinst deployments cannot be deleted