### PR TITLE
remove osx-specific ln args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,10 @@ external-doc:
 	make -C edgeproto external-doc
 
 lint:
-	@ln -sfh $(GOGOPROTO) link-gogo-protobuf
-	@ln -sfh $(GRPCGATEWAY) link-grpc-gateway
+	-@rm link-gogo-protobuf
+	-@rm link-grpc-gateway
+	@ln -s $(GOGOPROTO) link-gogo-protobuf
+	@ln -s $(GRPCGATEWAY) link-grpc-gateway
 	prototool lint edgeproto
 	prototool lint d-match-engine
 


### PR DESCRIPTION
Link command in makefile didn't work on linux (CI/CD).