### PR TITLE
Swagger doc jenkins build

### DIFF
--- a/jenkins/doc.Jenkinsfile
+++ b/jenkins/doc.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     options {
-        timeout(time: 5, unit: 'MINUTES')
+        timeout(time: 10, unit: 'MINUTES')
     }
     agent any
     environment {
@@ -23,6 +23,8 @@ pipeline {
                     sh label: 'make doc', script: '''#!/bin/bash
 export PATH=$PATH:$HOME/go/bin:$WORKSPACE/go/bin
 export GOPATH=$WORKSPACE/go
+export GO111MODULE=on
+go mod download
 make doc
                     '''
                 }


### PR DESCRIPTION
Jenkins job to build the edgeproto swagger spec nightly and publish it to artifactory.  This will serve as the base for a separate tool which generates a swagger API diff for the UI team.