### PR TITLE
EDGECLOUD-515 remove sessionCoookie from C++ rest

### DIFF
--- a/edge-mvp/cpp/rest/sample_client.cpp
+++ b/edge-mvp/cpp/rest/sample_client.cpp
@@ -187,7 +187,6 @@ class MexRestClient {
 
     json RegisterClient(const string &baseuri, const json &request, string &reply, long &httpResponse) {
         json jreply = postRequest(baseuri + registerAPI, request.dump(), httpResponse, reply, getReplyCallback);
-        cout << "RegClient jreply: " << jreply.dump() << endl;
         if (httpResponse != 200) {
             return jreply;
         }
@@ -216,7 +215,6 @@ class MexRestClient {
         tokenizedRequest["GpsLocation"] = request["GpsLocation"];
         tokenizedRequest["VerifyLocToken"] = token;
 
-        cout << "Posting JSON: " << tokenizedRequest.dump() << endl;
         json jreply = postRequest(baseuri + verifylocationAPI, tokenizedRequest.dump(), httpResponse, reply, getReplyCallback);
         return jreply;
     }


### PR DESCRIPTION
Original remove print from C++ GRPC sample client only. Rest sample is now also updated. 

mexdemo.dme Server is still currently sending public_path. (Assertion failure, path_prefix key missing)