### PR TITLE
Fix GRPC C# makefile to use nuget directly

### DIFF
--- a/edge-mvp/csharp/grpc/Makefile
+++ b/edge-mvp/csharp/grpc/Makefile
@@ -60,7 +60,7 @@ build-release:
 
 publish:
 	test MEX_LIB_API_KEY
-	$(shell dotnet nuget push $(BINOUT)/Release/Mobiledgex.MatchingEngineGrpcLibrary.1.3.8.nupkg -k $(MEX_LIB_API_KEY) -s $(NUGET_RELEASE_SERVER) > $(PUBLISHLOG))
+	$(shell nuget push $(BINOUT)/Release/Mobiledgex.MatchingEngineGrpcLibrary.1.4.2.nupkg -ApiKey $(MEX_LIB_API_KEY) -Source $(NUGET_RELEASE_SERVER) > $(PUBLISHLOG))
 	cat $(PUBLISHLOG)
 
 

--- a/edge-mvp/csharp/grpc/MatchingEngineSDK/MatchingEngineGrpcLibrary/MatchingEngineGrpcLibrary.csproj
+++ b/edge-mvp/csharp/grpc/MatchingEngineSDK/MatchingEngineGrpcLibrary/MatchingEngineGrpcLibrary.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <PackageId>MobiledgeX.MatchingEngineGrpcLibrary</PackageId>
-    <Version>1.4.0</Version>
+    <Version>1.4.2</Version>
     <Authors>MobiledgeX, Inc</Authors>
     <Company>MobiledgeX, Inc.</Company>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ReleaseVersion>1.4.0</ReleaseVersion>
+    <ReleaseVersion>1.4.2</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/edge-mvp/csharp/grpc/MatchingEngineSDK/MatchingEngineSDK.sln
+++ b/edge-mvp/csharp/grpc/MatchingEngineSDK/MatchingEngineSDK.sln
@@ -15,6 +15,6 @@ Global
 		{CDB7BF58-8CAC-4603-AF5E-83CD74371A84}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 1.4.0
+		version = 1.4.2
 	EndGlobalSection
 EndGlobal

--- a/edge-mvp/csharp/grpc/SampleApps/MexGrpcSampleConsoleApp/MexGrpcSampleConsoleApp.csproj
+++ b/edge-mvp/csharp/grpc/SampleApps/MexGrpcSampleConsoleApp/MexGrpcSampleConsoleApp.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineGrpcLibrary" Version="1.4.0" />
+    <PackageReference Include="MobiledgeX.MatchingEngineGrpcLibrary" Version="1.4.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Simple changes. nuget build command to full command. Updated version number to 1.4.2.