### PR TITLE
MatchingEngineSDK: Update C++ clients to use mexdemo.dme.mobiledgex.net

### DIFF
--- a/edge-mvp/cpp/grpc/Makefile
+++ b/edge-mvp/cpp/grpc/Makefile
@@ -21,7 +21,7 @@ CXX = g++
 CPPFLAGS += `pkg-config --cflags protobuf grpc`
 CPPFLAGS += -I.
 CPPFLAGS += -I../common
-CXXFLAGS += -std=c++11
+CXXFLAGS += -std=c++17
 ifeq ($(SYSTEM),Darwin)
 LDFLAGS += -L/usr/local/lib `pkg-config --libs protobuf grpc++ grpc`\
            -lgrpc++_reflection\

--- a/edge-mvp/cpp/grpc/sample_client.cpp
+++ b/edge-mvp/cpp/grpc/sample_client.cpp
@@ -1,5 +1,6 @@
 #include <grpcpp/grpcpp.h>
 
+#include <sstream>
 #include <iostream>
 
 #include <curl/curl.h>
@@ -26,17 +27,28 @@ struct MutualAuthFiles {
 
 class MexGrpcClient {
   public:
+    inline static const string carrierNameDefault = "TDG";
+    inline static const string baseDmeHost = "dme.mobiledgex.net";
+    static const unsigned int defaultDmePort = 50051;
+    unsigned int dmePort = defaultDmePort;
     unsigned long timeoutSec = 5000;
-    const string appName = "EmptyMatchEngineApp"; // Your application name
-    const string devName = "EmptyMatchEngineApp"; // Your developer name
+    const string devName = "MobiledgeX"; // Your developer name
+    const string appName = "MobiledgeX SDK Demo"; // Your application name
     const string appVersionStr = "1.0";
 
     MexGrpcClient(std::shared_ptr<Channel> channel)
         : stub_(Match_Engine_Api::NewStub(channel)) {}
 
     // Retrieve the carrier name of the cellular network interface.
-    string getCarrierName() {
-        return string("TDG");
+    static string getCarrierName() {
+        return carrierNameDefault;
+    }
+
+    static string generateDmeHostPath(string carrierName) {
+        if (carrierName == "") {
+            return carrierNameDefault + "." + baseDmeHost;
+        }
+        return carrierName + "." + baseDmeHost;
     }
 
     // A C++ GPS location provider/binding is needed here.
@@ -323,7 +335,18 @@ class MexGrpcClient {
 
 int main() {
     cout << "Hello C++ MEX GRPC Lib" << endl;
-    string host = "tdg2.dme.mobiledgex.net:50051";
+    string host = "tdg.dme.mobiledgex.net:50051"; // A default, if tdg were the carrier.
+
+    // Use demo server?
+    string yn;
+    cout << "Use the demo server? [yN]" << endl;
+    cin >> yn;
+    if (yn.compare("y") == 0) {
+      host = MexGrpcClient::generateDmeHostPath("mexdemo");
+    } else {
+      host = MexGrpcClient::generateDmeHostPath(MexGrpcClient::getCarrierName());
+    }
+
 
     // Credentials, Mutual Authentication:
     unique_ptr<test_credentials> test_creds = unique_ptr<test_credentials>(
@@ -338,13 +361,17 @@ int main() {
     credentials.pem_cert_chain = test_creds->clientCrt;
     credentials.pem_private_key = test_creds->clientKey;
 
+    stringstream ssUri;
+    ssUri << host << ":" << MexGrpcClient::defaultDmePort;
     auto channel_creds = grpc::SslCredentials(grpc::SslCredentialsOptions(credentials));
-    shared_ptr<Channel> channel = grpc::CreateChannel(host, channel_creds);
+    shared_ptr<Channel> channel = grpc::CreateChannel(ssUri.str(), channel_creds);
 
+    cout << "Url to use: " << ssUri.str() << endl;
     unique_ptr<MexGrpcClient> mexClient = unique_ptr<MexGrpcClient>(new MexGrpcClient(channel));
 
     try {
         shared_ptr<Loc> loc = mexClient->retrieveLocation();
+
 
         cout << "Register MEX client." << endl;
         cout << "====================" << endl

--- a/edge-mvp/cpp/rest/Makefile
+++ b/edge-mvp/cpp/rest/Makefile
@@ -5,7 +5,7 @@
 CXX = g++
 CPPFLAGS += -I.
 CPPFLAGS += -I../common
-CXXFLAGS += -std=c++11
+CXXFLAGS += -std=c++17
 LDFLAGS += -L/usr/local/lib \
            -ldl\
            -lcurl

--- a/edge-mvp/cpp/rest/sample_client.cpp
+++ b/edge-mvp/cpp/rest/sample_client.cpp
@@ -27,8 +27,8 @@ class MexRestClient {
     string dynamiclocgroupAPI = "/v1/dynamiclocgroup";
 
     unsigned long timeoutSec = 5000;
-    const string appName = "EmptyMatchEngineApp"; // Your application name
-    const string devName = "EmptyMatchEngineApp"; // Your developer name
+    const string devName = "MobiledgeX"; // Your developer name
+    const string appName = "MobiledgeX SDK Demo"; // Your application name
     const string appVersionStr = "1.0";
 
     // SSL files:
@@ -78,8 +78,8 @@ class MexRestClient {
     // A C++ GPS location provider/binding is needed here.
     json retrieveLocation() {
         json location;
-        location["latitude"] = -122.149349;
-        location["longitude"] = 37.459609;
+        location["latitude"] = 37.459609;
+        location["longitude"] = -122.149349;
         location["horizontal_accuracy"] = 5;
         location["vertical_accuracy"] = 20;
         location["altitude"] = 100;
@@ -390,11 +390,21 @@ int main() {
         string baseuri;
         json loc = mexClient->retrieveLocation();
 
+        string yn;
+        cout << "Use the demo server? [yN]" << endl;
+        cin >> yn;
+        if (yn.compare("y") == 0) {
+          baseuri = mexClient->generateBaseUri("mexdemo", mexClient->dmePort);
+        } else {
+          baseuri = mexClient->generateBaseUri(mexClient->getCarrierName(), mexClient->dmePort);
+        }
+
+
         cout << "Register MEX client." << endl;
         cout << "====================" << endl
              << endl;
 
-        baseuri = mexClient->generateBaseUri(mexClient->getCarrierName(), mexClient->dmePort);
+
         string strRegisterClientReply;
         json registerClientRequest = mexClient->createRegisterClientRequest();
         json registerClientReply = mexClient->RegisterClient(baseuri, registerClientRequest, strRegisterClientReply, httpResponse);
@@ -419,7 +429,6 @@ int main() {
         cout << "===================================" << endl
              << endl;
 
-        baseuri = mexClient->generateBaseUri(mexClient->getCarrierName(), mexClient->dmePort);
         loc = mexClient->retrieveLocation();
         string strVerifyLocationReply;
         json verifyLocationRequest = mexClient->createVerifyLocationRequest(mexClient->getCarrierName(), loc, "");
@@ -438,7 +447,6 @@ int main() {
         cout << "===========================================================" << endl
              << endl;
 
-        baseuri = mexClient->generateBaseUri(mexClient->getCarrierName(), mexClient->dmePort);
         loc = mexClient->retrieveLocation();
         string strFindCloudletReply;
         json findCloudletRequest = mexClient->createFindCloudletRequest(mexClient->getCarrierName(), loc);


### PR DESCRIPTION
Makefile also pushes GRPC and REST based C++ requirements to C++17. No particular reason other than the fact C++11 is much older, and syntax changes (specifically: static const class fields can be initialized in class instead of outside in a header file in C++17).

Note: C++ SampleClients directly implement the REST and GRPC interfaces, so they aren't actually SDKs, so much as client examples with no extra functionality.