### PR TITLE
enum decode hook for map structure

### DIFF
--- a/d-match-engine/dme-proto/app-client.pb.go
+++ b/d-match-engine/dme-proto/app-client.pb.go
@@ -48,6 +48,7 @@ import binary "encoding/binary"
 
 import "errors"
 import "strconv"
+import reflect "reflect"
 
 import io "io"
 
@@ -2552,6 +2553,30 @@ func applyMatchOptions(opts *MatchOptions, args ...MatchOpt) {
 	for _, f := range args {
 		f(opts)
 	}
+}
+
+// DecodeHook for use with the mapstructure package.
+// Allows decoding to handle protobuf enums that are
+// represented as strings.
+func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
+	if from.Kind() != reflect.String {
+		return data, nil
+	}
+	switch to {
+	case reflect.TypeOf(LProto(0)):
+		if en, ok := LProto_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(IDTypes(0)):
+		if en, ok := IDTypes_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(ReplyStatus(0)):
+		if en, ok := ReplyStatus_value[data.(string)]; ok {
+			return en, nil
+		}
+	}
+	return data, nil
 }
 
 func (m *RegisterClientRequest) Size() (n int) {

--- a/edgeproto/app.pb.go
+++ b/edgeproto/app.pb.go
@@ -1701,6 +1701,62 @@ func applyMatchOptions(opts *MatchOptions, args ...MatchOpt) {
 	}
 }
 
+// DecodeHook for use with the mapstructure package.
+// Allows decoding to handle protobuf enums that are
+// represented as strings.
+func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
+	if from.Kind() != reflect.String {
+		return data, nil
+	}
+	switch to {
+	case reflect.TypeOf(ImageType(0)):
+		if en, ok := ImageType_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(DeleteType(0)):
+		if en, ok := DeleteType_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(Liveness(0)):
+		if en, ok := Liveness_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(IpSupport(0)):
+		if en, ok := IpSupport_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(IpAccess(0)):
+		if en, ok := IpAccess_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(TrackedState(0)):
+		if en, ok := TrackedState_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(CRMOverride(0)):
+		if en, ok := CRMOverride_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(CloudletState(0)):
+		if en, ok := CloudletState_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(NodeType(0)):
+		if en, ok := NodeType_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(NoticeAction(0)):
+		if en, ok := NoticeAction_value[data.(string)]; ok {
+			return en, nil
+		}
+	case reflect.TypeOf(VersionHash(0)):
+		if en, ok := VersionHash_value[data.(string)]; ok {
+			return en, nil
+		}
+	}
+	return data, nil
+}
+
 func (m *AppKey) Size() (n int) {
 	var l int
 	_ = l

--- a/log/debug.pb.go
+++ b/log/debug.pb.go
@@ -22,6 +22,7 @@ import grpc "google.golang.org/grpc"
 
 import "errors"
 import "strconv"
+import reflect "reflect"
 
 import io "io"
 
@@ -426,6 +427,22 @@ func applyMatchOptions(opts *MatchOptions, args ...MatchOpt) {
 	for _, f := range args {
 		f(opts)
 	}
+}
+
+// DecodeHook for use with the mapstructure package.
+// Allows decoding to handle protobuf enums that are
+// represented as strings.
+func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
+	if from.Kind() != reflect.String {
+		return data, nil
+	}
+	switch to {
+	case reflect.TypeOf(DebugLevel(0)):
+		if en, ok := DebugLevel_value[data.(string)]; ok {
+			return en, nil
+		}
+	}
+	return data, nil
 }
 
 func (m *DebugLevels) Size() (n int) {

--- a/testgen/sample.pb.go
+++ b/testgen/sample.pb.go
@@ -29,6 +29,7 @@ import binary "encoding/binary"
 
 import "errors"
 import "strconv"
+import reflect "reflect"
 
 import io "io"
 
@@ -2362,6 +2363,22 @@ func applyMatchOptions(opts *MatchOptions, args ...MatchOpt) {
 	for _, f := range args {
 		f(opts)
 	}
+}
+
+// DecodeHook for use with the mapstructure package.
+// Allows decoding to handle protobuf enums that are
+// represented as strings.
+func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
+	if from.Kind() != reflect.String {
+		return data, nil
+	}
+	switch to {
+	case reflect.TypeOf(OuterEnum(0)):
+		if en, ok := OuterEnum_value[data.(string)]; ok {
+			return en, nil
+		}
+	}
+	return data, nil
 }
 
 func (m *NestedMessage) Size() (n int) {


### PR DESCRIPTION
This generates a decode hook function used by mapstructure when converting a generic map[string]interface{} to a concrete struct like edgeproto.AppInst{}. The hook function knows how to convert protobuf enums that are represented by strings. For example, IpSupport can be either int(2), or string "IpSupportDynamic".

Take a look at EnumDecodeHook in the auto-generated files.

This will be used by argument parsing for master controller cli.