### PR TITLE
EDGECLOUD-536 Clean up stale CloudletInfo

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -104,6 +104,8 @@ func main() {
 	sync.Start()
 	defer sync.Done()
 
+	// register controller must be called before starting Notify protocol
+	// to set up controllerAliveLease.
 	err = controllerApi.registerController()
 	if err != nil {
 		log.FatalLog("Failed to register controller", "err", err)

--- a/controller/controller_api.go
+++ b/controller/controller_api.go
@@ -21,6 +21,7 @@ type ControllerApi struct {
 var controllerApi = ControllerApi{}
 
 var leaseTimeoutSec int64 = 20
+var controllerAliveLease int64
 
 func InitControllerApi(sync *Sync) {
 	controllerApi.sync = sync
@@ -39,6 +40,7 @@ func (s *ControllerApi) registerController() error {
 	if err != nil {
 		return err
 	}
+	controllerAliveLease = lease
 
 	ctrl := edgeproto.Controller{}
 	ctrl.Key.Addr = *externalApiAddr

--- a/edgeproto/app.pb.go
+++ b/edgeproto/app.pb.go
@@ -1284,10 +1284,11 @@ func (s *AppStore) STMGet(stm concurrency.STM, key *AppKey, buf *App) bool {
 	return true
 }
 
-func (s *AppStore) STMPut(stm concurrency.STM, obj *App) {
+func (s *AppStore) STMPut(stm concurrency.STM, obj *App, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("App", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *AppStore) STMDel(stm concurrency.STM, key *AppKey) {

--- a/edgeproto/app_inst.pb.go
+++ b/edgeproto/app_inst.pb.go
@@ -1669,10 +1669,11 @@ func (s *AppInstStore) STMGet(stm concurrency.STM, key *AppInstKey, buf *AppInst
 	return true
 }
 
-func (s *AppInstStore) STMPut(stm concurrency.STM, obj *AppInst) {
+func (s *AppInstStore) STMPut(stm concurrency.STM, obj *AppInst, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("AppInst", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *AppInstStore) STMDel(stm concurrency.STM, key *AppInstKey) {
@@ -2429,10 +2430,11 @@ func (s *AppInstInfoStore) STMGet(stm concurrency.STM, key *AppInstKey, buf *App
 	return true
 }
 
-func (s *AppInstInfoStore) STMPut(stm concurrency.STM, obj *AppInstInfo) {
+func (s *AppInstInfoStore) STMPut(stm concurrency.STM, obj *AppInstInfo, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("AppInstInfo", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *AppInstInfoStore) STMDel(stm concurrency.STM, key *AppInstKey) {

--- a/edgeproto/cloudlet.pb.go
+++ b/edgeproto/cloudlet.pb.go
@@ -1856,10 +1856,11 @@ func (s *CloudletStore) STMGet(stm concurrency.STM, key *CloudletKey, buf *Cloud
 	return true
 }
 
-func (s *CloudletStore) STMPut(stm concurrency.STM, obj *Cloudlet) {
+func (s *CloudletStore) STMPut(stm concurrency.STM, obj *Cloudlet, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("Cloudlet", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *CloudletStore) STMDel(stm concurrency.STM, key *CloudletKey) {
@@ -2531,10 +2532,11 @@ func (s *CloudletInfoStore) STMGet(stm concurrency.STM, key *CloudletKey, buf *C
 	return true
 }
 
-func (s *CloudletInfoStore) STMPut(stm concurrency.STM, obj *CloudletInfo) {
+func (s *CloudletInfoStore) STMPut(stm concurrency.STM, obj *CloudletInfo, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("CloudletInfo", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *CloudletInfoStore) STMDel(stm concurrency.STM, key *CloudletKey) {

--- a/edgeproto/cluster.pb.go
+++ b/edgeproto/cluster.pb.go
@@ -644,10 +644,11 @@ func (s *ClusterStore) STMGet(stm concurrency.STM, key *ClusterKey, buf *Cluster
 	return true
 }
 
-func (s *ClusterStore) STMPut(stm concurrency.STM, obj *Cluster) {
+func (s *ClusterStore) STMPut(stm concurrency.STM, obj *Cluster, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("Cluster", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *ClusterStore) STMDel(stm concurrency.STM, key *ClusterKey) {

--- a/edgeproto/clusterflavor.pb.go
+++ b/edgeproto/clusterflavor.pb.go
@@ -702,10 +702,11 @@ func (s *ClusterFlavorStore) STMGet(stm concurrency.STM, key *ClusterFlavorKey, 
 	return true
 }
 
-func (s *ClusterFlavorStore) STMPut(stm concurrency.STM, obj *ClusterFlavor) {
+func (s *ClusterFlavorStore) STMPut(stm concurrency.STM, obj *ClusterFlavor, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("ClusterFlavor", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *ClusterFlavorStore) STMDel(stm concurrency.STM, key *ClusterFlavorKey) {

--- a/edgeproto/clusterinst.pb.go
+++ b/edgeproto/clusterinst.pb.go
@@ -1198,10 +1198,11 @@ func (s *ClusterInstStore) STMGet(stm concurrency.STM, key *ClusterInstKey, buf 
 	return true
 }
 
-func (s *ClusterInstStore) STMPut(stm concurrency.STM, obj *ClusterInst) {
+func (s *ClusterInstStore) STMPut(stm concurrency.STM, obj *ClusterInst, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("ClusterInst", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *ClusterInstStore) STMDel(stm concurrency.STM, key *ClusterInstKey) {
@@ -1875,10 +1876,11 @@ func (s *ClusterInstInfoStore) STMGet(stm concurrency.STM, key *ClusterInstKey, 
 	return true
 }
 
-func (s *ClusterInstInfoStore) STMPut(stm concurrency.STM, obj *ClusterInstInfo) {
+func (s *ClusterInstInfoStore) STMPut(stm concurrency.STM, obj *ClusterInstInfo, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("ClusterInstInfo", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *ClusterInstInfoStore) STMDel(stm concurrency.STM, key *ClusterInstKey) {

--- a/edgeproto/controller.pb.go
+++ b/edgeproto/controller.pb.go
@@ -482,10 +482,11 @@ func (s *ControllerStore) STMGet(stm concurrency.STM, key *ControllerKey, buf *C
 	return true
 }
 
-func (s *ControllerStore) STMPut(stm concurrency.STM, obj *Controller) {
+func (s *ControllerStore) STMPut(stm concurrency.STM, obj *Controller, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("Controller", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *ControllerStore) STMDel(stm concurrency.STM, key *ControllerKey) {

--- a/edgeproto/developer.pb.go
+++ b/edgeproto/developer.pb.go
@@ -677,10 +677,11 @@ func (s *DeveloperStore) STMGet(stm concurrency.STM, key *DeveloperKey, buf *Dev
 	return true
 }
 
-func (s *DeveloperStore) STMPut(stm concurrency.STM, obj *Developer) {
+func (s *DeveloperStore) STMPut(stm concurrency.STM, obj *Developer, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("Developer", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *DeveloperStore) STMDel(stm concurrency.STM, key *DeveloperKey) {

--- a/edgeproto/flavor.pb.go
+++ b/edgeproto/flavor.pb.go
@@ -650,10 +650,11 @@ func (s *FlavorStore) STMGet(stm concurrency.STM, key *FlavorKey, buf *Flavor) b
 	return true
 }
 
-func (s *FlavorStore) STMPut(stm concurrency.STM, obj *Flavor) {
+func (s *FlavorStore) STMPut(stm concurrency.STM, obj *Flavor, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("Flavor", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *FlavorStore) STMDel(stm concurrency.STM, key *FlavorKey) {

--- a/edgeproto/node.pb.go
+++ b/edgeproto/node.pb.go
@@ -687,10 +687,11 @@ func (s *NodeStore) STMGet(stm concurrency.STM, key *NodeKey, buf *Node) bool {
 	return true
 }
 
-func (s *NodeStore) STMPut(stm concurrency.STM, obj *Node) {
+func (s *NodeStore) STMPut(stm concurrency.STM, obj *Node, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("Node", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *NodeStore) STMDel(stm concurrency.STM, key *NodeKey) {

--- a/edgeproto/operator.pb.go
+++ b/edgeproto/operator.pb.go
@@ -587,10 +587,11 @@ func (s *OperatorStore) STMGet(stm concurrency.STM, key *OperatorKey, buf *Opera
 	return true
 }
 
-func (s *OperatorStore) STMPut(stm concurrency.STM, obj *Operator) {
+func (s *OperatorStore) STMPut(stm concurrency.STM, obj *Operator, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("Operator", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *OperatorStore) STMDel(stm concurrency.STM, key *OperatorKey) {

--- a/edgeproto/refs.pb.go
+++ b/edgeproto/refs.pb.go
@@ -634,10 +634,11 @@ func (s *CloudletRefsStore) STMGet(stm concurrency.STM, key *CloudletKey, buf *C
 	return true
 }
 
-func (s *CloudletRefsStore) STMPut(stm concurrency.STM, obj *CloudletRefs) {
+func (s *CloudletRefsStore) STMPut(stm concurrency.STM, obj *CloudletRefs, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("CloudletRefs", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *CloudletRefsStore) STMDel(stm concurrency.STM, key *CloudletKey) {
@@ -1101,10 +1102,11 @@ func (s *ClusterRefsStore) STMGet(stm concurrency.STM, key *ClusterInstKey, buf 
 	return true
 }
 
-func (s *ClusterRefsStore) STMPut(stm concurrency.STM, obj *ClusterRefs) {
+func (s *ClusterRefsStore) STMPut(stm concurrency.STM, obj *ClusterRefs, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("ClusterRefs", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *ClusterRefsStore) STMDel(stm concurrency.STM, key *ClusterInstKey) {

--- a/edgeproto/stm.go
+++ b/edgeproto/stm.go
@@ -1,0 +1,15 @@
+package edgeproto
+
+import (
+	v3 "github.com/coreos/etcd/clientv3"
+	"github.com/mobiledgex/edge-cloud/objstore"
+)
+
+func GetSTMOpts(opts ...objstore.KVOp) []v3.OpOption {
+	kvopts := objstore.GetKVOptions(opts)
+	v3opts := []v3.OpOption{}
+	if kvopts.LeaseID != 0 {
+		v3opts = append(v3opts, v3.WithLease(v3.LeaseID(kvopts.LeaseID)))
+	}
+	return v3opts
+}

--- a/protoc-gen-gomex/mexgen/mex.go
+++ b/protoc-gen-gomex/mexgen/mex.go
@@ -757,10 +757,11 @@ func (s *{{.Name}}Store) STMGet(stm concurrency.STM, key *{{.KeyType}}, buf *{{.
 	return true
 }
 
-func (s *{{.Name}}Store) STMPut(stm concurrency.STM, obj *{{.Name}}) {
+func (s *{{.Name}}Store) STMPut(stm concurrency.STM, obj *{{.Name}}, ops ...objstore.KVOp) {
 	keystr := objstore.DbKeyString("{{.Name}}", obj.GetKey())
 	val, _ := json.Marshal(obj)
-	stm.Put(keystr, string(val))
+	v3opts := GetSTMOpts(ops...)
+	stm.Put(keystr, string(val), v3opts...)
 }
 
 func (s *{{.Name}}Store) STMDel(stm concurrency.STM, key *{{.KeyType}}) {


### PR DESCRIPTION
Put CloudletInfo in etcd with a lease so etcd will automatically remove it if controller goes away. This deals with the situation described in the bug. Letting etcd deal with it is the best solution here because we don't want to have race conditions between controllers trying to manage CloudletInfos from controllers that have gone away.