### PR TITLE
clean up WaitForStatus error message

### DIFF
--- a/edgeproto/app_inst.pb.go
+++ b/edgeproto/app_inst.pb.go
@@ -1971,7 +1971,8 @@ func (c *AppInstCache) WaitForState(ctx context.Context, key *AppInstKey, target
 		}
 	case <-failed:
 		if c.Get(key, &info) {
-			err = fmt.Errorf("Encountered failures: %v", info.Errors)
+			errs := strings.Join(info.Errors, ", ")
+			err = fmt.Errorf("Encountered failures: %s", errs)
 		} else {
 			// this shouldn't happen, since only way to get here
 			// is if info state is set to Error
@@ -1981,7 +1982,8 @@ func (c *AppInstCache) WaitForState(ctx context.Context, key *AppInstKey, target
 		hasInfo := c.Get(key, &info)
 		if hasInfo && info.State == errorState {
 			// error may have been sent back before watch started
-			err = fmt.Errorf("Encountered failures: %v", info.Errors)
+			errs := strings.Join(info.Errors, ", ")
+			err = fmt.Errorf("Encountered failures: %s", errs)
 		} else if _, found := transitionStates[info.State]; hasInfo && found {
 			// no success response, but state is a valid transition
 			// state. That means work is still in progress.

--- a/edgeproto/clusterinst.pb.go
+++ b/edgeproto/clusterinst.pb.go
@@ -1500,7 +1500,8 @@ func (c *ClusterInstCache) WaitForState(ctx context.Context, key *ClusterInstKey
 		}
 	case <-failed:
 		if c.Get(key, &info) {
-			err = fmt.Errorf("Encountered failures: %v", info.Errors)
+			errs := strings.Join(info.Errors, ", ")
+			err = fmt.Errorf("Encountered failures: %s", errs)
 		} else {
 			// this shouldn't happen, since only way to get here
 			// is if info state is set to Error
@@ -1510,7 +1511,8 @@ func (c *ClusterInstCache) WaitForState(ctx context.Context, key *ClusterInstKey
 		hasInfo := c.Get(key, &info)
 		if hasInfo && info.State == errorState {
 			// error may have been sent back before watch started
-			err = fmt.Errorf("Encountered failures: %v", info.Errors)
+			errs := strings.Join(info.Errors, ", ")
+			err = fmt.Errorf("Encountered failures: %s", errs)
 		} else if _, found := transitionStates[info.State]; hasInfo && found {
 			// no success response, but state is a valid transition
 			// state. That means work is still in progress.

--- a/protoc-gen-gomex/mexgen/mex.go
+++ b/protoc-gen-gomex/mexgen/mex.go
@@ -1097,7 +1097,8 @@ func (c *{{.Name}}Cache) WaitForState(ctx context.Context, key *{{.KeyType}}, ta
 		}
 	case <-failed:
 		if c.Get(key, &info) {
-			err = fmt.Errorf("Encountered failures: %v", info.Errors)
+			errs := strings.Join(info.Errors, ", ")
+			err = fmt.Errorf("Encountered failures: %s", errs)
 		} else {
 			// this shouldn't happen, since only way to get here
 			// is if info state is set to Error
@@ -1107,7 +1108,8 @@ func (c *{{.Name}}Cache) WaitForState(ctx context.Context, key *{{.KeyType}}, ta
 		hasInfo := c.Get(key, &info)
 		if hasInfo && info.State == errorState {
 			// error may have been sent back before watch started
-			err = fmt.Errorf("Encountered failures: %v", info.Errors)
+			errs := strings.Join(info.Errors, ", ")
+			err = fmt.Errorf("Encountered failures: %s", errs)
 		} else if _, found := transitionStates[info.State]; hasInfo && found {
 			// no success response, but state is a valid transition
 			// state. That means work is still in progress.
@@ -1236,6 +1238,7 @@ func (m *mex) generateMessage(file *generator.FileDescriptor, desc *generator.De
 		if args.WaitForState != "" {
 			m.importErrors = true
 			m.importTime = true
+			m.importStrings = true
 		}
 	}
 	if GetObjKey(message) {


### PR DESCRIPTION
This just cleans up an error message exposed to the user to make it a little more user-friendly (removes the array brackets).
old: ```Encountered failures: [Create failed: failed to create blah blah blah]```
new: ```Encountered failures: Create failed: failed to create blah blah blah```
