### PR TITLE
EDGECLOUD-575 fix intermittent error on restart_2ctrls e2e test; fix …

### DIFF
--- a/setup-env/e2e-tests/data/crm_info.yml
+++ b/setup-env/e2e-tests/data/crm_info.yml
@@ -316,6 +316,7 @@ appinstances:
   - proto: LProtoHTTP
     internalport: 443
     publicport: 443
+    pathprefix: acmeappco/someapplication110/p443
   - proto: LProtoUDP
     internalport: 10002
     publicport: 10002
@@ -355,6 +356,7 @@ appinstances:
   - proto: LProtoHTTP
     internalport: 443
     publicport: 443
+    pathprefix: acmeappco/someapplication110/p443
   - proto: LProtoUDP
     internalport: 10002
     publicport: 10002

--- a/setup-env/e2e-tests/data/find-cloudlet-response-azure.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-azure.yml
@@ -5,9 +5,10 @@ ports:
   internalport: 80
   publicport: 80
   fqdnprefix: someapplication1-tcp.
-- proto: LProtoHTTP
+- proto: LProtoTCP
   internalport: 443
   publicport: 443
+  fqdnprefix: someapplication1-tcp.
 - proto: LProtoUDP
   internalport: 10002
   publicport: 10002

--- a/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet1.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet1.yml
@@ -8,6 +8,7 @@ ports:
 - proto: LProtoHTTP
   internalport: 443
   publicport: 443
+  pathprefix: acmeappco/someapplication110/p443
 - proto: LProtoUDP
   internalport: 10002
   publicport: 10002

--- a/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet2.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet2.yml
@@ -7,6 +7,7 @@ ports:
 - proto: LProtoHTTP
   internalport: 443
   publicport: 443
+  pathprefix: acmeappco/someapplication110/p443
 - proto: LProtoUDP
   internalport: 10002
   publicport: 10002

--- a/setup-env/e2e-tests/data/get_appinstlist_result_app1.yml
+++ b/setup-env/e2e-tests/data/get_appinstlist_result_app1.yml
@@ -15,9 +15,10 @@ cloudlets:
       internalport: 80
       publicport: 80
       fqdnprefix: someapplication1-tcp.
-    - proto: LProtoHTTP
+    - proto: LProtoTCP
       internalport: 443
       publicport: 443
+      fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002
@@ -37,9 +38,10 @@ cloudlets:
       internalport: 80
       publicport: 80
       fqdnprefix: someapplication1-tcp.
-    - proto: LProtoHTTP
+    - proto: LProtoTCP
       internalport: 443
       publicport: 443
+      fqdnprefix: someapplication1-tcp.
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002
@@ -62,6 +64,7 @@ cloudlets:
     - proto: LProtoHTTP
       internalport: 443
       publicport: 443
+      pathprefix: acmeappco/someapplication110/p443
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002
@@ -84,6 +87,7 @@ cloudlets:
     - proto: LProtoHTTP
       internalport: 443
       publicport: 443
+      pathprefix: acmeappco/someapplication110/p443
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002
@@ -106,6 +110,7 @@ cloudlets:
     - proto: LProtoHTTP
       internalport: 443
       publicport: 443
+      pathprefix: acmeappco/someapplication110/p443
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002
@@ -128,6 +133,7 @@ cloudlets:
     - proto: LProtoHTTP
       internalport: 443
       publicport: 443
+      pathprefix: acmeappco/someapplication110/p443
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002
@@ -150,6 +156,7 @@ cloudlets:
     - proto: LProtoHTTP
       internalport: 443
       publicport: 443
+      pathprefix: acmeappco/someapplication110/p443
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002
@@ -172,6 +179,7 @@ cloudlets:
     - proto: LProtoHTTP
       internalport: 443
       publicport: 443
+      pathprefix: acmeappco/someapplication110/p443
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002
@@ -194,6 +202,7 @@ cloudlets:
     - proto: LProtoHTTP
       internalport: 443
       publicport: 443
+      pathprefix: acmeappco/someapplication110/p443
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002
@@ -216,6 +225,7 @@ cloudlets:
     - proto: LProtoHTTP
       internalport: 443
       publicport: 443
+      pathprefix: acmeappco/someapplication110/p443
     - proto: LProtoUDP
       internalport: 10002
       publicport: 10002

--- a/setup-env/e2e-tests/testfiles/restarts_2ctrls.yml
+++ b/setup-env/e2e-tests/testfiles/restarts_2ctrls.yml
@@ -50,13 +50,19 @@ tests:
 - name: stop ctrl2 
   actions: [stop=ctrl2]
 
+- name: verify CRMs are ready after reconnecting to ctrl1
+  actions: [status=allcrms]
+
 - name: delete provisioning
   actions: [ctrlapi-delete]
   apifile: "{{datadir}}/appdata.yml"
 
 - name: start ctrl2
   actions: [start=ctrl2]
-  
+
+- name: verify CRMs are ready
+  actions: [status=allcrms]
+
 - name: show ctrl1 provisioning, verify it is empty
   actions: [ctrlapi-show=ctrl1]
   compareyaml:

--- a/setup-env/setup-mex/setup-mex.go
+++ b/setup-env/setup-mex/setup-mex.go
@@ -89,7 +89,7 @@ func WaitForProcesses(processName string, procs []process.Process) bool {
 		go util.ConnectDme(dme, c)
 	}
 	for _, crm := range util.Deployment.Crms {
-		if processName != "" && processName != crm.Name {
+		if processName != "" && processName != crm.Name && processName != "allcrms" {
 			continue
 		}
 		count++


### PR DESCRIPTION
…pathprefix data files

I broke e2e tests with the L7 nginx changes. I needed to add the pathprefix field to some of the expected data results.

In the process, I hit bug 575. When we stop the controller gracefully, it sets the CloudletState to Offline for all cloudlets connected to it. When the cloudlets detect the lost connection, they reconnect to the remaining controller, and then that controller sets the CloudletState to Ready. So the fix is have the e2e test code check the cloudlet state after stopping the controller. This is already done after all processes are started. I added a new tag to allow the e2e test code to check all crms, which connects to a controller to verify state is ready (in util.go.ConnectCRM).