### PR TITLE
Fix unit tests

### DIFF
--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -59,9 +59,9 @@ func TestAppInstApi(t *testing.T) {
 		// make sure error matches responder
 		// if app-inst triggers auto-cluster, the error will be for a cluster
 		if strings.Contains(err.Error(), "cluster inst") {
-			assert.Equal(t, "Encountered failures: [crm create cluster inst failed]", err.Error())
+			assert.Equal(t, "Encountered failures: crm create cluster inst failed", err.Error())
 		} else {
-			assert.Equal(t, "Encountered failures: [crm create app inst failed]", err.Error())
+			assert.Equal(t, "Encountered failures: crm create app inst failed", err.Error())
 		}
 	}
 	responder.SetSimulateAppCreateFailure(false)

--- a/controller/clusterinst_api_test.go
+++ b/controller/clusterinst_api_test.go
@@ -49,7 +49,7 @@ func TestClusterInstApi(t *testing.T) {
 		err := clusterInstApi.CreateClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
 		assert.NotNil(t, err, "Create cluster inst responder failures")
 		// make sure error matches responder
-		assert.Equal(t, "Encountered failures: [crm create cluster inst failed]", err.Error())
+		assert.Equal(t, "Encountered failures: crm create cluster inst failed", err.Error())
 	}
 	responder.SetSimulateClusterCreateFailure(false)
 	assert.Equal(t, 0, len(clusterInstApi.cache.Objs))


### PR DESCRIPTION
Fixed Unit tests failure caused due to following commit:
`commit 9cda42bba826c4c4f1ca65351886245aaa042358: clean up WaitForStatus error message (#448)`

```
❯ go test ./...
ok      github.com/mobiledgex/edge-cloud/cloud-resource-manager/cmd/crmserver   0.116s
?       github.com/mobiledgex/edge-cloud/cloud-resource-manager/crmutil [no test files]
?       github.com/mobiledgex/edge-cloud/cloud-resource-manager/dockermgmt      [no test files]
?       github.com/mobiledgex/edge-cloud/cloud-resource-manager/k8smgmt [no test files]
?       github.com/mobiledgex/edge-cloud/cloud-resource-manager/nginx   [no test files]
?       github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform        [no test files]
?       github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/dind   [no test files]
?       github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/fake   [no test files]
?       github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc     [no test files]
ok      github.com/mobiledgex/edge-cloud/cloudcommon    (cached)
?       github.com/mobiledgex/edge-cloud/cloudcommon/influxsup  [no test files]
ok      github.com/mobiledgex/edge-cloud/cluster-svc    (cached)
ok      github.com/mobiledgex/edge-cloud/controller     (cached)
?       github.com/mobiledgex/edge-cloud/controller/influxq_client      [no test files]
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-client-sdk  [no test files]
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-common      [no test files]
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-common/genauthtoken [no test files]
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-loc-group   [no test files]
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-locapi      [no test files]
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-locapi/loc-api-sim  [no test files]
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-locapi/tok-srv-sim  [no test files]
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-locapi/util [no test files]
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto       [no test files]
ok      github.com/mobiledgex/edge-cloud/d-match-engine/dme-server      (cached)
?       github.com/mobiledgex/edge-cloud/d-match-engine/dme-testutil    [no test files]
?       github.com/mobiledgex/edge-cloud/deploygen      [no test files]
ok      github.com/mobiledgex/edge-cloud/deploygen/server       (cached)
?       github.com/mobiledgex/edge-cloud/edgectl        [no test files]
?       github.com/mobiledgex/edge-cloud/edgeproto      [no test files]
?       github.com/mobiledgex/edge-cloud/flavor [no test files]
?       github.com/mobiledgex/edge-cloud/gencmd [no test files]
?       github.com/mobiledgex/edge-cloud/gensupport     [no test files]
?       github.com/mobiledgex/edge-cloud/integration/process    [no test files]
ok      github.com/mobiledgex/edge-cloud/log    (cached)
?       github.com/mobiledgex/edge-cloud/metrics/grpc   [no test files]
ok      github.com/mobiledgex/edge-cloud/metrics-exporter       (cached)
ok      github.com/mobiledgex/edge-cloud/notify (cached)
ok      github.com/mobiledgex/edge-cloud/objstore       (cached)
?       github.com/mobiledgex/edge-cloud/protoc-gen-cmd [no test files]
?       github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup  [no test files]
?       github.com/mobiledgex/edge-cloud/protoc-gen-cmd/protocmd        [no test files]
?       github.com/mobiledgex/edge-cloud/protoc-gen-gomex       [no test files]
?       github.com/mobiledgex/edge-cloud/protoc-gen-gomex/mexgen        [no test files]
?       github.com/mobiledgex/edge-cloud/protoc-gen-notify      [no test files]
?       github.com/mobiledgex/edge-cloud/protoc-gen-test        [no test files]
?       github.com/mobiledgex/edge-cloud/protogen       [no test files]
?       github.com/mobiledgex/edge-cloud/setup-env/apis [no test files]
?       github.com/mobiledgex/edge-cloud/setup-env/e2e-tests    [no test files]
?       github.com/mobiledgex/edge-cloud/setup-env/e2e-tests/e2eapi     [no test files]
?       github.com/mobiledgex/edge-cloud/setup-env/iptest       [no test files]
?       github.com/mobiledgex/edge-cloud/setup-env/setup-mex    [no test files]
?       github.com/mobiledgex/edge-cloud/setup-env/simapp       [no test files]
?       github.com/mobiledgex/edge-cloud/setup-env/test-mex     [no test files]
?       github.com/mobiledgex/edge-cloud/setup-env/util [no test files]
ok      github.com/mobiledgex/edge-cloud/testgen        (cached)
?       github.com/mobiledgex/edge-cloud/testgen/gencmd [no test files]
?       github.com/mobiledgex/edge-cloud/testutil       [no test files]
?       github.com/mobiledgex/edge-cloud/tls    [no test files]
ok      github.com/mobiledgex/edge-cloud/util   (cached)
?       github.com/mobiledgex/edge-cloud/util/webrtcutil        [no test files]
ok      github.com/mobiledgex/edge-cloud/vault  3.324s
```