### PR TITLE
EDGECLOUD-468: C# SDK - Parse and return more server DME errors to SDK Client.

### DIFF
--- a/edge-mvp/csharp/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/edge-mvp/csharp/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -2,17 +2,37 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Json;
 using System.Text;
 
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
-using System.Security.Authentication;
 using System.Threading.Tasks;
 using System.Runtime.Serialization.Json;
 
 
 namespace DistributedMatchEngine
 {
+
+  public class HttpException : Exception
+  {
+    public HttpStatusCode HttpStatusCode { get; set; }
+    public int ErrorCode { get; set; }
+    public HttpException(string message, HttpStatusCode statusCode, int errorCode)
+        : base(message)
+    {
+      this.HttpStatusCode = statusCode;
+      this.ErrorCode = errorCode;
+    }
+
+    public HttpException(string message, HttpStatusCode statusCode, int errorCode, Exception innerException)
+        : base(message, innerException)
+    {
+      this.HttpStatusCode = statusCode;
+      this.ErrorCode = errorCode;
+    }
+  }
+
   public class TokenException : Exception
   {
     public TokenException(string message)
@@ -27,7 +47,8 @@ namespace DistributedMatchEngine
   }
 
   // Minimal logger without log levels:
-  static class Log {
+  static class Log
+  {
     // Stdout:
     public static void S(string msg)
     {
@@ -69,10 +90,6 @@ namespace DistributedMatchEngine
     private string dynamiclocgroupAPI = "/v1/dynamiclocgroup";
     private string getfqdnlistAPI = "/v1/getfqdnlist";
 
-    UInt32 timeoutSec = 5000;
-    string appName;
-    string devName;
-
     public string sessionCookie { get; set; }
     string tokenServerURI;
     string authToken { get; set; }
@@ -113,7 +130,7 @@ namespace DistributedMatchEngine
       return carrierNameDefault;
     }
 
-    string generateDmeHostPath(string carrierName)
+    string GenerateDmeHostPath(string carrierName)
     {
       if (carrierName == null || carrierName == "")
       {
@@ -124,7 +141,7 @@ namespace DistributedMatchEngine
 
     public string GenerateDmeBaseUri(string carrierName, UInt32 port = defaultDmeRestPort)
     {
-      return "https://" + generateDmeHostPath(carrierName) + ":" + port;
+      return "https://" + GenerateDmeHostPath(carrierName) + ":" + port;
     }
 
     public string CreateUri(string host, UInt32 port)
@@ -139,7 +156,7 @@ namespace DistributedMatchEngine
     /*
      * This is temporary, and must be updated later.
      */
-    private bool setCredentials(string caCert, string clientCert, string clientPrivKey)
+    private bool SetCredentials(string caCert, string clientCert, string clientPrivKey)
     {
       return false;
     }
@@ -153,13 +170,51 @@ namespace DistributedMatchEngine
       Log.D("Post Body: " + jsonStr);
       var response = await httpClient.PostAsync(uri, stringContent);
 
-      response.EnsureSuccessStatusCode();
 
+      if (response == null)
+      {
+        throw new Exception("Null http response object!");
+      }
+
+      if (response.StatusCode != HttpStatusCode.OK)
+      {
+        string responseBodyStr = response.Content.ReadAsStringAsync().Result;
+        JsonObject jsObj = (JsonObject)JsonValue.Parse(responseBodyStr);
+        string extendedErrorStr;
+        int errorCode;
+        if (jsObj.ContainsKey("message") && jsObj.ContainsKey("code"))
+        {
+          extendedErrorStr = jsObj["message"];
+          try
+          {
+            errorCode = jsObj["code"];
+          }
+          catch (FormatException)
+          {
+            errorCode = -1; // Bad code number format
+          }
+          throw new HttpException(extendedErrorStr, response.StatusCode, errorCode);
+        }
+        else
+        {
+          // Unknown error message format, throw exception with inner:
+          try
+          {
+            response.EnsureSuccessStatusCode();
+          }
+          catch (Exception e)
+          {
+            throw new HttpException(e.Message, response.StatusCode, -1, e);
+          }
+        }
+      }
+
+      // Normal path:
       Stream replyStream = await response.Content.ReadAsStreamAsync();
       return replyStream;
     }
 
-    private static String parseToken(String uri)
+    private static String ParseToken(String uri)
     {
       string[] uriandparams = uri.Split('?');
       if (uriandparams.Length < 1)
@@ -235,7 +290,7 @@ namespace DistributedMatchEngine
       if (uriLocation != null)
       {
         Log.D("uriLocation: " + uriLocation);
-        token = parseToken(uriLocation);
+        token = ParseToken(uriLocation);
       }
 
       if (token == null)

--- a/edge-mvp/csharp/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/edge-mvp/csharp/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>1.3.8</ReleaseVersion>
+    <ReleaseVersion>1.3.8.1</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.3.8</PackageVersion>
+    <PackageVersion>1.3.8.1</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineRestSDKLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>1.3.8</AssemblyVersion>
-    <FileVersion>1.3.8</FileVersion>
+    <AssemblyVersion>1.3.8.1</AssemblyVersion>
+    <FileVersion>1.3.8.1</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 

--- a/edge-mvp/csharp/rest/RestSample/RestSample.cs
+++ b/edge-mvp/csharp/rest/RestSample/RestSample.cs
@@ -46,9 +46,10 @@ namespace RestSample
           var registerClientReply = await me.RegisterClient(host, port, registerClientRequest);
           Console.WriteLine("RegisterClient Reply Status: " + registerClientReply.Status);
         }
-        catch (System.Net.WebException we) // REST HTTP call error codes.
+        catch (HttpException httpe) // HTTP status, and REST API call error codes.
         {
-          Console.WriteLine("RegisterClient Exception: " + we.Message + "\nStack: " + we.StackTrace);
+          // server error code, and human readable message:
+          Console.WriteLine("RegisterClient Exception: " + httpe.Message + ", HTTP StatusCode: " + httpe.HttpStatusCode + ", API ErrorCode: " + httpe.ErrorCode + "\nStack: " + httpe.StackTrace);
         }
         // Do Verify and FindCloudlet in concurrent tasks:
         var loc = await locTask;
@@ -82,9 +83,9 @@ namespace RestSample
                   ", path_prefix: " + p.path_prefix);
           }
         }
-        catch (System.Net.WebException we)
+        catch (HttpException httpe)
         {
-          Console.WriteLine("FindCloudlet Exception: " + we.Message + "\nStack: " + we.StackTrace);
+          Console.WriteLine("FindCloudlet Exception: " + httpe.Message + ", HTTP StatusCode: " + httpe.HttpStatusCode + ", API ErrorCode: " + httpe.ErrorCode + "\nStack: " + httpe.StackTrace);
         }
 
         // Get Location:
@@ -94,9 +95,9 @@ namespace RestSample
           var location = getLocationReply.NetworkLocation;
           Console.WriteLine("GetLocationReply: longitude: " + location.longitude + ", latitude: " + location.latitude);
         }
