### PR TITLE
EDGECLOUD-515: Don't print dump with sessionCookie in RegisterClient.

### DIFF
--- a/edge-mvp/cpp/rest/sample_client.cpp
+++ b/edge-mvp/cpp/rest/sample_client.cpp
@@ -415,7 +415,8 @@ int main() {
             return 1;
         } else {
             cout << "REST RegisterClient Status: "
-                 << ", Dump: [" << registerClientReply.dump() << "]"
+                 << ", Version: " << registerClientReply["Ver"]
+                 << ", Client Status: " << registerClientReply["Status"]
                  << endl
                  << endl;
         }


### PR DESCRIPTION
Note: The sample Post() still does jsonMsg.dump() to string, which includes sessionCookie.