### PR TITLE
EC-638: VM based Apps doesn't show FQDN

### DIFF
--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -91,6 +91,16 @@ func GetAppFQDN(key *edgeproto.AppInstKey, cloudletKey *edgeproto.CloudletKey, c
 	return fmt.Sprintf("%s%s%s.%s", dev, app, ver, lb)
 }
 
+// GetVMAppFQDN gets the app-specific Fully Qualified Domain Name
+// for VM based apps
+func GetVMAppFQDN(key *edgeproto.AppInstKey, cloudletKey *edgeproto.CloudletKey) string {
+	lb := GetRootLBFQDN(cloudletKey)
+	app := util.DNSSanitize(key.AppKey.Name)
+	dev := util.DNSSanitize(key.AppKey.DeveloperKey.Name)
+	ver := util.DNSSanitize(key.AppKey.Version)
+	return fmt.Sprintf("%s%s%s.%s", dev, app, ver, lb)
+}
+
 func FqdnPrefix(svcName string) string {
 	return svcName + "."
 }

--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -426,8 +426,10 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		}
 
 		ports, _ := edgeproto.ParseAppPorts(app.AccessPorts)
-		if defaultCloudlet || !cloudcommon.IsClusterInstReqd(&app) {
+		if defaultCloudlet {
 			// nothing to do
+		} else if !cloudcommon.IsClusterInstReqd(&app) {
+			in.Uri = cloudcommon.GetVMAppFQDN(&in.Key, &in.Key.ClusterInstKey.CloudletKey)
 		} else if ipaccess == edgeproto.IpAccess_IP_ACCESS_SHARED {
 			in.Uri = cloudcommon.GetRootLBFQDN(&in.Key.ClusterInstKey.CloudletKey)
 			if cloudletRefs.RootLbPorts == nil {


### PR DESCRIPTION
Refer https://github.com/mobiledgex/edge-cloud-infra/pull/156 for notes on this bug.

**Test:**
* Note the `uri` field
```
❯ ShowAppInst
- key:
    appkey:
      developerkey:
        name: MEXInc
      name: AshishVM
      version: "1.0"
    clusterinstkey:
      clusterkey:
        name: SomeCluster
      cloudletkey:
        operatorkey:
          name: TDG
        name: frankfurt_testcloudlet
      developer: MEXInc
  cloudletloc:
    latitude: 35
    longitude: -95
    timestamp: {}
  uri: mexincashishvm10.frankfurt-testcloudlet.tdg.mobiledgex.net
  liveness: LivenessStatic
  mappedports:
  - proto: LProtoTcp
    internalport: 22
  - proto: LProtoUdp
    internalport: 1111
  flavor:
    name: x1.medium
  state: Ready
  createdat:
    seconds: 1558700838
    nanos: 128931000
```