### PR TITLE
Issue EDGECLOUD-657

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -236,6 +236,13 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			in.Key.ClusterInstKey.Developer = in.Key.AppKey.DeveloperKey.Name
 		}
 	}
+	if in.Key.AppKey.DeveloperKey.Name == "" {
+		// we still allow this to deal with existing clusters, but eventually will be disallowed
+		log.DebugLog(log.DebugLevelApi, "Notice: empty appinst developer name is deprecated")
+	} else if in.Key.AppKey.DeveloperKey.Name != cloudcommon.DeveloperMobiledgeX &&
+		in.Key.AppKey.DeveloperKey.Name != in.Key.ClusterInstKey.Developer {
+		return fmt.Errorf("Developer name mismatch between app: %s and cluster inst: %s", in.Key.AppKey.DeveloperKey.Name, in.Key.ClusterInstKey.Developer)
+	}
 
 	if !defaultCloudlet {
 		err := s.sync.ApplySTMWait(func(stm concurrency.STM) error {

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -114,6 +114,18 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 			return err
 		}
 	}
+	if in.Key.Developer == "" {
+		return fmt.Errorf("Developer cannot be empty")
+	}
+	if in.Key.CloudletKey.Name == "" {
+		return fmt.Errorf("Cloudlet name cannot be empty")
+	}
+	if in.Key.CloudletKey.OperatorKey.Name == "" {
+		return fmt.Errorf("Operator name cannot be empty")
+	}
+	if in.Key.ClusterKey.Name == "" {
+		return fmt.Errorf("Cluster name cannot be empty")
+	}
 	if in.IpAccess == edgeproto.IpAccess_IpAccessUnknown {
 		// default to shared
 		in.IpAccess = edgeproto.IpAccess_IpAccessShared

--- a/setup-env/e2e-tests/data/appdata.yml
+++ b/setup-env/e2e-tests/data/appdata.yml
@@ -29,6 +29,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-1
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -43,6 +44,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-2
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -182,6 +184,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -201,6 +204,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95
@@ -220,6 +224,7 @@ appinstances:
         operatorkey:
           name: developer
         name: default
+      developer: AcmeAppCo
   liveness: LivenessStatic
   uri: someapp1.acmeappco.com
   flavor:
@@ -237,6 +242,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -256,6 +262,7 @@ appinstances:
         operatorkey:
           name: developer
         name: default
+      developer: Samsung
   liveness: LivenessStatic
   uri: default.samsungenablement.samsung.com
   flavor:

--- a/setup-env/e2e-tests/data/appdata_2.yml
+++ b/setup-env/e2e-tests/data/appdata_2.yml
@@ -12,6 +12,12 @@ flavors:
   ram: 2048
   vcpus: 2
   disk: 2
+- key:
+    name: x1.medium
+  ram: 4096
+  vcpus: 4
+  disk: 4
+
 
 
 operators:

--- a/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
+++ b/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
@@ -30,6 +30,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-1
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -43,6 +44,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-2
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -262,6 +264,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 40
     longitude: -99
@@ -282,6 +285,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95
@@ -302,6 +306,7 @@ appinstances:
         operatorkey:
           name: developer
         name: default
+      developer: AcmeAppCo
   uri: someapp1.acmeappco.com
   liveness: LivenessStatic
   flavor:
@@ -319,6 +324,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 40
     longitude: -99
@@ -339,6 +345,7 @@ appinstances:
         operatorkey:
           name: developer
         name: default
+      developer: Samsung
   uri: default.samsungenablement.samsung.com
   liveness: LivenessStatic
   flavor:
@@ -356,6 +363,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 40
     longitude: -99
@@ -376,6 +384,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95
@@ -396,6 +405,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95
@@ -416,6 +426,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 40
     longitude: -99

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
@@ -29,6 +29,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-1
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -153,6 +154,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -173,6 +175,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1.yml
@@ -29,6 +29,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-1
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -89,6 +90,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
@@ -41,6 +41,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-1
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -146,6 +147,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -165,6 +167,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -185,6 +188,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91

--- a/setup-env/e2e-tests/data/appdata_dind.yml
+++ b/setup-env/e2e-tests/data/appdata_dind.yml
@@ -41,6 +41,7 @@ clusterinsts:
       operatorkey:
         name: mexdev
       name: localtest
+    developer: MobiledgeX
   flavor:
     name: x1.medium
   liveness: LivenessStatic
@@ -109,6 +110,7 @@ appinstances:
         operatorkey:
           name: mexdev
         name: localtest
+      developer: MobiledgeX
 - key:
     appkey:
       developerkey:
@@ -122,3 +124,4 @@ appinstances:
         operatorkey:
           name: mexdev
         name: localtest
+      developer: MobiledgeX

--- a/setup-env/e2e-tests/data/appdata_no_appinst.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst.yml
@@ -30,6 +30,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-1
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -44,6 +45,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-2
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic

--- a/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
@@ -30,6 +30,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-1
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -43,6 +44,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-2
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -232,6 +234,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -252,6 +255,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95
@@ -272,6 +276,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -292,6 +297,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95

--- a/setup-env/e2e-tests/data/appdata_no_cluster.yml
+++ b/setup-env/e2e-tests/data/appdata_no_cluster.yml
@@ -76,6 +76,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -95,6 +96,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95

--- a/setup-env/e2e-tests/data/appdata_show.yml
+++ b/setup-env/e2e-tests/data/appdata_show.yml
@@ -29,6 +29,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-1
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -42,6 +43,7 @@ clusterinsts:
       operatorkey:
         name: tmus
       name: tmus-cloud-2
+    developer: AcmeAppCo
   flavor:
     name: x1.small
   liveness: LivenessStatic
@@ -261,6 +263,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -281,6 +284,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -301,6 +305,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95
@@ -321,6 +326,7 @@ appinstances:
         operatorkey:
           name: developer
         name: default
+      developer: AcmeAppCo
   uri: someapp1.acmeappco.com
   liveness: LivenessStatic
   flavor:
@@ -338,6 +344,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95
@@ -358,6 +365,7 @@ appinstances:
         operatorkey:
           name: developer
         name: default
+      developer: Samsung
   uri: default.samsungenablement.samsung.com
   liveness: LivenessStatic
   flavor:
@@ -375,6 +383,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91
@@ -395,6 +404,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 35
     longitude: -95
@@ -415,6 +425,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91

--- a/setup-env/e2e-tests/data/appinst1.yml
+++ b/setup-env/e2e-tests/data/appinst1.yml
@@ -12,6 +12,7 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-1
+      developer: AcmeAppCo
   cloudletloc:
     latitude: 31
     longitude: -91

--- a/setup-env/e2e-tests/data/appinst2.yml
+++ b/setup-env/e2e-tests/data/appinst2.yml
@@ -12,3 +12,4 @@ appinstances:
         operatorkey:
           name: tmus
         name: tmus-cloud-2
+      developer: AcmeAppCo

--- a/setup-env/e2e-tests/data/show10.yml
+++ b/setup-env/e2e-tests/data/show10.yml
@@ -574,6 +574,7 @@ appinstances:
         operatorkey:
           name: developer
         name: default
+      developer: Samsung
   uri: default.samsungenablement.samsung.com
   liveness: LivenessStatic
   flavor:
@@ -696,6 +697,7 @@ appinstances:
         operatorkey:
           name: developer
         name: default
+      developer: AcmeAppCo
   uri: default.someapplication1.AcmeAppCo.com
   liveness: LivenessStatic
   flavor:
@@ -839,6 +841,7 @@ appinstances:
         operatorkey:
           name: developer
         name: default
+      developer: AcmeAppCo
   uri: default.someapplication2.AcmeAppCo.com
   liveness: LivenessStatic
   flavor:

--- a/setup-env/e2e-tests/data/show2.yml
+++ b/setup-env/e2e-tests/data/show2.yml
@@ -9,6 +9,11 @@ flavors:
   ram: 2048
   vcpus: 2
   disk: 2
+- key:
+    name: x1.medium
+  ram: 4096
+  vcpus: 4
+  disk: 4
 
 clusters:
 
@@ -64,16 +69,6 @@ cloudlets:
 - key:
     operatorkey:
       name: tmus
-    name: tmus-cloud-1
-  accessuri: tmus-cloud.1
-  location:
-    latitude: 1
-    longitude: 1
-  ipsupport: IpSupportDynamic
-  numdynamicips: 254
-- key:
-    operatorkey:
-      name: tmus
     name: tmus-cloud-2
   accessuri: tmus-cloud.2
   location:
@@ -81,8 +76,82 @@ cloudlets:
     longitude: 2
   ipsupport: IpSupportDynamic
   numdynamicips: 254
+- key:
+    operatorkey:
+      name: tmus
+    name: tmus-cloud-1
+  accessuri: tmus-cloud.1
+  location:
+    latitude: 1
+    longitude: 1
+  ipsupport: IpSupportDynamic
+  numdynamicips: 254
 
 apps:
+- key:
+    developerkey:
+      name: MobiledgeX
+    name: MEXPrometheusAppName
+    version: "1.0"
+  imagepath: stable/prometheus-operator
+  defaultflavor:
+    name: x1.medium
+  deployment: helm
+  configs:
+  - kind: hemlCustomizationYaml
+    config: |
+      prometheus:
+        prometheusSpec:
+          scrapeInterval: "15s"
+        service:
+          type: LoadBalancer
+      kubelet:
+        serviceMonitor:
+          ## Enable scraping the kubelet over https. For requirements to enable this see
+          ## https://github.com/coreos/prometheus-operator/issues/926
+          ##
+          https: true
+- key:
+    developerkey:
+      name: MobiledgeX
+    name: MEXMetricsExporter
+    version: "1.0"
+  imagepath: docker.mobiledgex.net/mobiledgex/images/metrics-exporter:latest
+  imagetype: ImageTypeDocker
+  defaultflavor:
+    name: x1.medium
+  deployment: kubernetes
+  configs:
+  - kind: envVarsYaml
+    config: |
+      - name: MEX_INFLUXDB_ADDR
+        value: 0.0.0.0:8086
+      - name: MEX_INFLUXDB_USER
+        value: root
+      - name: MEX_INFLUXDB_PASS
+        value: root
+      - name: MEX_SCRAPE_INTERVAL
+        value: 15s
+  - kind: envVarsYaml
+    config: |
+      - name: MEX_CLUSTER_NAME
+        valueFrom:
+          configMapKeyRef:
+            name: mexcluster-info
+            key: ClusterName
+            optional: true
+      - name: MEX_CLOUDLET_NAME
+        valueFrom:
+          configMapKeyRef:
+            name: mexcluster-info
+            key: CloudletName
+            optional: true
+      - name: MEX_OPERATOR_NAME
+        valueFrom:
+          configMapKeyRef:
+            name: mexcluster-info
+            key: OperatorName
+            optional: true
 - key:
     developerkey:
       name: AcmeAppCo
@@ -114,6 +183,45 @@ appinstances:
       version: "1.0"
     clusterinstkey:
       clusterkey:
+        name: default
+      cloudletkey:
+        operatorkey:
+          name: developer
+        name: default
+      developer: AcmeAppCo
+  uri: default.someapplication1.AcmeAppCo.com
+  liveness: LivenessStatic
+  flavor:
+    name: x1.small
+- key:
+    appkey:
+      developerkey:
+        name: MobiledgeX
+      name: MEXMetricsExporter
+      version: "1.0"
+    clusterinstkey:
+      clusterkey:
+        name: autoclustersomeapplication1
+      cloudletkey:
+        operatorkey:
+          name: tmus
+        name: tmus-cloud-2
+      developer: AcmeAppCo
+  cloudletloc:
+    latitude: 1
+    longitude: 2
+  uri: tmus-cloud-2.tmus.mobiledgex.net
+  liveness: LivenessStatic
+  flavor:
+    name: x1.medium
+- key:
+    appkey:
+      developerkey:
+        name: AcmeAppCo
+      name: someapplication1
+      version: "1.0"
+    clusterinstkey:
+      clusterkey:
         name: autoclustersomeapplication1
       cloudletkey:
         operatorkey:
@@ -127,6 +235,27 @@ appinstances:
   liveness: LivenessStatic
   flavor:
     name: x1.small
+- key:
+    appkey:
+      developerkey:
+        name: MobiledgeX
+      name: MEXMetricsExporter
+      version: "1.0"
+    clusterinstkey:
+      clusterkey:
+        name: autoclustersomeapplication1
+      cloudletkey:
+        operatorkey:
+          name: tmus
+        name: tmus-cloud-1
+      developer: AcmeAppCo
+  cloudletloc:
+    latitude: 1
+    longitude: 1
+  uri: tmus-cloud-1.tmus.mobiledgex.net
+  liveness: LivenessStatic
+  flavor:
+    name: x1.medium
 - key:
     appkey:
       developerkey:
@@ -151,18 +280,43 @@ appinstances:
 - key:
     appkey:
       developerkey:
-        name: AcmeAppCo
-      name: someapplication1
+        name: MobiledgeX
+      name: MEXPrometheusAppName
       version: "1.0"
     clusterinstkey:
       clusterkey:
-        name: default
+        name: autoclustersomeapplication1
       cloudletkey:
         operatorkey:
-          name: developer
-        name: default
-  uri: default.someapplication1.AcmeAppCo.com
+          name: tmus
+        name: tmus-cloud-2
+      developer: AcmeAppCo
+  cloudletloc:
+    latitude: 1
+    longitude: 2
+  uri: tmus-cloud-2.tmus.mobiledgex.net
   liveness: LivenessStatic
   flavor:
-    name: x1.small
+    name: x1.medium
+- key:
+    appkey:
+      developerkey:
+        name: MobiledgeX
+      name: MEXPrometheusAppName
+      version: "1.0"
+    clusterinstkey:
+      clusterkey:
+        name: autoclustersomeapplication1
+      cloudletkey:
+        operatorkey:
+          name: tmus
+        name: tmus-cloud-1
+      developer: AcmeAppCo
+  cloudletloc:
+    latitude: 1
+    longitude: 1
+  uri: tmus-cloud-1.tmus.mobiledgex.net
+  liveness: LivenessStatic
+  flavor:
+    name: x1.medium
 

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -256,6 +256,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey:  ClusterData[0].Key,
 			CloudletKey: CloudletData[0].Key,
+			Developer:   DevData[0].Key.Name,
 		},
 		Flavor:     FlavorData[0].Key,
 		IpAccess:   edgeproto.IpAccess_IpAccessDedicated,
@@ -267,6 +268,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey:  ClusterData[0].Key,
 			CloudletKey: CloudletData[1].Key,
+			Developer:   DevData[0].Key.Name,
 		},
 		Flavor:     FlavorData[0].Key,
 		IpAccess:   edgeproto.IpAccess_IpAccessShared,