-        catch (System.Net.WebException we)
+        catch (HttpException httpe)
         {
-          Console.WriteLine("GetLocation Exception: " + we.Message + "\nStack: " + we.StackTrace);
+          Console.WriteLine("GetLocation Exception: " + httpe.Message + ", HTTP StatusCode: " + httpe.HttpStatusCode + ", API ErrorCode: " + httpe.ErrorCode + "\nStack: " + httpe.StackTrace);
         }
 
         // Verify Location:
@@ -106,9 +107,9 @@ namespace RestSample
           var verifyLocationReply = await me.VerifyLocation(host, port, verifyLocationRequest);
           Console.WriteLine("VerifyLocation Reply: " + verifyLocationReply.gps_location_status);
         }
-        catch (System.Net.WebException we)
+        catch (HttpException httpe)
         {
-          Console.WriteLine("VerifyLocation Exception: " + we.Message + "\nStack: " + we.StackTrace);
+          Console.WriteLine("VerifyLocation Exception: " + httpe.Message + ", HTTP StatusCode: " + httpe.HttpStatusCode + ", API ErrorCode: " + httpe.ErrorCode + "\nStack: " + httpe.StackTrace);
         }
         catch (InvalidTokenServerTokenException itste)
         {

--- a/edge-mvp/csharp/rest/RestSample/RestSample.csproj
+++ b/edge-mvp/csharp/rest/RestSample/RestSample.csproj
@@ -4,9 +4,9 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>1.3.7</ReleaseVersion>
+    <ReleaseVersion>1.3.8.1</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.3.8" />
+    <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.3.8.1" />
   </ItemGroup>
 </Project>

--- a/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Json;
 using System.Text;
 
 using System.Net.Http;
@@ -12,6 +13,26 @@ using System.Threading.Tasks;
 
 namespace DistributedMatchEngine
 {
+
+  public class HttpException : Exception
+  {
+    public WebExceptionStatus WebExceptionStatus { get; set; }
+    public int ErrorCode { get; set; }
+    public HttpException(string message, WebExceptionStatus statusCode, int errorCode)
+        : base(message)
+    {
+      this.WebExceptionStatus = statusCode;
+      this.ErrorCode = errorCode;
+    }
+
+    public HttpException(string message, WebExceptionStatus statusCode, int errorCode, Exception innerException)
+        : base(message, innerException)
+    {
+      this.WebExceptionStatus = statusCode;
+      this.ErrorCode = errorCode;
+    }
+  }
+
   public class TokenException : Exception
   {
     public TokenException(string message)
@@ -66,11 +87,6 @@ namespace DistributedMatchEngine
     private string dynamiclocgroupAPI = "/v1/dynamiclocgroup";
     private string getfqdnlistAPI = "/v1/getfqdnlist";
 
-    UInt32 timeoutSec = 5000;
-    string appName;
-    string devName;
-    string appVersionStr = "1.0";
-
     public string sessionCookie { get; set; }
     string tokenServerURI;
     string authToken { get; set; }
@@ -79,7 +95,7 @@ namespace DistributedMatchEngine
     {
     }
 
-    private HttpWebRequest createWebRequest(string uri)
+    private HttpWebRequest CreateWebRequest(string uri)
     {
       HttpWebRequest httpWebRequest = (HttpWebRequest)WebRequest.Create(uri);
       // FIXME: This should not be here.
@@ -107,12 +123,12 @@ namespace DistributedMatchEngine
       return httpWebRequest;
     }
 
-    public string getCarrierName()
+    public string GetCarrierName()
     {
       return carrierNameDefault;
     }
 
-    string generateDmeHostPath(string carrierName)
+    string GenerateDmeHostPath(string carrierName)
     {
       if (carrierName == null || carrierName == "")
       {
@@ -123,7 +139,7 @@ namespace DistributedMatchEngine
 
     public string GenerateDmeBaseUri(string carrierName, UInt32 port = defaultDmeRestPort)
     {
-      return "https://" + generateDmeHostPath(carrierName) + ":" + port;
+      return "https://" + GenerateDmeHostPath(carrierName) + ":" + port;
     }
 
     public string CreateUri(string host, UInt32 port)
@@ -136,7 +152,7 @@ namespace DistributedMatchEngine
     }
 
     /*
-     * This is temporary, and must be updated later.   
+     * This is temporary, and must be updated later.
      */
     private bool SetCredentials(string caCert, string clientCert, string clientPrivKey)
     {
@@ -147,7 +163,7 @@ namespace DistributedMatchEngine
     {
       return await Task.Run(() =>
       {
-        var webRequest = createWebRequest(uri);
+        var webRequest = CreateWebRequest(uri);
         // Choose network TBD (async)
 
         webRequest.Method = "POST";
@@ -163,12 +179,28 @@ namespace DistributedMatchEngine
           }
         }
 
-        Stream replyStream = webRequest.GetResponse().GetResponseStream();
+        // try to get extended server repsonse if there's an error:
+        HttpWebResponse response;
+
+        try
+        {
+          response = (HttpWebResponse)webRequest.GetResponse();
+        }
+        catch (WebException we)
+        {
+          // ContentLength is -1?
+          Log.D("Exception: " + we.Message);
+
+          throw new HttpException(we.Message, we.Status, -1);
+        }
+
+        // Normal:
+        Stream replyStream = response.GetResponseStream();
         return replyStream;
       });
     }
 
-    private static String parseToken(String uri)
+    private static String ParseToken(String uri)
     {
       string[] uriandparams = uri.Split('?');
       if (uriandparams.Length < 1)
@@ -244,7 +276,7 @@ namespace DistributedMatchEngine
       if (uriLocation != null)
       {
         Log.D("uriLocation: " + uriLocation);
-        token = parseToken(uriLocation);
+        token = ParseToken(uriLocation);
       }
 
       if (token == null)
@@ -257,13 +289,15 @@ namespace DistributedMatchEngine
 
     public RegisterClientRequest CreateRegisterClientRequest(string carrierName, string developerName, string appName, string appVersion, string authToken)
     {
-      return new RegisterClientRequest {
+      return new RegisterClientRequest
+      {
         Ver = 1,
         CarrierName = carrierName,
+        DevName = developerName,
         AppName = appName,
-        AuthToken = authToken,
-        AppVers = appVersionStr,
-        DevName = developerName };
+        AppVers = appVersion,
+        AuthToken = authToken
+      };
     }
 
     public async Task<RegisterClientReply> RegisterClient(string host, uint port, RegisterClientRequest request)
@@ -317,7 +351,7 @@ namespace DistributedMatchEngine
         return null;
       }
 
-      DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(FindCloudletReply));      
+      DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(FindCloudletReply));
       FindCloudletReply reply = (FindCloudletReply)deserializer.ReadObject(responseStream);
       return reply;
     }

