### PR TITLE
allow target package name override for protoc generators

### DIFF
--- a/gensupport/support.go
+++ b/gensupport/support.go
@@ -401,6 +401,8 @@ func RunMain(pkg, fileSuffix string, p generator.Plugin, support *PluginSupport)
 			switch kv[0] {
 			case "suffix":
 				fileSuffix = kv[1]
+			case "pkg":
+				pkg = kv[1]
 			}
 		}
 	}


### PR DESCRIPTION
This allows the protoc plugin generator to override the target package name. I'm using this in infra where the same plugin generator (protoc-gen-mc2) will be used to generate several different package files for api/client/test/etc.