@@ -278,6 +280,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey:  ClusterData[0].Key,
 			CloudletKey: CloudletData[2].Key,
+			Developer:   DevData[3].Key.Name,
 		},
 		Flavor:     FlavorData[0].Key,
 		IpAccess:   edgeproto.IpAccess_IpAccessDedicatedOrShared,
@@ -289,6 +292,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey:  ClusterData[1].Key,
 			CloudletKey: CloudletData[0].Key,
+			Developer:   DevData[0].Key.Name,
 		},
 		Flavor:     FlavorData[1].Key,
 		IpAccess:   edgeproto.IpAccess_IpAccessDedicated,
@@ -300,6 +304,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey:  ClusterData[1].Key,
 			CloudletKey: CloudletData[1].Key,
+			Developer:   DevData[3].Key.Name,
 		},
 		Flavor:     FlavorData[1].Key,
 		IpAccess:   edgeproto.IpAccess_IpAccessShared,
@@ -311,6 +316,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey:  ClusterData[2].Key,
 			CloudletKey: CloudletData[2].Key,
+			Developer:   DevData[3].Key.Name,
 		},
 		Flavor:     FlavorData[2].Key,
 		IpAccess:   edgeproto.IpAccess_IpAccessDedicated,
@@ -322,6 +328,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey:  ClusterData[3].Key,
 			CloudletKey: CloudletData[3].Key,
+			Developer:   DevData[3].Key.Name,
 		},
 		Flavor:     FlavorData[2].Key,
 		NodeFlavor: CloudletInfoData[3].Flavors[0].Name,


### PR DESCRIPTION
Delete for default cloudlet appinst fails because of code that adds the developer name automatically to the appinst when trying to delete it if the cluster name contains "auto".  This automatic addition of developer name is not applicable to default cloudlet appinst.   