--- a/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>1.3.8</ReleaseVersion>
+    <ReleaseVersion>1.3.8.1</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.3.8</PackageVersion>
+    <PackageVersion>1.3.8.1</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Library for Unity</Description>
     <Owners>MobiledgeX, Inc.</Owners>

--- a/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.cs
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.cs
@@ -44,11 +44,12 @@ namespace RestSample
         try
         {
           var registerClientReply = await me.RegisterClient(host, port, registerClientRequest);
-          Console.WriteLine("Reply: Session Cookie: " + registerClientReply.SessionCookie + ", Status: " + registerClientReply.Status);
+          Console.WriteLine("RegisterClient Reply Status: " + registerClientReply.Status);
         }
-        catch (System.Net.WebException we) // REST HTTP call error codes.
+        catch (HttpException httpe) // HTTP status, and REST API call error codes.
         {
-          Console.WriteLine("RegisterClient Exception: " + we.Message + "\nStack: " + we.StackTrace);
+          // server error code, and human readable message:
+          Console.WriteLine("RegisterClient Exception: " + httpe.Message + ", WebException StatusCode: " + httpe.WebExceptionStatus + ", API ErrorCode: " + httpe.ErrorCode + "\nStack: " + httpe.StackTrace);
         }
         // Do Verify and FindCloudlet in concurrent tasks:
         var loc = await locTask;
