### PR TITLE
EDGECLOUD-658: Add a subscriber info check to return a better exception on network switch

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/.idea/gradle.xml
+++ b/edge-mvp/android/EmptyMatchEngineApp/.idea/gradle.xml
@@ -3,6 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
@@ -258,7 +258,10 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
                     //String carrierName = mMatchingEngine.retrieveNetworkCarrierName(ctx); // Regular use case
                     String carrierName = "mexdemo";                                         // Override carrierName
-                    //String host = mMatchingEngine.generateDmeHostAddress(carrierName);    // Regular use case
+                    //String carrierName = mMatchingEngine.retrieveNetworkCarrierName(ctx); // Regular use case
+                    if (carrierName == null) {
+                        someText = "No carrier Info!";
+                    }
                     String host = mMatchingEngine.generateDmeHostAddress(carrierName);      // Override carrier specific host name
                     int port = mMatchingEngine.getPort(); // Keep same port.
 

--- a/edge-mvp/android/EmptyMatchEngineApp/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -3,6 +3,7 @@ package com.mobiledgex.matchingengine;
 import android.app.UiAutomation;
 import android.content.Context;
 import android.os.Environment;
+import android.os.Looper;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -40,15 +41,22 @@ public class EngineCallTest {
 
     // There's no clear way to get this programmatically outside the app signing certificate, and may
     // not be required in the future.
-    public static final String developerName = "EmptyMatchEngineApp";
-    public static final String applicationName = "EmptyMatchEngineApp";
+    public static final String developerName = "MobiledgeX";
+    public static final String applicationName = "MobiledgeX SDK Demo";
 
     FusedLocationProviderClient fusedLocationClient;
 
-    public static String hostOverride = "tdg2.dme.mobiledgex.net";
+    public static String hostOverride = "mexdemo.dme.mobiledgex.net";
     public static int portOverride = 50051;
 
     public boolean useHostOverride = true;
+
+    @Before
+    public void LooperEnsure() {
+        // SubscriberManager needs a thread. Start one:
+        if (Looper.myLooper()==null)
+            Looper.prepare();
+    }
 
     @Before
     public void grantPermissions() {
@@ -185,6 +193,7 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         MexLocation mexLoc = new MexLocation(me);
         Location location;
@@ -232,6 +241,7 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         MexLocation mexLoc = new MexLocation(me);
         Location location;
@@ -276,6 +286,7 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(false);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
         MexLocation mexLoc = new MexLocation(me);
 
         Location loc = MockUtils.createLocation("mexDisabledTest", 122.3321, 47.6062);
@@ -380,6 +391,7 @@ public class EngineCallTest {
         MatchingEngine me = new MatchingEngine(context);
         me.setNetworkSwitchingEnabled(false);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
         MexLocation mexLoc = new MexLocation(me);
 
         Location loc = MockUtils.createLocation("mexNetworkingDisabledTest", 122.3321, 47.6062);
@@ -421,6 +433,7 @@ public class EngineCallTest {
         AppClient.FindCloudletReply findCloudletReply = null;
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
         MexLocation mexLoc = new MexLocation(me);
 
         Location loc = MockUtils.createLocation("findCloudletTest", 122.3321, 47.6062);
@@ -457,7 +470,7 @@ public class EngineCallTest {
 
         if (findCloudletReply != null) {
             // Temporary.
-            assertEquals("App's expected test cloudlet FQDN doesn't match.", "tmocloud1.t-mobile.mobiledgex.net", findCloudletReply.getFQDN());
+            assertEquals("App's expected test cloudlet FQDN doesn't match.", "mobiledgexmobiledgexsdkdemo10.westindia-mexdemo.azure.mobiledgex.net", findCloudletReply.getFQDN());
         } else {
             assertFalse("No findCloudlet response!", false);
         }
@@ -470,6 +483,7 @@ public class EngineCallTest {
         AppClient.FindCloudletReply result = null;
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
         MexLocation mexLoc = new MexLocation(me);
 
         Location loc = MockUtils.createLocation("findCloudletTest", 122.3321, 47.6062);
@@ -500,7 +514,7 @@ public class EngineCallTest {
         }
 
         // Temporary.
-        assertEquals("Fully qualified domain name not epected.", "tmocloud1.t-mobile.mobiledgex.net", result.getFQDN());
+        assertEquals("Fully qualified domain name not epected.", "mobiledgexmobiledgexsdkdemo10.westindia-mexdemo.azure.mobiledgex.net", result.getFQDN());
 
     }
 
@@ -510,6 +524,7 @@ public class EngineCallTest {
 
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
         MexLocation mexLoc = new MexLocation(me);
         AppClient.VerifyLocationReply verifyLocationReply = null;
 
@@ -559,6 +574,7 @@ public class EngineCallTest {
 
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
         MexLocation mexLoc = new MexLocation(me);
         AppClient.VerifyLocationReply verifyLocationReply = null;
         Future<AppClient.VerifyLocationReply> verifyLocationReplyFuture = null;
@@ -612,6 +628,7 @@ public class EngineCallTest {
 
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
         MexLocation mexLoc = new MexLocation(me);
 
         AppClient.VerifyLocationReply verifyLocationReply = null;
@@ -646,7 +663,7 @@ public class EngineCallTest {
         // Temporary.
         assertEquals(0, verifyLocationReply.getVer());
         assertEquals(AppClient.VerifyLocationReply.Tower_Status.TOWER_UNKNOWN, verifyLocationReply.getTowerStatus());
-        assertEquals(AppClient.VerifyLocationReply.GPS_Location_Status.LOC_ROAMING_COUNTRY_MISMATCH, verifyLocationReply.getGpsLocationStatus()); // Based on test data.
+        assertEquals(AppClient.VerifyLocationReply.GPS_Location_Status.LOC_ROAMING_COUNTRY_MATCH, verifyLocationReply.getGpsLocationStatus()); // Based on test data.
 
     }
 
@@ -655,6 +672,7 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
         MexLocation mexLoc = new MexLocation(me);
         Location location;
         AppClient.GetLocationReply getLocationReply = null;
@@ -709,6 +727,7 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         MexLocation mexLoc = new MexLocation(me);
         Location location;
@@ -767,6 +786,7 @@ public class EngineCallTest {
 
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         AppClient.DynamicLocGroupReply dynamicLocGroupReply = null;
 
@@ -816,6 +836,7 @@ public class EngineCallTest {
 
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         AppClient.DynamicLocGroupReply dynamicLocGroupReply = null;
 
@@ -867,6 +888,7 @@ public class EngineCallTest {
 
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         AppClient.AppInstListReply appInstListReply = null;
 
@@ -891,7 +913,7 @@ public class EngineCallTest {
 
             assertEquals(0, list.getVer());
             assertEquals(AppClient.AppInstListReply.AI_Status.AI_SUCCESS, list.getStatus());
-            assertEquals(1, list.getCloudletsCount()); // NOTE: This is entirely test server dependent.
+            assertEquals(3, list.getCloudletsCount()); // NOTE: This is entirely test server dependent.
             for (int i = 0; i < list.getCloudletsCount(); i++) {
                 Log.v(TAG, "Cloudlet: " + list.getCloudlets(i).toString());
             }
@@ -917,6 +939,7 @@ public class EngineCallTest {
 
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         enableMockLocation(context,true);
         Location location = MockUtils.createLocation("getAppInstListFutureTest", 122.3321, 47.6062);
@@ -940,7 +963,7 @@ public class EngineCallTest {
 
             assertEquals(0, list.getVer());
             assertEquals(AppClient.AppInstListReply.AI_Status.AI_SUCCESS, list.getStatus());
-            assertEquals(1, list.getCloudletsCount()); // NOTE: This is entirely test server dependent.
+            assertEquals(3, list.getCloudletsCount()); // NOTE: This is entirely test server dependent.
             for (int i = 0; i < list.getCloudletsCount(); i++) {
                 Log.v(TAG, "Cloudlet: " + list.getCloudlets(i).toString());
             }

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/LimitsTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/LimitsTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.location.Location;
 import android.os.AsyncTask;
 import android.os.Build;
+import android.os.Looper;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.telephony.TelephonyManager;
@@ -35,16 +36,22 @@ public class LimitsTest {
     public static final String TAG = "LimitsTest";
     public static final long GRPC_TIMEOUT_MS = 10000;
 
-    public static final String developerName = "EmptyMatchEngineApp";
-    public static final String applicationName = "EmptyMatchEngineApp";
+    public static final String developerName = "MobiledgeX";
+    public static final String applicationName = "MobiledgeX SDK Demo";
 
     FusedLocationProviderClient fusedLocationClient;
 
-    public static String hostOverride = "tdg2.dme.mobiledgex.net";
+    public static String hostOverride = "mexdemo.dme.mobiledgex.net";
     public static int portOverride = 50051;
 
     public boolean useHostOverride = true;
 
+    @Before
+    public void LooperEnsure() {
+        // SubscriberManager needs a thread. Start one:
+        if (Looper.myLooper()==null)
+            Looper.prepare();
+    }
 
     @Before
     public void grantPermissions() {
@@ -145,6 +152,7 @@ public class LimitsTest {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context, Executors.newFixedThreadPool(20));
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         MexLocation mexLoc = new MexLocation(me);
         Location location;
@@ -233,6 +241,7 @@ public class LimitsTest {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         MexLocation mexLoc = new MexLocation(me);
         Location location;
@@ -345,6 +354,7 @@ public class LimitsTest {
      */
     @Test
     public void parameterizedLatencyTest1() {
+
         parameterizedLatencyTestConcurrent("parameterizedLatencyTest1", 10, 1100, 180 * 1000);
     }
 
@@ -360,6 +370,7 @@ public class LimitsTest {
 
         final long start = System.currentTimeMillis();
         me.setMexLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
 
         MexLocation mexLoc = new MexLocation(me);
         Location location;

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkRequestNoSubscriptionInfoException.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkRequestNoSubscriptionInfoException.java
@@ -1,0 +1,9 @@
+package com.mobiledgex.matchingengine;
+
+import java.lang.Exception;
+
+public class NetworkRequestNoSubscriptionInfoException extends Exception {
+    public NetworkRequestNoSubscriptionInfoException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
Android: Unit tested on Pixel 2 (tdg sim), Emulator. Bump to v1.3.9.

New exception if Subscriber info is empty: NetworkRequestNoSubscriptionInfoException

However, the app can catch this somewhat earlier instead of sending the request through the NetworkManager: retrieveCarrierName() == null if the SIM, or data is not available. 

Or, if the SIM is disabled during the API call, it's possible it'll timeout or throw the same error. The networkManager is making a request to an external system service.

