### PR TITLE
fix unit tests

### DIFF
--- a/controller/app_api_test.go
+++ b/controller/app_api_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/objstore"
 	"github.com/mobiledgex/edge-cloud/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAppApi(t *testing.T) {
@@ -26,7 +26,7 @@ func TestAppApi(t *testing.T) {
 	ctx := context.TODO()
 	for _, obj := range testutil.AppData {
 		_, err := appApi.CreateApp(ctx, &obj)
-		assert.NotNil(t, err, "Create app without developer")
+		require.NotNil(t, err, "Create app without developer")
 	}
 
 	// create support data

--- a/controller/cloudlet_api_test.go
+++ b/controller/cloudlet_api_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/objstore"
 	"github.com/mobiledgex/edge-cloud/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCloudletApi(t *testing.T) {
@@ -36,11 +36,11 @@ func TestCloudletApi(t *testing.T) {
 	clbad = testutil.CloudletData[0]
 	clbad.Key.Name = "test num dyn ips"
 	err := cloudletApi.CreateCloudlet(&clbad, &testutil.CudStreamoutCloudlet{})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	clbad.NumDynamicIps = 0
 	clbad.Fields = []string{edgeproto.CloudletFieldNumDynamicIps}
 	err = cloudletApi.UpdateCloudlet(&clbad, &testutil.CudStreamoutCloudlet{})
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 
 	dummy.Stop()
 }
@@ -49,7 +49,7 @@ func testBadLat(t *testing.T, clbad *edgeproto.Cloudlet, lats []float64) {
 	for _, lat := range lats {
 		clbad.Location.Latitude = lat
 		err := cloudletApi.CreateCloudlet(clbad, &testutil.CudStreamoutCloudlet{})
-		assert.NotNil(t, err, "create cloudlet bad latitude")
+		require.NotNil(t, err, "create cloudlet bad latitude")
 	}
 }
 
@@ -57,6 +57,6 @@ func testBadLong(t *testing.T, clbad *edgeproto.Cloudlet, longs []float64) {
 	for _, long := range longs {
 		clbad.Location.Longitude = long
 		err := cloudletApi.CreateCloudlet(clbad, &testutil.CudStreamoutCloudlet{})
-		assert.NotNil(t, err, "create cloudlet bad longitude")
+		require.NotNil(t, err, "create cloudlet bad longitude")
 	}
 }

--- a/controller/clusterinst_api_test.go
+++ b/controller/clusterinst_api_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/objstore"
 	"github.com/mobiledgex/edge-cloud/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClusterInstApi(t *testing.T) {
@@ -30,7 +30,7 @@ func TestClusterInstApi(t *testing.T) {
 	// cannot create insts without cluster/cloudlet
 	for _, obj := range testutil.ClusterInstData {
 		err := clusterInstApi.CreateClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-		assert.NotNil(t, err, "Create cluster inst without cloudlet")
+		require.NotNil(t, err, "Create ClusterInst without cloudlet")
 	}
 
 	// create support data
@@ -46,12 +46,12 @@ func TestClusterInstApi(t *testing.T) {
 	responder.SetSimulateClusterCreateFailure(true)
 	for _, obj := range testutil.ClusterInstData {
 		err := clusterInstApi.CreateClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-		assert.NotNil(t, err, "Create cluster inst responder failures")
+		require.NotNil(t, err, "Create ClusterInst responder failures")
 		// make sure error matches responder
-		assert.Equal(t, "Encountered failures: crm create cluster inst failed", err.Error())
+		require.Equal(t, "Encountered failures: crm create ClusterInst failed", err.Error())
 	}
 	responder.SetSimulateClusterCreateFailure(false)
-	assert.Equal(t, 0, len(clusterInstApi.cache.Objs))
+	require.Equal(t, 0, len(clusterInstApi.cache.Objs))
 
 	testutil.InternalClusterInstTest(t, "cud", &clusterInstApi, testutil.ClusterInstData)
 	// after cluster insts create, check that cloudlet refs data is correct.
@@ -63,24 +63,24 @@ func TestClusterInstApi(t *testing.T) {
 	responder.SetSimulateClusterDeleteFailure(true)
 	obj := testutil.ClusterInstData[0]
 	err := clusterInstApi.DeleteClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-	assert.NotNil(t, err, "Delete ClusterInst responder failure")
+	require.NotNil(t, err, "Delete ClusterInst responder failure")
 	responder.SetSimulateClusterDeleteFailure(false)
 	checkClusterInstState(t, commonApi, &obj, edgeproto.TrackedState_Ready)
 
 	// check override of error DeleteError
 	err = forceClusterInstState(&obj, edgeproto.TrackedState_DeleteError)
-	assert.Nil(t, err, "force state")
+	require.Nil(t, err, "force state")
 	checkClusterInstState(t, commonApi, &obj, edgeproto.TrackedState_DeleteError)
 	err = clusterInstApi.CreateClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-	assert.Nil(t, err, "create overrides delete error")
+	require.Nil(t, err, "create overrides delete error")
 	checkClusterInstState(t, commonApi, &obj, edgeproto.TrackedState_Ready)
 
 	// check override of error CreateError
 	err = forceClusterInstState(&obj, edgeproto.TrackedState_CreateError)
-	assert.Nil(t, err, "force state")
+	require.Nil(t, err, "force state")
 	checkClusterInstState(t, commonApi, &obj, edgeproto.TrackedState_CreateError)
 	err = clusterInstApi.DeleteClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-	assert.Nil(t, err, "delete overrides create error")
+	require.Nil(t, err, "delete overrides create error")
 	checkClusterInstState(t, commonApi, &obj, edgeproto.TrackedState_NotPresent)
 
 	// override CRM error
@@ -89,27 +89,27 @@ func TestClusterInstApi(t *testing.T) {
 	obj = testutil.ClusterInstData[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IgnoreCRMErrors
 	err = clusterInstApi.CreateClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-	assert.Nil(t, err, "override crm error")
+	require.Nil(t, err, "override crm error")
 	obj = testutil.ClusterInstData[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IgnoreCRMErrors
 	err = clusterInstApi.DeleteClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-	assert.Nil(t, err, "override crm error")
+	require.Nil(t, err, "override crm error")
 
 	// ignore CRM
 	obj = testutil.ClusterInstData[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IgnoreCRM
 	err = clusterInstApi.CreateClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-	assert.Nil(t, err, "ignore crm")
+	require.Nil(t, err, "ignore crm")
 	obj = testutil.ClusterInstData[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IgnoreCRM
 	err = clusterInstApi.DeleteClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-	assert.Nil(t, err, "ignore crm")
+	require.Nil(t, err, "ignore crm")
 
 	// inavailability of matching node flavor
 	obj = testutil.ClusterInstData[0]
 	obj.Flavor = testutil.FlavorData[0].Key
 	err = clusterInstApi.CreateClusterInst(&obj, &testutil.CudStreamoutClusterInst{})
-	assert.NotNil(t, err, "flavor not available")
+	require.NotNil(t, err, "flavor not available")
 
 	responder.SetSimulateClusterCreateFailure(false)
 	responder.SetSimulateClusterDeleteFailure(false)
@@ -131,10 +131,10 @@ func checkClusterInstState(t *testing.T, api *testutil.ClusterInstCommonApi, in 
 	out := edgeproto.ClusterInst{}
 	found := testutil.GetClusterInst(t, api, &in.Key, &out)
 	if state == edgeproto.TrackedState_NotPresent {
-		assert.False(t, found, "get cluster inst")
+		require.False(t, found, "get cluster inst")
 	} else {
-		assert.True(t, found, "get cluster inst")
-		assert.Equal(t, state, out.State, "cluster inst state")
+		require.True(t, found, "get cluster inst")
+		require.Equal(t, state, out.State, "cluster inst state")
 	}
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	influxq "github.com/mobiledgex/edge-cloud/controller/influxq_client"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/integration/process"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/notify"
 	"github.com/mobiledgex/edge-cloud/objstore"
@@ -31,6 +32,7 @@ import (
 // Command line options
 var rootDir = flag.String("r", "", "root directory; set for testing")
 var localEtcd = flag.Bool("localEtcd", false, "set to start local etcd for testing")
+var initLocalEtcd = flag.Bool("initLocalEtcd", false, "set to init local etcd database")
 var region = flag.Uint("region", 1, "Region")
 var etcdUrls = flag.String("etcdUrls", "http://127.0.0.1:2380", "etcd client listener URLs")
 var apiAddr = flag.String("apiAddr", "127.0.0.1:55001", "API listener address")
@@ -55,12 +57,36 @@ func GetRootDir() string {
 var ErrCtrlAlreadyInProgress = errors.New("Change already in progress")
 
 var sigChan chan os.Signal
+var services Services
 
-// testing hook
-var mainStarted chan struct{}
+type Services struct {
+	etcdLocal       *process.Etcd
+	sync            *Sync
+	influxQ         *influxq.InfluxQ
+	notifyServerMgr bool
+	grpcServer      *grpc.Server
+	httpServer      *http.Server
+}
 
 func main() {
 	flag.Parse()
+
+	err := startServices()
+	if err != nil {
+		stopServices()
+		log.FatalLog(err.Error())
+	}
+	defer stopServices()
+
+	sigChan = make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+
+	// wait until process in killed/interrupted
+	sig := <-sigChan
+	fmt.Println(sig)
+}
+
+func startServices() error {
 	log.SetDebugLevelStrs(*debugLevels)
 
 	if *externalApiAddr == "" {
@@ -71,61 +97,64 @@ func main() {
 	objstore.InitRegion(uint32(*region))
 
 	if *localEtcd {
-		etcdServer, err := StartLocalEtcdServer()
-		if err != nil {
-			log.FatalLog("No clientIP and clientPort specified, starting local etcd server failed: %s", err)
+		opts := []process.StartOp{}
+		if *initLocalEtcd {
+			opts = append(opts, process.WithCleanStartup())
 		}
-		etcdUrls = &etcdServer.Config.ClientUrls
-		defer etcdServer.Stop()
+		etcdLocal, err := StartLocalEtcdServer(opts...)
+		if err != nil {
+			return fmt.Errorf("starting local etcd server failed: %v", err)
+		}
+		services.etcdLocal = etcdLocal
+		etcdUrls = &etcdLocal.ClientAddrs
 	}
 	objStore, err := GetEtcdClientBasic(*etcdUrls)
 	if err != nil {
-		log.FatalLog("Failed to initialize Object Store", "err", err)
+		return fmt.Errorf("Failed to initialize Object Store, %v", err)
 	}
 	err = objStore.CheckConnected(50, 20*time.Millisecond)
 	if err != nil {
-		log.FatalLog("Failed to connect to etcd servers", "err", err)
+		return fmt.Errorf("Failed to connect to etcd servers, %v", err)
 	}
 
 	if !*skipVersionCheck {
 		// First off - check version of the objectStore we are running
 		if err = checkVersion(objStore); err != nil {
-			log.FatalLog("Running version doesn't match the version of etcd", "err", err)
+			return fmt.Errorf("Running version doesn't match the version of etcd, %v", err)
 		}
 	}
 	lis, err := net.Listen("tcp", *apiAddr)
 	if err != nil {
-		log.FatalLog("Failed to listen on address", "address", *apiAddr,
-			"error", err)
+		return fmt.Errorf("Failed to listen on address %s, %v", *apiAddr, err)
 	}
 
 	sync := InitSync(objStore)
 	InitApis(sync)
 	sync.Start()
-	defer sync.Done()
+	services.sync = sync
 
 	// register controller must be called before starting Notify protocol
 	// to set up controllerAliveLease.
 	err = controllerApi.registerController()
 	if err != nil {
-		log.FatalLog("Failed to register controller", "err", err)
+		return fmt.Errorf("Failed to register controller, %v", err)
 	}
 
 	influxQ := influxq.NewInfluxQ(InfluxDBName)
 	err = influxQ.Start(*influxAddr)
 	if err != nil {
-		log.FatalLog("Failed to start influx queue",
-			"address", *influxAddr, "err", err)
+		return fmt.Errorf("Failed to start influx queue address %s, %v",
+			*influxAddr, err)
 	}
-	defer influxQ.Stop()
+	services.influxQ = influxQ
 
 	InitNotify(influxQ)
 	notify.ServerMgrOne.Start(*notifyAddr, *tlsCertFile)
-	defer notify.ServerMgrOne.Stop()
+	services.notifyServerMgr = true
 
 	creds, err := tls.GetTLSServerCreds(*tlsCertFile)
 	if err != nil {
-		log.FatalLog("get TLS Credentials", "error", err)
+		return fmt.Errorf("get TLS Credentials failed, %v", err)
 	}
 	server := grpc.NewServer(grpc.Creds(creds),
 		grpc.UnaryInterceptor(AuditUnaryInterceptor),
@@ -151,7 +180,7 @@ func main() {
 			log.FatalLog("Failed to serve", "error", err)
 		}
 	}()
-	defer server.Stop()
+	services.grpcServer = server
 
 	// REST gateway
 	mux := http.NewServeMux()
@@ -174,7 +203,7 @@ func main() {
 	}
 	gw, err := cloudcommon.GrpcGateway(gwcfg)
 	if err != nil {
-		log.FatalLog("Failed to create grpc gateway", "error", err)
+		return fmt.Errorf("Failed to create grpc gateway, %v", err)
 	}
 	mux.Handle("/", gw)
 	tlscfg := &ctls.Config{
@@ -203,19 +232,31 @@ func main() {
 		ErrorLog:  &nullLogger,
 	}
 	go cloudcommon.GrpcGatewayServe(gwcfg, httpServer)
-	defer httpServer.Shutdown(context.Background())
+	services.httpServer = httpServer
 
-	sigChan = make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt)
-
-	if mainStarted != nil {
-		close(mainStarted)
-	}
 	log.InfoLog("Ready")
+	return nil
+}
 
-	// wait until process in killed/interrupted
-	sig := <-sigChan
-	fmt.Println(sig)
+func stopServices() {
+	if services.httpServer != nil {
+		services.httpServer.Shutdown(context.Background())
+	}
+	if services.grpcServer != nil {
+		services.grpcServer.Stop()
+	}
+	if services.notifyServerMgr {
+		notify.ServerMgrOne.Stop()
+	}
+	if services.influxQ != nil {
+		services.influxQ.Stop()
+	}
+	if services.sync != nil {
+		services.sync.Done()
+	}
+	if services.etcdLocal != nil {
+		services.etcdLocal.StopLocal()
+	}
 }
 
 // Helper function to verify the compatibility of etcd version and

--- a/controller/dummy_info_responder.go
+++ b/controller/dummy_info_responder.go
@@ -79,36 +79,36 @@ func (d *DummyInfoResponder) clusterInstChanged(key *edgeproto.ClusterInstKey) {
 	}
 	if inst.State == edgeproto.TrackedState_UpdateRequested {
 		// update
-		log.DebugLog(log.DebugLevelApi, "Update cluster inst", "key", key)
+		log.DebugLog(log.DebugLevelApi, "Update ClusterInst", "key", key)
 		time.Sleep(DummyInfoDelay)
 		d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Updating)
-		log.DebugLog(log.DebugLevelApi, "cluster inst ready", "key", key)
+		log.DebugLog(log.DebugLevelApi, "ClusterInst ready", "key", key)
 		if d.simulateClusterUpdateFailure {
-			d.ClusterInstInfoCache.SetError(key, edgeproto.TrackedState_UpdateError, "crm update cluster inst failed")
+			d.ClusterInstInfoCache.SetError(key, edgeproto.TrackedState_UpdateError, "crm update ClusterInst failed")
 		} else {
 			d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Ready)
 		}
 	} else if inst.State == edgeproto.TrackedState_CreateRequested {
 		// create
-		log.DebugLog(log.DebugLevelApi, "Create cluster inst", "key", key)
+		log.DebugLog(log.DebugLevelApi, "Create ClusterInst", "key", key)
 		time.Sleep(DummyInfoDelay)
 		d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Creating)
 		time.Sleep(DummyInfoDelay)
-		log.DebugLog(log.DebugLevelApi, "cluster inst ready", "key", key)
+		log.DebugLog(log.DebugLevelApi, "ClusterInst ready", "key", key)
 		if d.simulateClusterCreateFailure {
-			d.ClusterInstInfoCache.SetError(key, edgeproto.TrackedState_CreateError, "crm create cluster inst failed")
+			d.ClusterInstInfoCache.SetError(key, edgeproto.TrackedState_CreateError, "crm create ClusterInst failed")
 		} else {
 			d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Ready)
 		}
 	} else if inst.State == edgeproto.TrackedState_DeleteRequested {
 		// delete
-		log.DebugLog(log.DebugLevelApi, "Delete cluster inst", "key", key)
+		log.DebugLog(log.DebugLevelApi, "Delete ClusterInst", "key", key)
 		time.Sleep(DummyInfoDelay)
 		d.ClusterInstInfoCache.SetState(key, edgeproto.TrackedState_Deleting)
 		time.Sleep(DummyInfoDelay)
-		log.DebugLog(log.DebugLevelApi, "cluster inst deleted", "key", key)
+		log.DebugLog(log.DebugLevelApi, "ClusterInst deleted", "key", key)
 		if d.simulateClusterDeleteFailure {
-			d.ClusterInstInfoCache.SetError(key, edgeproto.TrackedState_DeleteError, "crm delete cluster inst failed")
+			d.ClusterInstInfoCache.SetError(key, edgeproto.TrackedState_DeleteError, "crm delete ClusterInst failed")
 		} else {
 			info := edgeproto.ClusterInstInfo{Key: *key}
 			d.ClusterInstInfoCache.Delete(&info, 0)

--- a/controller/etcd_server.go
+++ b/controller/etcd_server.go
@@ -4,118 +4,33 @@
 package main
 
 import (
-	"errors"
-	"fmt"
-	"net"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 
+	"github.com/mobiledgex/edge-cloud/integration/process"
 	"github.com/mobiledgex/edge-cloud/log"
 )
-
-// Configuration for starting the etcd service to be used as the backing store
-// for the MEX database
-type EtcdConfig struct {
-	// etcd binary + path
-	EtcdBin string
-	// member name
-	Name string
-	// location of database files
-	DataDir string
-	// ip and port to listen for peer traffic
-	PeerIP   string
-	PeerPort uint16
-	// etcd client URls
-	ClientUrls string
-	// more stuff later for certs
-	LogFile string
-}
-
-type EtcdServer struct {
-	Config  EtcdConfig
-	testDir string
-	logfile *os.File
-	cmd     *exec.Cmd
-	isLocal bool
-	started bool
-}
 
 const EtcdLocalData string = "etcdLocal_data"
 const EtcdLocalLog string = "etcdLocal.log"
 
-func StartLocalEtcdServer() (*EtcdServer, error) {
+func StartLocalEtcdServer(opts ...process.StartOp) (*process.Etcd, error) {
 	_, filename, _, _ := runtime.Caller(0)
 	testdir := filepath.Dir(filename) + "/" + EtcdLocalData
-	logfile := testdir + "/" + EtcdLocalLog
-	config := EtcdConfig{
-		EtcdBin:    "etcd",
-		Name:       "test",
-		DataDir:    testdir,
-		PeerIP:     "127.0.0.1",
-		PeerPort:   52379,
-		ClientUrls: "http://127.0.0.1:52380",
-		LogFile:    logfile,
+
+	etcd := &process.Etcd{
+		Common: process.Common{
+			Name: "etcd-local",
+		},
+		DataDir:        testdir,
+		PeerAddrs:      "http://127.0.0.1:52379",
+		ClientAddrs:    "http://127.0.0.1:52380",
+		InitialCluster: "etcd-local=http://127.0.0.1:52379",
 	}
-	log.InfoLog("Starting local etcd", "clientUrls", config.ClientUrls)
-	server := EtcdServer{}
-	err := server.Start(&config)
+	log.InfoLog("Starting local etcd", "clientUrls", etcd.ClientAddrs)
+	err := etcd.StartLocal("", opts...)
 	if err != nil {
 		return nil, err
 	}
-	server.isLocal = true
-	return &server, nil
-}
-
-func (e *EtcdServer) Start(config *EtcdConfig) error {
-	if net.ParseIP(config.PeerIP) == nil {
-		return errors.New("EtcdConfig: Invalid Peer IP")
-	}
-
-	peerUrl := fmt.Sprintf("http://%s:%d", config.PeerIP, config.PeerPort)
-
-	e.cmd = exec.Command(config.EtcdBin, "--name", config.Name,
-		"--data-dir", config.DataDir, "--listen-peer-urls", peerUrl,
-		"--listen-client-urls", config.ClientUrls, "--advertise-client-urls",
-		config.ClientUrls)
-
-	logdir := filepath.Dir(config.LogFile)
-	err := os.MkdirAll(logdir, 0744)
-	if err != nil {
-		return err
-	}
-
-	logfile, err := os.OpenFile(config.LogFile,
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	e.cmd.Stdout = logfile
-	e.cmd.Stderr = logfile
-	err = e.cmd.Start()
-	if err != nil {
-		logfile.Close()
-		return err
-	}
-	e.Config = *config
-	e.logfile = logfile
-	e.started = true
-	return nil
-}
-
-func (e *EtcdServer) Stop() {
-	if !e.started {
-		return
-	}
-	e.cmd.Process.Kill()
-	e.logfile.Close()
-	if e.isLocal {
-		// clean up all files
-		os.RemoveAll(e.Config.DataDir)
-	}
-	err := e.cmd.Wait()
-	if err != nil {
-		log.InfoLog("Wait for etcd process failed", "pid", e.cmd.Process.Pid, "err", err)
-	}
+	return etcd, nil
 }

--- a/controller/etcd_test.go
+++ b/controller/etcd_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -312,33 +311,6 @@ func TestEtcdDummy(t *testing.T) {
 	dummy.Start()
 	testCalls(t, &dummy)
 	dummy.Stop()
-}
-
-func TestEtcdReal(t *testing.T) {
-	log.SetDebugLevel(log.DebugLevelEtcd)
-	etcd, err := StartLocalEtcdServer()
-	assert.Nil(t, err, "Etcd start")
-	if err != nil {
-		return
-	}
-	_, err = os.Stat(etcd.Config.LogFile)
-	assert.Nil(t, err, "Stat log file %s", etcd.Config.LogFile)
-
-	objStore, err := GetEtcdClientBasic(etcd.Config.ClientUrls)
-	assert.Nil(t, err, "Etcd client")
-	if err != nil {
-		return
-	}
-	testCalls(t, objStore)
-
-	etcd.Stop()
-	if _, err := os.Stat(etcd.Config.LogFile); !os.IsNotExist(err) {
-		t.Errorf("Etcd logfile still present after cleanup: %s", err)
-	}
-	if _, err := os.Stat(etcd.Config.DataDir); !os.IsNotExist(err) {
-		// this indicates etcd process is probably still running
-		t.Errorf("testdir still present after cleanup: %s", err)
-	}
 }
 
 type SyncCheck struct {

--- a/controller/main_test.go
+++ b/controller/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"os"
 	"testing"
 	"time"
@@ -11,45 +12,29 @@ import (
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/notify"
 	"github.com/mobiledgex/edge-cloud/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	yaml "gopkg.in/yaml.v2"
 )
 
-func startMain(t *testing.T) (*grpc.ClientConn, chan struct{}, error) {
-	// these vars are defined in main()
-	mainStarted = make(chan struct{})
-	// channel to wait for main to finish
-	mainDone := make(chan struct{})
-	go func() {
-		main()
-		close(mainDone)
-	}()
-	// wait unil main is ready
-	<-mainStarted
-	assert.True(t, true, "Main Started")
-
+func getGrpcClient(t *testing.T) (*grpc.ClientConn, error) {
 	// grpc client
-	conn, err := grpc.Dial("127.0.0.1:55001", grpc.WithInsecure())
-	assert.Nil(t, err, "grpc Dial")
-	if err != nil {
-		return nil, nil, err
-	}
 	reduceInfoTimeouts()
-	return conn, mainDone, nil
+	return grpc.Dial("127.0.0.1:55001", grpc.WithInsecure())
 }
 
 func TestController(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelNotify | log.DebugLevelApi)
+	flag.Parse() // set defaults
+	*localEtcd = true
+	*initLocalEtcd = true
 
-	os.Args = append(os.Args, "-localEtcd")
+	err := startServices()
+	require.Nil(t, err, "start")
+	defer stopServices()
 
-	conn, mainDone, err := startMain(t)
-	if err != nil {
-		close(sigChan)
-		return
-	}
+	conn, err := getGrpcClient(t)
+	require.Nil(t, err, "grpc client")
 	defer conn.Close()
 
 	// test notify clients
@@ -95,16 +80,16 @@ func TestController(t *testing.T) {
 	dmeNotify.WaitForAppInsts(6)
 	crmNotify.WaitForFlavors(3)
 
-	assert.Equal(t, 6, len(dmeNotify.AppInstCache.Objs), "num appinsts")
-	assert.Equal(t, 4, len(crmNotify.FlavorCache.Objs), "num flavors")
-	assert.Equal(t, 9, len(crmNotify.ClusterInstInfoCache.Objs), "crm cluster inst infos")
-	assert.Equal(t, 6, len(crmNotify.AppInstInfoCache.Objs), "crm cluster inst infos")
+	require.Equal(t, 6, len(dmeNotify.AppInstCache.Objs), "num appinsts")
+	require.Equal(t, 4, len(crmNotify.FlavorCache.Objs), "num flavors")
+	require.Equal(t, 9, len(crmNotify.ClusterInstInfoCache.Objs), "crm cluster inst infos")
+	require.Equal(t, 6, len(crmNotify.AppInstInfoCache.Objs), "crm cluster inst infos")
 
 	ClientAppInstCachedFieldsTest(t, appClient, cloudletClient, appInstClient)
 
 	WaitForCloudletInfo(len(testutil.CloudletInfoData))
-	assert.Equal(t, len(testutil.CloudletInfoData), len(cloudletInfoApi.cache.Objs))
-	assert.Equal(t, len(crmNotify.CloudletInfoCache.Objs), len(cloudletInfoApi.cache.Objs))
+	require.Equal(t, len(testutil.CloudletInfoData), len(cloudletInfoApi.cache.Objs))
+	require.Equal(t, len(crmNotify.CloudletInfoCache.Objs), len(cloudletInfoApi.cache.Objs))
 
 	// test show api for info structs
 	// XXX These checks won't work until we move notifyId out of struct
@@ -116,64 +101,59 @@ func TestController(t *testing.T) {
 	// test that delete checks disallow deletes of dependent objects
 	ctx := context.TODO()
 	_, err = devClient.DeleteDeveloper(ctx, &testutil.DevData[0])
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	_, err = operClient.DeleteOperator(ctx, &testutil.OperatorData[0])
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	stream, err := cloudletClient.DeleteCloudlet(ctx, &testutil.CloudletData[0])
 	err = testutil.CloudletReadResultStream(stream, err)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	_, err = appClient.DeleteApp(ctx, &testutil.AppData[0])
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	// test that delete works after removing dependencies
 	for _, inst := range testutil.AppInstData {
 		stream, err := appInstClient.DeleteAppInst(ctx, &inst)
 		err = testutil.AppInstReadResultStream(stream, err)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 	}
 	for _, inst := range testutil.ClusterInstData {
 		stream, err := clusterInstClient.DeleteClusterInst(ctx, &inst)
 		err = testutil.ClusterInstReadResultStream(stream, err)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 	}
 	for _, obj := range testutil.AppData {
 		_, err = appClient.DeleteApp(ctx, &obj)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 	}
 	for _, obj := range testutil.CloudletData {
 		_, err = cloudletClient.DeleteCloudlet(ctx, &obj)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 	}
 	for _, obj := range testutil.DevData {
 		_, err = devClient.DeleteDeveloper(ctx, &obj)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 	}
 	for _, obj := range testutil.OperatorData {
 		_, err = operClient.DeleteOperator(ctx, &obj)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 	}
 	// make sure dynamic app insts were deleted along with Apps
 	dmeNotify.WaitForAppInsts(0)
-	assert.Equal(t, 0, len(dmeNotify.AppInstCache.Objs), "num appinsts")
+	require.Equal(t, 0, len(dmeNotify.AppInstCache.Objs), "num appinsts")
 	// deleting appinsts/cloudlets should also delete associated info
-	assert.Equal(t, 4, len(cloudletInfoApi.cache.Objs))
-	assert.Equal(t, 0, len(clusterInstApi.cache.Objs))
-	assert.Equal(t, 0, len(appInstApi.cache.Objs))
-
-	// closing the signal channel triggers main to exit
-	close(sigChan)
-	// wait until main is done so it can clean up properly
-	<-mainDone
+	require.Equal(t, 4, len(cloudletInfoApi.cache.Objs))
+	require.Equal(t, 0, len(clusterInstApi.cache.Objs))
+	require.Equal(t, 0, len(appInstApi.cache.Objs))
 }
 
 func TestDataGen(t *testing.T) {
 	out, err := os.Create("data_test.json")
 	if err != nil {
-		assert.Nil(t, err, "open file")
+		require.Nil(t, err, "open file")
 		return
 	}
 	for _, obj := range testutil.DevData {
 		val, err := json.Marshal(&obj)
-		assert.Nil(t, err, "marshal %s", obj.Key.GetKeyString())
+		require.Nil(t, err, "marshal %s", obj.Key.GetKeyString())
 		out.Write(val)
 		out.WriteString("\n")
 	}
@@ -182,14 +162,16 @@ func TestDataGen(t *testing.T) {
 
 func TestEdgeCloudBug26(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelNotify)
+	flag.Parse()
+	*localEtcd = true
+	*initLocalEtcd = true
 
-	os.Args = append(os.Args, "-localEtcd")
+	err := startServices()
+	require.Nil(t, err, "start")
+	defer stopServices()
 
-	conn, mainDone, err := startMain(t)
-	if err != nil {
-		close(sigChan)
-		return
-	}
+	conn, err := getGrpcClient(t)
+	require.Nil(t, err, "grcp client")
 	defer conn.Close()
 
 	devClient := edgeproto.NewDeveloperApiClient(conn)
@@ -263,15 +245,15 @@ cloudletinfos:
 
 	ctx := context.TODO()
 	_, err = devClient.CreateDeveloper(ctx, &data.Developers[0])
-	assert.Nil(t, err, "create dev")
+	require.Nil(t, err, "create dev")
 	_, err = flavorClient.CreateFlavor(ctx, &data.Flavors[0])
-	assert.Nil(t, err, "create flavor")
+	require.Nil(t, err, "create flavor")
 	_, err = appClient.CreateApp(ctx, &data.Applications[0])
-	assert.Nil(t, err, "create app")
+	require.Nil(t, err, "create app")
 	_, err = operClient.CreateOperator(ctx, &data.Operators[0])
-	assert.Nil(t, err, "create operator")
+	require.Nil(t, err, "create operator")
 	_, err = cloudletClient.CreateCloudlet(ctx, &data.Cloudlets[0])
-	assert.Nil(t, err, "create cloudlet")
+	require.Nil(t, err, "create cloudlet")
 	insertCloudletInfo(data.CloudletInfos)
 
 	show := testutil.ShowApp{}
@@ -279,22 +261,17 @@ cloudletinfos:
 	filterNone := edgeproto.App{}
 	stream, err := appClient.ShowApp(ctx, &filterNone)
 	show.ReadStream(stream, err)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, 1, len(show.Data), "show app count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, 1, len(show.Data), "show app count")
 
 	_, err = appInstClient.CreateAppInst(ctx, &data.AppInstances[0])
-	assert.Nil(t, err, "create app inst")
+	require.Nil(t, err, "create app inst")
 
 	show.Init()
 	stream, err = appClient.ShowApp(ctx, &filterNone)
 	show.ReadStream(stream, err)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, 1, len(show.Data), "show app count after creating app inst")
-
-	// closing the signal channel triggers main to exit
-	close(sigChan)
-	// wait until main is done so it can clean up properly
-	<-mainDone
+	require.Nil(t, err, "show data")
+	require.Equal(t, 1, len(show.Data), "show app count after creating app inst")
 }
 
 func WaitForCloudletInfo(count int) {
@@ -314,9 +291,9 @@ func CheckCloudletInfo(t *testing.T, client edgeproto.CloudletInfoApiClient, dat
 	show.Init()
 	filterNone := edgeproto.CloudletInfo{}
 	err := api.ShowCloudletInfo(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show cloudlet info")
+	require.Nil(t, err, "show cloudlet info")
 	for _, obj := range data {
 		show.AssertFound(t, &obj)
 	}
-	assert.Equal(t, len(data), len(show.Data), "show count")
+	require.Equal(t, len(data), len(show.Data), "show count")
 }

--- a/notify/dummy_notify.go
+++ b/notify/dummy_notify.go
@@ -56,6 +56,7 @@ func (s *DummyHandler) RegisterCRMClient(cl *Client) {
 	cl.RegisterRecvAppInstCache(&s.AppInstCache)
 	cl.RegisterRecvCloudletCache(&s.CloudletCache)
 	cl.RegisterRecvFlavorCache(&s.FlavorCache)
+	cl.RegisterRecvClusterInstCache(&s.ClusterInstCache)
 }
 
 func (s *DummyHandler) RegisterDMEClient(cl *Client) {
@@ -70,7 +71,6 @@ const (
 	AppInstType           = iota
 	CloudletType
 	FlavorType
-	ClusterFlavorType
 	ClusterInstType
 	AppInstInfoType
 	ClusterInstInfoType

--- a/notify/worker.go
+++ b/notify/worker.go
@@ -22,7 +22,6 @@ const (
 	TypeAppInstInfo
 	TypeCloudlet
 	TypeFlavor
-	TypeClusterFlavor
 	TypeClusterInst
 	TypeClusterInstInfo
 )

--- a/testutil/app_inst_testutil.go
+++ b/testutil/app_inst_testutil.go
@@ -9,7 +9,7 @@ import "io"
 import "testing"
 import "context"
 import "time"
-import "github.com/stretchr/testify/assert"
+import "github.com/stretchr/testify/require"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -97,9 +97,9 @@ func (x *ShowAppInst) CheckFound(obj *edgeproto.AppInst) bool {
 
 func (x *ShowAppInst) AssertFound(t *testing.T, obj *edgeproto.AppInst) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find AppInst %s", obj.Key.GetKeyString())
+	require.True(t, found, "find AppInst %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "AppInst are equal")
+		require.Equal(t, *obj, check, "AppInst are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -110,7 +110,7 @@ func (x *ShowAppInst) AssertFound(t *testing.T, obj *edgeproto.AppInst) {
 
 func (x *ShowAppInst) AssertNotFound(t *testing.T, obj *edgeproto.AppInst) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find AppInst %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find AppInst %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundAppInst(t *testing.T, api edgeproto.AppInstApiClient, obj *edgeproto.AppInst, count int, retry time.Duration) {
@@ -237,8 +237,8 @@ func basicAppInstShowTest(t *testing.T, api *AppInstCommonApi, testData []edgepr
 	show.Init()
 	filterNone := edgeproto.AppInst{}
 	err = api.ShowAppInst(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -253,7 +253,7 @@ func GetAppInst(t *testing.T, api *AppInstCommonApi, key *edgeproto.AppInstKey, 
 	filter := edgeproto.AppInst{}
 	filter.Key = *key
 	err = api.ShowAppInst(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj
@@ -266,7 +266,7 @@ func basicAppInstCudTest(t *testing.T, api *AppInstCommonApi, testData []edgepro
 	ctx := context.TODO()
 
 	if len(testData) < 3 {
-		assert.True(t, false, "Need at least 3 test data objects")
+		require.True(t, false, "Need at least 3 test data objects")
 		return
 	}
 
@@ -275,32 +275,32 @@ func basicAppInstCudTest(t *testing.T, api *AppInstCommonApi, testData []edgepro
 
 	// test duplicate create - should fail
 	_, err = api.CreateAppInst(ctx, &testData[0])
-	assert.NotNil(t, err, "Create duplicate AppInst")
+	require.NotNil(t, err, "Create duplicate AppInst")
 
 	// test show all items
 	basicAppInstShowTest(t, api, testData)
 
 	// test delete
 	_, err = api.DeleteAppInst(ctx, &testData[0])
-	assert.Nil(t, err, "delete AppInst %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "delete AppInst %s", testData[0].Key.GetKeyString())
 	show := ShowAppInst{}
 	show.Init()
 	filterNone := edgeproto.AppInst{}
 	err = api.ShowAppInst(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData)-1, len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData)-1, len(show.Data), "Show count")
 	show.AssertNotFound(t, &testData[0])
 	// test update of missing object
 	_, err = api.UpdateAppInst(ctx, &testData[0])
-	assert.NotNil(t, err, "Update missing object")
+	require.NotNil(t, err, "Update missing object")
 	// create it back
 	_, err = api.CreateAppInst(ctx, &testData[0])
-	assert.Nil(t, err, "Create AppInst %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Create AppInst %s", testData[0].Key.GetKeyString())
 
 	// test invalid keys
 	bad := edgeproto.AppInst{}
 	_, err = api.CreateAppInst(ctx, &bad)
-	assert.NotNil(t, err, "Create AppInst with no key info")
+	require.NotNil(t, err, "Create AppInst with no key info")
 
 }
 
@@ -318,7 +318,7 @@ func createAppInstData(t *testing.T, api *AppInstCommonApi, testData []edgeproto
 
 	for _, obj := range testData {
 		_, err = api.CreateAppInst(ctx, &obj)
-		assert.Nil(t, err, "Create AppInst %s", obj.Key.GetKeyString())
+		require.Nil(t, err, "Create AppInst %s", obj.Key.GetKeyString())
 	}
 }
 
@@ -360,9 +360,9 @@ func (x *ShowAppInstInfo) CheckFound(obj *edgeproto.AppInstInfo) bool {
 
 func (x *ShowAppInstInfo) AssertFound(t *testing.T, obj *edgeproto.AppInstInfo) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find AppInstInfo %s", obj.Key.GetKeyString())
+	require.True(t, found, "find AppInstInfo %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "AppInstInfo are equal")
+		require.Equal(t, *obj, check, "AppInstInfo are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -373,7 +373,7 @@ func (x *ShowAppInstInfo) AssertFound(t *testing.T, obj *edgeproto.AppInstInfo) 
 
 func (x *ShowAppInstInfo) AssertNotFound(t *testing.T, obj *edgeproto.AppInstInfo) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find AppInstInfo %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find AppInstInfo %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundAppInstInfo(t *testing.T, api edgeproto.AppInstInfoApiClient, obj *edgeproto.AppInstInfo, count int, retry time.Duration) {
@@ -457,8 +457,8 @@ func basicAppInstInfoShowTest(t *testing.T, api *AppInstInfoCommonApi, testData 
 	show.Init()
 	filterNone := edgeproto.AppInstInfo{}
 	err = api.ShowAppInstInfo(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -473,7 +473,7 @@ func GetAppInstInfo(t *testing.T, api *AppInstInfoCommonApi, key *edgeproto.AppI
 	filter := edgeproto.AppInstInfo{}
 	filter.Key = *key
 	err = api.ShowAppInstInfo(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj

--- a/testutil/app_testutil.go
+++ b/testutil/app_testutil.go
@@ -74,7 +74,7 @@ import "io"
 import "testing"
 import "context"
 import "time"
-import "github.com/stretchr/testify/assert"
+import "github.com/stretchr/testify/require"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -128,9 +128,9 @@ func (x *ShowApp) CheckFound(obj *edgeproto.App) bool {
 
 func (x *ShowApp) AssertFound(t *testing.T, obj *edgeproto.App) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find App %s", obj.Key.GetKeyString())
+	require.True(t, found, "find App %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "App are equal")
+		require.Equal(t, *obj, check, "App are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -141,7 +141,7 @@ func (x *ShowApp) AssertFound(t *testing.T, obj *edgeproto.App) {
 
 func (x *ShowApp) AssertNotFound(t *testing.T, obj *edgeproto.App) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find App %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find App %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundApp(t *testing.T, api edgeproto.AppApiClient, obj *edgeproto.App, count int, retry time.Duration) {
@@ -259,8 +259,8 @@ func basicAppShowTest(t *testing.T, api *AppCommonApi, testData []edgeproto.App)
 	show.Init()
 	filterNone := edgeproto.App{}
 	err = api.ShowApp(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -275,7 +275,7 @@ func GetApp(t *testing.T, api *AppCommonApi, key *edgeproto.AppKey, out *edgepro
 	filter := edgeproto.App{}
 	filter.Key = *key
 	err = api.ShowApp(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj
@@ -288,7 +288,7 @@ func basicAppCudTest(t *testing.T, api *AppCommonApi, testData []edgeproto.App) 
 	ctx := context.TODO()
 
 	if len(testData) < 3 {
-		assert.True(t, false, "Need at least 3 test data objects")
+		require.True(t, false, "Need at least 3 test data objects")
 		return
 	}
 
@@ -297,32 +297,32 @@ func basicAppCudTest(t *testing.T, api *AppCommonApi, testData []edgeproto.App) 
 
 	// test duplicate create - should fail
 	_, err = api.CreateApp(ctx, &testData[0])
-	assert.NotNil(t, err, "Create duplicate App")
+	require.NotNil(t, err, "Create duplicate App")
 
 	// test show all items
 	basicAppShowTest(t, api, testData)
 
 	// test delete
 	_, err = api.DeleteApp(ctx, &testData[0])
-	assert.Nil(t, err, "delete App %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "delete App %s", testData[0].Key.GetKeyString())
 	show := ShowApp{}
 	show.Init()
 	filterNone := edgeproto.App{}
 	err = api.ShowApp(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData)-1, len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData)-1, len(show.Data), "Show count")
 	show.AssertNotFound(t, &testData[0])
 	// test update of missing object
 	_, err = api.UpdateApp(ctx, &testData[0])
-	assert.NotNil(t, err, "Update missing object")
+	require.NotNil(t, err, "Update missing object")
 	// create it back
 	_, err = api.CreateApp(ctx, &testData[0])
-	assert.Nil(t, err, "Create App %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Create App %s", testData[0].Key.GetKeyString())
 
 	// test invalid keys
 	bad := edgeproto.App{}
 	_, err = api.CreateApp(ctx, &bad)
-	assert.NotNil(t, err, "Create App with no key info")
+	require.NotNil(t, err, "Create App with no key info")
 
 }
 
@@ -340,7 +340,7 @@ func createAppData(t *testing.T, api *AppCommonApi, testData []edgeproto.App) {
 
 	for _, obj := range testData {
 		_, err = api.CreateApp(ctx, &obj)
-		assert.Nil(t, err, "Create App %s", obj.Key.GetKeyString())
+		require.Nil(t, err, "Create App %s", obj.Key.GetKeyString())
 	}
 }
 

--- a/testutil/cloudlet_testutil.go
+++ b/testutil/cloudlet_testutil.go
@@ -9,7 +9,7 @@ import "io"
 import "testing"
 import "context"
 import "time"
-import "github.com/stretchr/testify/assert"
+import "github.com/stretchr/testify/require"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -96,9 +96,9 @@ func (x *ShowCloudlet) CheckFound(obj *edgeproto.Cloudlet) bool {
 
 func (x *ShowCloudlet) AssertFound(t *testing.T, obj *edgeproto.Cloudlet) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find Cloudlet %s", obj.Key.GetKeyString())
+	require.True(t, found, "find Cloudlet %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "Cloudlet are equal")
+		require.Equal(t, *obj, check, "Cloudlet are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -109,7 +109,7 @@ func (x *ShowCloudlet) AssertFound(t *testing.T, obj *edgeproto.Cloudlet) {
 
 func (x *ShowCloudlet) AssertNotFound(t *testing.T, obj *edgeproto.Cloudlet) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find Cloudlet %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find Cloudlet %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundCloudlet(t *testing.T, api edgeproto.CloudletApiClient, obj *edgeproto.Cloudlet, count int, retry time.Duration) {
@@ -236,8 +236,8 @@ func basicCloudletShowTest(t *testing.T, api *CloudletCommonApi, testData []edge
 	show.Init()
 	filterNone := edgeproto.Cloudlet{}
 	err = api.ShowCloudlet(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -252,7 +252,7 @@ func GetCloudlet(t *testing.T, api *CloudletCommonApi, key *edgeproto.CloudletKe
 	filter := edgeproto.Cloudlet{}
 	filter.Key = *key
 	err = api.ShowCloudlet(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj
@@ -265,7 +265,7 @@ func basicCloudletCudTest(t *testing.T, api *CloudletCommonApi, testData []edgep
 	ctx := context.TODO()
 
 	if len(testData) < 3 {
-		assert.True(t, false, "Need at least 3 test data objects")
+		require.True(t, false, "Need at least 3 test data objects")
 		return
 	}
 
@@ -274,32 +274,32 @@ func basicCloudletCudTest(t *testing.T, api *CloudletCommonApi, testData []edgep
 
 	// test duplicate create - should fail
 	_, err = api.CreateCloudlet(ctx, &testData[0])
-	assert.NotNil(t, err, "Create duplicate Cloudlet")
+	require.NotNil(t, err, "Create duplicate Cloudlet")
 
 	// test show all items
 	basicCloudletShowTest(t, api, testData)
 
 	// test delete
 	_, err = api.DeleteCloudlet(ctx, &testData[0])
-	assert.Nil(t, err, "delete Cloudlet %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "delete Cloudlet %s", testData[0].Key.GetKeyString())
 	show := ShowCloudlet{}
 	show.Init()
 	filterNone := edgeproto.Cloudlet{}
 	err = api.ShowCloudlet(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData)-1, len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData)-1, len(show.Data), "Show count")
 	show.AssertNotFound(t, &testData[0])
 	// test update of missing object
 	_, err = api.UpdateCloudlet(ctx, &testData[0])
-	assert.NotNil(t, err, "Update missing object")
+	require.NotNil(t, err, "Update missing object")
 	// create it back
 	_, err = api.CreateCloudlet(ctx, &testData[0])
-	assert.Nil(t, err, "Create Cloudlet %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Create Cloudlet %s", testData[0].Key.GetKeyString())
 
 	// test invalid keys
 	bad := edgeproto.Cloudlet{}
 	_, err = api.CreateCloudlet(ctx, &bad)
-	assert.NotNil(t, err, "Create Cloudlet with no key info")
+	require.NotNil(t, err, "Create Cloudlet with no key info")
 
 	// test update
 	updater := edgeproto.Cloudlet{}
@@ -308,19 +308,19 @@ func basicCloudletCudTest(t *testing.T, api *CloudletCommonApi, testData []edgep
 	updater.Fields = make([]string, 0)
 	updater.Fields = append(updater.Fields, edgeproto.CloudletFieldAccessUri)
 	_, err = api.UpdateCloudlet(ctx, &updater)
-	assert.Nil(t, err, "Update Cloudlet %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Update Cloudlet %s", testData[0].Key.GetKeyString())
 
 	show.Init()
 	updater = testData[0]
 	updater.AccessUri = "update just this"
 	err = api.ShowCloudlet(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show Cloudlet")
+	require.Nil(t, err, "show Cloudlet")
 	show.AssertFound(t, &updater)
 
 	// revert change
 	updater.AccessUri = testData[0].AccessUri
 	_, err = api.UpdateCloudlet(ctx, &updater)
-	assert.Nil(t, err, "Update back Cloudlet")
+	require.Nil(t, err, "Update back Cloudlet")
 }
 
 func InternalCloudletCreate(t *testing.T, api edgeproto.CloudletApiServer, testData []edgeproto.Cloudlet) {
@@ -337,7 +337,7 @@ func createCloudletData(t *testing.T, api *CloudletCommonApi, testData []edgepro
 
 	for _, obj := range testData {
 		_, err = api.CreateCloudlet(ctx, &obj)
-		assert.Nil(t, err, "Create Cloudlet %s", obj.Key.GetKeyString())
+		require.Nil(t, err, "Create Cloudlet %s", obj.Key.GetKeyString())
 	}
 }
 
@@ -379,9 +379,9 @@ func (x *ShowCloudletInfo) CheckFound(obj *edgeproto.CloudletInfo) bool {
 
 func (x *ShowCloudletInfo) AssertFound(t *testing.T, obj *edgeproto.CloudletInfo) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find CloudletInfo %s", obj.Key.GetKeyString())
+	require.True(t, found, "find CloudletInfo %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "CloudletInfo are equal")
+		require.Equal(t, *obj, check, "CloudletInfo are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -392,7 +392,7 @@ func (x *ShowCloudletInfo) AssertFound(t *testing.T, obj *edgeproto.CloudletInfo
 
 func (x *ShowCloudletInfo) AssertNotFound(t *testing.T, obj *edgeproto.CloudletInfo) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find CloudletInfo %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find CloudletInfo %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundCloudletInfo(t *testing.T, api edgeproto.CloudletInfoApiClient, obj *edgeproto.CloudletInfo, count int, retry time.Duration) {
@@ -476,8 +476,8 @@ func basicCloudletInfoShowTest(t *testing.T, api *CloudletInfoCommonApi, testDat
 	show.Init()
 	filterNone := edgeproto.CloudletInfo{}
 	err = api.ShowCloudletInfo(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -492,7 +492,7 @@ func GetCloudletInfo(t *testing.T, api *CloudletInfoCommonApi, key *edgeproto.Cl
 	filter := edgeproto.CloudletInfo{}
 	filter.Key = *key
 	err = api.ShowCloudletInfo(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj

--- a/testutil/cluster_testutil.go
+++ b/testutil/cluster_testutil.go
@@ -9,7 +9,7 @@ import "io"
 import "testing"
 import "context"
 import "time"
-import "github.com/stretchr/testify/assert"
+import "github.com/stretchr/testify/require"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -63,9 +63,9 @@ func (x *ShowCluster) CheckFound(obj *edgeproto.Cluster) bool {
 
 func (x *ShowCluster) AssertFound(t *testing.T, obj *edgeproto.Cluster) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find Cluster %s", obj.Key.GetKeyString())
+	require.True(t, found, "find Cluster %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "Cluster are equal")
+		require.Equal(t, *obj, check, "Cluster are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -76,7 +76,7 @@ func (x *ShowCluster) AssertFound(t *testing.T, obj *edgeproto.Cluster) {
 
 func (x *ShowCluster) AssertNotFound(t *testing.T, obj *edgeproto.Cluster) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find Cluster %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find Cluster %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundCluster(t *testing.T, api edgeproto.ClusterApiClient, obj *edgeproto.Cluster, count int, retry time.Duration) {
@@ -194,8 +194,8 @@ func basicClusterShowTest(t *testing.T, api *ClusterCommonApi, testData []edgepr
 	show.Init()
 	filterNone := edgeproto.Cluster{}
 	err = api.ShowCluster(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -210,7 +210,7 @@ func GetCluster(t *testing.T, api *ClusterCommonApi, key *edgeproto.ClusterKey, 
 	filter := edgeproto.Cluster{}
 	filter.Key = *key
 	err = api.ShowCluster(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj
@@ -223,7 +223,7 @@ func basicClusterCudTest(t *testing.T, api *ClusterCommonApi, testData []edgepro
 	ctx := context.TODO()
 
 	if len(testData) < 3 {
-		assert.True(t, false, "Need at least 3 test data objects")
+		require.True(t, false, "Need at least 3 test data objects")
 		return
 	}
 
@@ -232,32 +232,32 @@ func basicClusterCudTest(t *testing.T, api *ClusterCommonApi, testData []edgepro
 
 	// test duplicate create - should fail
 	_, err = api.CreateCluster(ctx, &testData[0])
-	assert.NotNil(t, err, "Create duplicate Cluster")
+	require.NotNil(t, err, "Create duplicate Cluster")
 
 	// test show all items
 	basicClusterShowTest(t, api, testData)
 
 	// test delete
 	_, err = api.DeleteCluster(ctx, &testData[0])
-	assert.Nil(t, err, "delete Cluster %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "delete Cluster %s", testData[0].Key.GetKeyString())
 	show := ShowCluster{}
 	show.Init()
 	filterNone := edgeproto.Cluster{}
 	err = api.ShowCluster(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData)-1, len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData)-1, len(show.Data), "Show count")
 	show.AssertNotFound(t, &testData[0])
 	// test update of missing object
 	_, err = api.UpdateCluster(ctx, &testData[0])
-	assert.NotNil(t, err, "Update missing object")
+	require.NotNil(t, err, "Update missing object")
 	// create it back
 	_, err = api.CreateCluster(ctx, &testData[0])
-	assert.Nil(t, err, "Create Cluster %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Create Cluster %s", testData[0].Key.GetKeyString())
 
 	// test invalid keys
 	bad := edgeproto.Cluster{}
 	_, err = api.CreateCluster(ctx, &bad)
-	assert.NotNil(t, err, "Create Cluster with no key info")
+	require.NotNil(t, err, "Create Cluster with no key info")
 
 }
 
@@ -275,7 +275,7 @@ func createClusterData(t *testing.T, api *ClusterCommonApi, testData []edgeproto
 
 	for _, obj := range testData {
 		_, err = api.CreateCluster(ctx, &obj)
-		assert.Nil(t, err, "Create Cluster %s", obj.Key.GetKeyString())
+		require.Nil(t, err, "Create Cluster %s", obj.Key.GetKeyString())
 	}
 }
 

--- a/testutil/clusterinst_testutil.go
+++ b/testutil/clusterinst_testutil.go
@@ -9,7 +9,7 @@ import "io"
 import "testing"
 import "context"
 import "time"
-import "github.com/stretchr/testify/assert"
+import "github.com/stretchr/testify/require"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -95,9 +95,9 @@ func (x *ShowClusterInst) CheckFound(obj *edgeproto.ClusterInst) bool {
 
 func (x *ShowClusterInst) AssertFound(t *testing.T, obj *edgeproto.ClusterInst) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find ClusterInst %s", obj.Key.GetKeyString())
+	require.True(t, found, "find ClusterInst %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "ClusterInst are equal")
+		require.Equal(t, *obj, check, "ClusterInst are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -108,7 +108,7 @@ func (x *ShowClusterInst) AssertFound(t *testing.T, obj *edgeproto.ClusterInst) 
 
 func (x *ShowClusterInst) AssertNotFound(t *testing.T, obj *edgeproto.ClusterInst) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find ClusterInst %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find ClusterInst %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundClusterInst(t *testing.T, api edgeproto.ClusterInstApiClient, obj *edgeproto.ClusterInst, count int, retry time.Duration) {
@@ -235,8 +235,8 @@ func basicClusterInstShowTest(t *testing.T, api *ClusterInstCommonApi, testData 
 	show.Init()
 	filterNone := edgeproto.ClusterInst{}
 	err = api.ShowClusterInst(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -251,7 +251,7 @@ func GetClusterInst(t *testing.T, api *ClusterInstCommonApi, key *edgeproto.Clus
 	filter := edgeproto.ClusterInst{}
 	filter.Key = *key
 	err = api.ShowClusterInst(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj
@@ -264,7 +264,7 @@ func basicClusterInstCudTest(t *testing.T, api *ClusterInstCommonApi, testData [
 	ctx := context.TODO()
 
 	if len(testData) < 3 {
-		assert.True(t, false, "Need at least 3 test data objects")
+		require.True(t, false, "Need at least 3 test data objects")
 		return
 	}
 
@@ -273,32 +273,32 @@ func basicClusterInstCudTest(t *testing.T, api *ClusterInstCommonApi, testData [
 
 	// test duplicate create - should fail
 	_, err = api.CreateClusterInst(ctx, &testData[0])
-	assert.NotNil(t, err, "Create duplicate ClusterInst")
+	require.NotNil(t, err, "Create duplicate ClusterInst")
 
 	// test show all items
 	basicClusterInstShowTest(t, api, testData)
 
 	// test delete
 	_, err = api.DeleteClusterInst(ctx, &testData[0])
-	assert.Nil(t, err, "delete ClusterInst %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "delete ClusterInst %s", testData[0].Key.GetKeyString())
 	show := ShowClusterInst{}
 	show.Init()
 	filterNone := edgeproto.ClusterInst{}
 	err = api.ShowClusterInst(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData)-1, len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData)-1, len(show.Data), "Show count")
 	show.AssertNotFound(t, &testData[0])
 	// test update of missing object
 	_, err = api.UpdateClusterInst(ctx, &testData[0])
-	assert.NotNil(t, err, "Update missing object")
+	require.NotNil(t, err, "Update missing object")
 	// create it back
 	_, err = api.CreateClusterInst(ctx, &testData[0])
-	assert.Nil(t, err, "Create ClusterInst %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Create ClusterInst %s", testData[0].Key.GetKeyString())
 
 	// test invalid keys
 	bad := edgeproto.ClusterInst{}
 	_, err = api.CreateClusterInst(ctx, &bad)
-	assert.NotNil(t, err, "Create ClusterInst with no key info")
+	require.NotNil(t, err, "Create ClusterInst with no key info")
 
 }
 
@@ -316,7 +316,7 @@ func createClusterInstData(t *testing.T, api *ClusterInstCommonApi, testData []e
 
 	for _, obj := range testData {
 		_, err = api.CreateClusterInst(ctx, &obj)
-		assert.Nil(t, err, "Create ClusterInst %s", obj.Key.GetKeyString())
+		require.Nil(t, err, "Create ClusterInst %s", obj.Key.GetKeyString())
 	}
 }
 
@@ -358,9 +358,9 @@ func (x *ShowClusterInstInfo) CheckFound(obj *edgeproto.ClusterInstInfo) bool {
 
 func (x *ShowClusterInstInfo) AssertFound(t *testing.T, obj *edgeproto.ClusterInstInfo) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find ClusterInstInfo %s", obj.Key.GetKeyString())
+	require.True(t, found, "find ClusterInstInfo %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "ClusterInstInfo are equal")
+		require.Equal(t, *obj, check, "ClusterInstInfo are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -371,7 +371,7 @@ func (x *ShowClusterInstInfo) AssertFound(t *testing.T, obj *edgeproto.ClusterIn
 
 func (x *ShowClusterInstInfo) AssertNotFound(t *testing.T, obj *edgeproto.ClusterInstInfo) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find ClusterInstInfo %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find ClusterInstInfo %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundClusterInstInfo(t *testing.T, api edgeproto.ClusterInstInfoApiClient, obj *edgeproto.ClusterInstInfo, count int, retry time.Duration) {
@@ -455,8 +455,8 @@ func basicClusterInstInfoShowTest(t *testing.T, api *ClusterInstInfoCommonApi, t
 	show.Init()
 	filterNone := edgeproto.ClusterInstInfo{}
 	err = api.ShowClusterInstInfo(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -471,7 +471,7 @@ func GetClusterInstInfo(t *testing.T, api *ClusterInstInfoCommonApi, key *edgepr
 	filter := edgeproto.ClusterInstInfo{}
 	filter.Key = *key
 	err = api.ShowClusterInstInfo(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj

--- a/testutil/developer_testutil.go
+++ b/testutil/developer_testutil.go
@@ -9,7 +9,7 @@ import "io"
 import "testing"
 import "context"
 import "time"
-import "github.com/stretchr/testify/assert"
+import "github.com/stretchr/testify/require"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -62,9 +62,9 @@ func (x *ShowDeveloper) CheckFound(obj *edgeproto.Developer) bool {
 
 func (x *ShowDeveloper) AssertFound(t *testing.T, obj *edgeproto.Developer) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find Developer %s", obj.Key.GetKeyString())
+	require.True(t, found, "find Developer %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "Developer are equal")
+		require.Equal(t, *obj, check, "Developer are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -75,7 +75,7 @@ func (x *ShowDeveloper) AssertFound(t *testing.T, obj *edgeproto.Developer) {
 
 func (x *ShowDeveloper) AssertNotFound(t *testing.T, obj *edgeproto.Developer) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find Developer %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find Developer %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundDeveloper(t *testing.T, api edgeproto.DeveloperApiClient, obj *edgeproto.Developer, count int, retry time.Duration) {
@@ -193,8 +193,8 @@ func basicDeveloperShowTest(t *testing.T, api *DeveloperCommonApi, testData []ed
 	show.Init()
 	filterNone := edgeproto.Developer{}
 	err = api.ShowDeveloper(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -209,7 +209,7 @@ func GetDeveloper(t *testing.T, api *DeveloperCommonApi, key *edgeproto.Develope
 	filter := edgeproto.Developer{}
 	filter.Key = *key
 	err = api.ShowDeveloper(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj
@@ -222,7 +222,7 @@ func basicDeveloperCudTest(t *testing.T, api *DeveloperCommonApi, testData []edg
 	ctx := context.TODO()
 
 	if len(testData) < 3 {
-		assert.True(t, false, "Need at least 3 test data objects")
+		require.True(t, false, "Need at least 3 test data objects")
 		return
 	}
 
@@ -231,32 +231,32 @@ func basicDeveloperCudTest(t *testing.T, api *DeveloperCommonApi, testData []edg
 
 	// test duplicate create - should fail
 	_, err = api.CreateDeveloper(ctx, &testData[0])
-	assert.NotNil(t, err, "Create duplicate Developer")
+	require.NotNil(t, err, "Create duplicate Developer")
 
 	// test show all items
 	basicDeveloperShowTest(t, api, testData)
 
 	// test delete
 	_, err = api.DeleteDeveloper(ctx, &testData[0])
-	assert.Nil(t, err, "delete Developer %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "delete Developer %s", testData[0].Key.GetKeyString())
 	show := ShowDeveloper{}
 	show.Init()
 	filterNone := edgeproto.Developer{}
 	err = api.ShowDeveloper(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData)-1, len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData)-1, len(show.Data), "Show count")
 	show.AssertNotFound(t, &testData[0])
 	// test update of missing object
 	_, err = api.UpdateDeveloper(ctx, &testData[0])
-	assert.NotNil(t, err, "Update missing object")
+	require.NotNil(t, err, "Update missing object")
 	// create it back
 	_, err = api.CreateDeveloper(ctx, &testData[0])
-	assert.Nil(t, err, "Create Developer %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Create Developer %s", testData[0].Key.GetKeyString())
 
 	// test invalid keys
 	bad := edgeproto.Developer{}
 	_, err = api.CreateDeveloper(ctx, &bad)
-	assert.NotNil(t, err, "Create Developer with no key info")
+	require.NotNil(t, err, "Create Developer with no key info")
 
 	// test update
 	updater := edgeproto.Developer{}
@@ -265,19 +265,19 @@ func basicDeveloperCudTest(t *testing.T, api *DeveloperCommonApi, testData []edg
 	updater.Fields = make([]string, 0)
 	updater.Fields = append(updater.Fields, edgeproto.DeveloperFieldEmail)
 	_, err = api.UpdateDeveloper(ctx, &updater)
-	assert.Nil(t, err, "Update Developer %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Update Developer %s", testData[0].Key.GetKeyString())
 
 	show.Init()
 	updater = testData[0]
 	updater.Email = "update just this"
 	err = api.ShowDeveloper(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show Developer")
+	require.Nil(t, err, "show Developer")
 	show.AssertFound(t, &updater)
 
 	// revert change
 	updater.Email = testData[0].Email
 	_, err = api.UpdateDeveloper(ctx, &updater)
-	assert.Nil(t, err, "Update back Developer")
+	require.Nil(t, err, "Update back Developer")
 }
 
 func InternalDeveloperCreate(t *testing.T, api edgeproto.DeveloperApiServer, testData []edgeproto.Developer) {
@@ -294,7 +294,7 @@ func createDeveloperData(t *testing.T, api *DeveloperCommonApi, testData []edgep
 
 	for _, obj := range testData {
 		_, err = api.CreateDeveloper(ctx, &obj)
-		assert.Nil(t, err, "Create Developer %s", obj.Key.GetKeyString())
+		require.Nil(t, err, "Create Developer %s", obj.Key.GetKeyString())
 	}
 }
 

--- a/testutil/flavor_testutil.go
+++ b/testutil/flavor_testutil.go
@@ -9,7 +9,7 @@ import "io"
 import "testing"
 import "context"
 import "time"
-import "github.com/stretchr/testify/assert"
+import "github.com/stretchr/testify/require"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -63,9 +63,9 @@ func (x *ShowFlavor) CheckFound(obj *edgeproto.Flavor) bool {
 
 func (x *ShowFlavor) AssertFound(t *testing.T, obj *edgeproto.Flavor) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find Flavor %s", obj.Key.GetKeyString())
+	require.True(t, found, "find Flavor %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "Flavor are equal")
+		require.Equal(t, *obj, check, "Flavor are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -76,7 +76,7 @@ func (x *ShowFlavor) AssertFound(t *testing.T, obj *edgeproto.Flavor) {
 
 func (x *ShowFlavor) AssertNotFound(t *testing.T, obj *edgeproto.Flavor) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find Flavor %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find Flavor %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundFlavor(t *testing.T, api edgeproto.FlavorApiClient, obj *edgeproto.Flavor, count int, retry time.Duration) {
@@ -194,8 +194,8 @@ func basicFlavorShowTest(t *testing.T, api *FlavorCommonApi, testData []edgeprot
 	show.Init()
 	filterNone := edgeproto.Flavor{}
 	err = api.ShowFlavor(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -210,7 +210,7 @@ func GetFlavor(t *testing.T, api *FlavorCommonApi, key *edgeproto.FlavorKey, out
 	filter := edgeproto.Flavor{}
 	filter.Key = *key
 	err = api.ShowFlavor(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj
@@ -223,7 +223,7 @@ func basicFlavorCudTest(t *testing.T, api *FlavorCommonApi, testData []edgeproto
 	ctx := context.TODO()
 
 	if len(testData) < 3 {
-		assert.True(t, false, "Need at least 3 test data objects")
+		require.True(t, false, "Need at least 3 test data objects")
 		return
 	}
 
@@ -232,32 +232,32 @@ func basicFlavorCudTest(t *testing.T, api *FlavorCommonApi, testData []edgeproto
 
 	// test duplicate create - should fail
 	_, err = api.CreateFlavor(ctx, &testData[0])
-	assert.NotNil(t, err, "Create duplicate Flavor")
+	require.NotNil(t, err, "Create duplicate Flavor")
 
 	// test show all items
 	basicFlavorShowTest(t, api, testData)
 
 	// test delete
 	_, err = api.DeleteFlavor(ctx, &testData[0])
-	assert.Nil(t, err, "delete Flavor %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "delete Flavor %s", testData[0].Key.GetKeyString())
 	show := ShowFlavor{}
 	show.Init()
 	filterNone := edgeproto.Flavor{}
 	err = api.ShowFlavor(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData)-1, len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData)-1, len(show.Data), "Show count")
 	show.AssertNotFound(t, &testData[0])
 	// test update of missing object
 	_, err = api.UpdateFlavor(ctx, &testData[0])
-	assert.NotNil(t, err, "Update missing object")
+	require.NotNil(t, err, "Update missing object")
 	// create it back
 	_, err = api.CreateFlavor(ctx, &testData[0])
-	assert.Nil(t, err, "Create Flavor %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Create Flavor %s", testData[0].Key.GetKeyString())
 
 	// test invalid keys
 	bad := edgeproto.Flavor{}
 	_, err = api.CreateFlavor(ctx, &bad)
-	assert.NotNil(t, err, "Create Flavor with no key info")
+	require.NotNil(t, err, "Create Flavor with no key info")
 
 }
 
@@ -275,7 +275,7 @@ func createFlavorData(t *testing.T, api *FlavorCommonApi, testData []edgeproto.F
 
 	for _, obj := range testData {
 		_, err = api.CreateFlavor(ctx, &obj)
-		assert.Nil(t, err, "Create Flavor %s", obj.Key.GetKeyString())
+		require.Nil(t, err, "Create Flavor %s", obj.Key.GetKeyString())
 	}
 }
 

--- a/testutil/operator_testutil.go
+++ b/testutil/operator_testutil.go
@@ -9,7 +9,7 @@ import "io"
 import "testing"
 import "context"
 import "time"
-import "github.com/stretchr/testify/assert"
+import "github.com/stretchr/testify/require"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -62,9 +62,9 @@ func (x *ShowOperator) CheckFound(obj *edgeproto.Operator) bool {
 
 func (x *ShowOperator) AssertFound(t *testing.T, obj *edgeproto.Operator) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find Operator %s", obj.Key.GetKeyString())
+	require.True(t, found, "find Operator %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "Operator are equal")
+		require.Equal(t, *obj, check, "Operator are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -75,7 +75,7 @@ func (x *ShowOperator) AssertFound(t *testing.T, obj *edgeproto.Operator) {
 
 func (x *ShowOperator) AssertNotFound(t *testing.T, obj *edgeproto.Operator) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find Operator %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find Operator %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundOperator(t *testing.T, api edgeproto.OperatorApiClient, obj *edgeproto.Operator, count int, retry time.Duration) {
@@ -193,8 +193,8 @@ func basicOperatorShowTest(t *testing.T, api *OperatorCommonApi, testData []edge
 	show.Init()
 	filterNone := edgeproto.Operator{}
 	err = api.ShowOperator(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -209,7 +209,7 @@ func GetOperator(t *testing.T, api *OperatorCommonApi, key *edgeproto.OperatorKe
 	filter := edgeproto.Operator{}
 	filter.Key = *key
 	err = api.ShowOperator(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj
@@ -222,7 +222,7 @@ func basicOperatorCudTest(t *testing.T, api *OperatorCommonApi, testData []edgep
 	ctx := context.TODO()
 
 	if len(testData) < 3 {
-		assert.True(t, false, "Need at least 3 test data objects")
+		require.True(t, false, "Need at least 3 test data objects")
 		return
 	}
 
@@ -231,32 +231,32 @@ func basicOperatorCudTest(t *testing.T, api *OperatorCommonApi, testData []edgep
 
 	// test duplicate create - should fail
 	_, err = api.CreateOperator(ctx, &testData[0])
-	assert.NotNil(t, err, "Create duplicate Operator")
+	require.NotNil(t, err, "Create duplicate Operator")
 
 	// test show all items
 	basicOperatorShowTest(t, api, testData)
 
 	// test delete
 	_, err = api.DeleteOperator(ctx, &testData[0])
-	assert.Nil(t, err, "delete Operator %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "delete Operator %s", testData[0].Key.GetKeyString())
 	show := ShowOperator{}
 	show.Init()
 	filterNone := edgeproto.Operator{}
 	err = api.ShowOperator(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData)-1, len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData)-1, len(show.Data), "Show count")
 	show.AssertNotFound(t, &testData[0])
 	// test update of missing object
 	_, err = api.UpdateOperator(ctx, &testData[0])
-	assert.NotNil(t, err, "Update missing object")
+	require.NotNil(t, err, "Update missing object")
 	// create it back
 	_, err = api.CreateOperator(ctx, &testData[0])
-	assert.Nil(t, err, "Create Operator %s", testData[0].Key.GetKeyString())
+	require.Nil(t, err, "Create Operator %s", testData[0].Key.GetKeyString())
 
 	// test invalid keys
 	bad := edgeproto.Operator{}
 	_, err = api.CreateOperator(ctx, &bad)
-	assert.NotNil(t, err, "Create Operator with no key info")
+	require.NotNil(t, err, "Create Operator with no key info")
 
 }
 
@@ -274,7 +274,7 @@ func createOperatorData(t *testing.T, api *OperatorCommonApi, testData []edgepro
 
 	for _, obj := range testData {
 		_, err = api.CreateOperator(ctx, &obj)
-		assert.Nil(t, err, "Create Operator %s", obj.Key.GetKeyString())
+		require.Nil(t, err, "Create Operator %s", obj.Key.GetKeyString())
 	}
 }
 

--- a/testutil/refs_testutil.go
+++ b/testutil/refs_testutil.go
@@ -9,7 +9,7 @@ import "io"
 import "testing"
 import "context"
 import "time"
-import "github.com/stretchr/testify/assert"
+import "github.com/stretchr/testify/require"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
@@ -63,9 +63,9 @@ func (x *ShowCloudletRefs) CheckFound(obj *edgeproto.CloudletRefs) bool {
 
 func (x *ShowCloudletRefs) AssertFound(t *testing.T, obj *edgeproto.CloudletRefs) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find CloudletRefs %s", obj.Key.GetKeyString())
+	require.True(t, found, "find CloudletRefs %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "CloudletRefs are equal")
+		require.Equal(t, *obj, check, "CloudletRefs are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -76,7 +76,7 @@ func (x *ShowCloudletRefs) AssertFound(t *testing.T, obj *edgeproto.CloudletRefs
 
 func (x *ShowCloudletRefs) AssertNotFound(t *testing.T, obj *edgeproto.CloudletRefs) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find CloudletRefs %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find CloudletRefs %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundCloudletRefs(t *testing.T, api edgeproto.CloudletRefsApiClient, obj *edgeproto.CloudletRefs, count int, retry time.Duration) {
@@ -160,8 +160,8 @@ func basicCloudletRefsShowTest(t *testing.T, api *CloudletRefsCommonApi, testDat
 	show.Init()
 	filterNone := edgeproto.CloudletRefs{}
 	err = api.ShowCloudletRefs(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -176,7 +176,7 @@ func GetCloudletRefs(t *testing.T, api *CloudletRefsCommonApi, key *edgeproto.Cl
 	filter := edgeproto.CloudletRefs{}
 	filter.Key = *key
 	err = api.ShowCloudletRefs(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj
@@ -222,9 +222,9 @@ func (x *ShowClusterRefs) CheckFound(obj *edgeproto.ClusterRefs) bool {
 
 func (x *ShowClusterRefs) AssertFound(t *testing.T, obj *edgeproto.ClusterRefs) {
 	check, found := x.Data[obj.Key.GetKeyString()]
-	assert.True(t, found, "find ClusterRefs %s", obj.Key.GetKeyString())
+	require.True(t, found, "find ClusterRefs %s", obj.Key.GetKeyString())
 	if found && !check.Matches(obj, edgeproto.MatchIgnoreBackend(), edgeproto.MatchSortArrayedKeys()) {
-		assert.Equal(t, *obj, check, "ClusterRefs are equal")
+		require.Equal(t, *obj, check, "ClusterRefs are equal")
 	}
 	if found {
 		// remove in case there are dups in the list, so the
@@ -235,7 +235,7 @@ func (x *ShowClusterRefs) AssertFound(t *testing.T, obj *edgeproto.ClusterRefs) 
 
 func (x *ShowClusterRefs) AssertNotFound(t *testing.T, obj *edgeproto.ClusterRefs) {
 	_, found := x.Data[obj.Key.GetKeyString()]
-	assert.False(t, found, "do not find ClusterRefs %s", obj.Key.GetKeyString())
+	require.False(t, found, "do not find ClusterRefs %s", obj.Key.GetKeyString())
 }
 
 func WaitAssertFoundClusterRefs(t *testing.T, api edgeproto.ClusterRefsApiClient, obj *edgeproto.ClusterRefs, count int, retry time.Duration) {
@@ -319,8 +319,8 @@ func basicClusterRefsShowTest(t *testing.T, api *ClusterRefsCommonApi, testData 
 	show.Init()
 	filterNone := edgeproto.ClusterRefs{}
 	err = api.ShowClusterRefs(ctx, &filterNone, &show)
-	assert.Nil(t, err, "show data")
-	assert.Equal(t, len(testData), len(show.Data), "Show count")
+	require.Nil(t, err, "show data")
+	require.Equal(t, len(testData), len(show.Data), "Show count")
 	for _, obj := range testData {
 		show.AssertFound(t, &obj)
 	}
@@ -335,7 +335,7 @@ func GetClusterRefs(t *testing.T, api *ClusterRefsCommonApi, key *edgeproto.Clus
 	filter := edgeproto.ClusterRefs{}
 	filter.Key = *key
 	err = api.ShowClusterRefs(ctx, &filter, &show)
-	assert.Nil(t, err, "show data")
+	require.Nil(t, err, "show data")
 	obj, found := show.Data[key.GetKeyString()]
 	if found {
 		*out = obj


### PR DESCRIPTION
This fixes an issue with unit tests failing, and cleans up a bunch of other stuff.
- add back registering ClusterInst in dummy_notify.go, that was causing unit tests to fail
- change controller main to be more friendly to unit testing. This allows us to use "require" instead of "assert", because before if require hit a failure, TestController didn't clean up local etcd process properly.
- change most of the test "assert" calls to "require", since for long tests, it's really hard to debug a failure if we don't stop on failure.
- replace local etcd process in controller with process.Etcd. That was written before we had e2e tests, so it's redundant with process.Etcd.