### PR TITLE
EDGECLOUD-753: CreateApp - should verify a valid md5 is sent when specifying imagepath

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -155,8 +155,11 @@ func updateAppFields(in *edgeproto.App) error {
 		if cSum[0] != "md5" {
 			return fmt.Errorf("only md5 checksum is supported")
 		}
+		if len(cSum[1]) < 32 {
+			return fmt.Errorf("md5 checksum must be at least 32 characters")
+		}
 		_, err := hex.DecodeString(cSum[1])
-		if err != nil || len(cSum[1]) != 32 {
+		if err != nil {
 			return fmt.Errorf("invalid md5 checksum")
 		}
 	}


### PR DESCRIPTION
* Added MD5 validation

Tests:
```
❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://abcd.com/test.img\#md5:abcdefg
Error: CreateApp failed: invalid md5 checksum

❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://abcd.com/test.img\#md5:abcd
Error: CreateApp failed: invalid md5 checksum

❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://abcd.com/test.img\#md5:
Error: CreateApp failed: invalid md5 checksum

❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://abcd.com/test.img\#md5:x
Error: CreateApp failed: invalid md5 checksum

❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://abcd.com/test.img\#md5:x1111111111111111111111111111111
Error: CreateApp failed: invalid md5 checksum

❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://abcd.com/test.img\#md5:11111111111111111111111111111111
{}
```