### PR TITLE
make unit-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,11 @@ tools:
 doc:
 	make -C edgeproto doc
 
+UNIT_TEST_LOG = /tmp/edge-cloud-unit-test.log
+
+unit-test:
+	go test ./... > $(UNIT_TEST_LOG) || !(grep FAIL $(UNIT_TEST_LOG))
+
 test:
 	e2e-tests -testfile ./setup-env/e2e-tests/testfiles/regression_group.yml -setupfile ./setup-env/e2e-tests/setups/local_multi.yml
 

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -554,6 +554,7 @@ func StartLocal(name, bin string, args, envs []string, logfile string) (*exec.Cm
 func StopLocal(cmd *exec.Cmd) {
 	if cmd != nil {
 		cmd.Process.Kill()
+		cmd.Process.Wait()
 	}
 }
 


### PR DESCRIPTION
Make target for unit tests. Make it easy for developers to run unit-tests.

Output looks like (for failure):
```
> edge-cloud make unit-test
go test -v ./... > /tmp/edge-cloud-unit-test.log || !(grep FAIL /tmp/edge-cloud-unit-test.log)
--- FAIL: TestController (2.49s)
FAIL
FAIL	github.com/mobiledgex/edge-cloud/controller	5.366s
--- FAIL: TestNotifyBasic (2.37s)
--- FAIL: TestNotifyTree (1.12s)
FAIL
FAIL	github.com/mobiledgex/edge-cloud/notify	3.550s
make: *** [unit-test] Error 1
```

Also fixed an issue where between two unit tests that both ran etcd locally, etcd was not fully stopped by the time the second test tried to start etcd again, causing etcd to fail to start and tests to hang. So now we wait until process is gone in StopLocal.