@@ -82,9 +83,9 @@ namespace RestSample
                   ", path_prefix: " + p.path_prefix);
           }
         }
-        catch (System.Net.WebException we)
+        catch (HttpException httpe)
         {
-          Console.WriteLine("FindCloudlet Exception: " + we.Message + "\nStack: " + we.StackTrace);
+          Console.WriteLine("FindCloudlet Exception: " + httpe.Message + ", WebException StatusCode: " + httpe.WebExceptionStatus + ", API ErrorCode: " + httpe.ErrorCode + "\nStack: " + httpe.StackTrace);
         }
 
         // Get Location:
@@ -94,9 +95,9 @@ namespace RestSample
           var location = getLocationReply.NetworkLocation;
           Console.WriteLine("GetLocationReply: longitude: " + location.longitude + ", latitude: " + location.latitude);
         }
-        catch (System.Net.WebException we)
+        catch (HttpException httpe)
         {
-          Console.WriteLine("GetLocation Exception: " + we.Message + "\nStack: " + we.StackTrace);
+          Console.WriteLine("GetLocation Exception: " + httpe.Message + ", WebException StatusCode: " + httpe.WebExceptionStatus + ", API ErrorCode: " + httpe.ErrorCode + "\nStack: " + httpe.StackTrace);
         }
 
         // Verify Location:
@@ -106,9 +107,9 @@ namespace RestSample
           var verifyLocationReply = await me.VerifyLocation(host, port, verifyLocationRequest);
           Console.WriteLine("VerifyLocation Reply: " + verifyLocationReply.gps_location_status);
         }
-        catch (System.Net.WebException we)
+        catch (HttpException httpe)
         {
-          Console.WriteLine("VerifyLocation Exception: " + we.Message + "\nStack: " + we.StackTrace);
+          Console.WriteLine("VerifyLocation Exception: " + httpe.Message + ", WebException StatusCode: " + httpe.WebExceptionStatus + ", API ErrorCode: " + httpe.ErrorCode + "\nStack: " + httpe.StackTrace);
         }
         catch (InvalidTokenServerTokenException itste)
         {

--- a/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.csproj
+++ b/edge-mvp/unity/MatchingEngineSDK/rest/RestSample/RestSample.csproj
@@ -4,10 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>1.3.8</ReleaseVersion>
+    <ReleaseVersion>1.3.8.1</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineUnityRestSDKLibrary" Version="1.3.8" />
+    <PackageReference Include="MobiledgeX.MatchingEngineUnityRestSDKLibrary" Version="1.3.8.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Attaching interested parties. Mainly, grab as much info as possible from the server to create the exception.

The API did technically "change" if an HTTP error shows up.

Unity/Mono is severely limited due to requiring (HTTP)WebRequest, which throws exceptions, but (traigically?) swallows the entire server response (ContentLength = -1). HttpWebRequest is not recommended for new applications in normal C# land. Unity 2019.1.f02.

Regular C# has the full server error message since it uses the recommended HttpClient, parses via the .Net standard System.Json API, and is now returned via DistributedMatchEngine.HttpException.

Misc formatting and IDE/lint warning fixes.
