### PR TITLE
EDGECLOUD 698: CreateClusterInst incorrectly looking for openstack flavor even if specified flavor does not exist

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -223,7 +223,7 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 
 		nodeFlavor := edgeproto.Flavor{}
 		if !flavorApi.store.STMGet(stm, &in.Flavor, &nodeFlavor) {
-			return fmt.Errorf("Cluster flavor %s not found", in.Flavor.Name)
+			return fmt.Errorf("flavor %s not found", in.Flavor.Name)
 		}
 		var err error
 		in.NodeFlavor, err = flavor.GetClosestFlavor(info.Flavors, nodeFlavor)


### PR DESCRIPTION
This is just a display issue. It is doing right check for flavor name.