### PR TITLE
EC-512: RegisterClient for app that doesnot exist should return GRPC status of NOT_FOUND

### DIFF
--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -163,21 +163,14 @@ func getAuthPublicKey(devname string, appname string, appvers string) (string, e
 	key.DeveloperKey.Name = devname
 	key.Name = appname
 	key.Version = appvers
-	authkey := ""
-	foundApp := false
 	tbl.Lock()
 	defer tbl.Unlock()
 
 	app, ok := tbl.apps[key]
 	if ok {
-		authkey = app.authPublicKey
-		foundApp = true
+		return app.authPublicKey, nil
 	}
-
-	if !foundApp {
-		return "", grpc.Errorf(codes.InvalidArgument, "app not found")
-	}
-	return authkey, nil
+	return "", grpc.Errorf(codes.NotFound, "app not found")
 }
 
 func (s *server) RegisterClient(ctx context.Context,


### PR DESCRIPTION
#### Notes
* Missing/Invalid arguments should return 400 (Invalid Argument) Status
* Valid argument, but app not found should return 404 (Not Found) Status

#### Tests
```
❯ curl -v "https://0.0.0.0:38001/v1/registerclient" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{  \"Ver\": 0,  \"DevName\": \"AAcmeAppCo\",  \"AppName\": \"\",  \"AppVers\": \"1.0\",  \"CarrierName\": \"tdg\",  \"AuthToken\": \"\"}"  --cacert tls/out/mex-ca.crt --key tls/out/mex-client.key --cert tls/out/mex-client.crt
--snip--
        * Connection state changed (MAX_CONCURRENT_STREAMS updated)!
        * We are completely uploaded and fine
        < HTTP/2 400
        < content-type: application/json
        < trailer: Grpc-Trailer-Content-Type
        < content-length: 71
        < date: Fri, 03 May 2019 05:59:50 GMT
        <
        {
         "code": 3,
         "message": "AppName cannot be empty",
         "details": [
         ]
--snip--

❯ curl -v "https://0.0.0.0:38001/v1/registerclient" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{  \"Ver\": 0,  \"DevName\": \"AAcmeAppCo\",  \"AppName\": \"helmApplication\",  \"AppVers\": \"1.0\",  \"CarrierName\": \"tdg\",  \"AuthToken\": \"\"}"  --cacert tls/out/mex-ca.crt --key tls/out/mex-client.key --cert tls/out/mex-client.crt
--snip--
        * Connection state changed (MAX_CONCURRENT_STREAMS updated)!
        * We are completely uploaded and fine
        < HTTP/2 404
        < content-type: application/json
        < trailer: Grpc-Trailer-Content-Type
        < content-length: 61
        < date: Fri, 03 May 2019 06:01:03 GMT
        <
        {
         "code": 5,
         "message": "app not found",
         "details": [
         ]
--snip--
```