### PR TITLE
Crash fix isRoamingData() if onAvailableNetwork oddly as no networkcapabilities.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/app/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation project(":matchingengine")
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:1.3.0'
+    //implementation 'com.mobiledgex:matchingengine:1.4.2'
     // Dependencies of Matching Engine, if using Maven:
     //implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     //implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "1.4.0"
+        versionName "1.4.2"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
@@ -186,9 +186,16 @@ public class NetworkManager extends SubscriptionManager.OnSubscriptionsChangedLi
     // This Roaming Data value is un-reliable except under a new NetworkCapabilities Key in API 28.
     @RequiresApi(api = android.os.Build.VERSION_CODES.P)
     boolean isRoamingData() {
-        boolean isroaming = mConnectivityManager.getNetworkCapabilities(mConnectivityManager.getActiveNetwork())
-            .hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_ROAMING);
-        return isroaming;
+        Network activeNetwork = mConnectivityManager.getActiveNetwork();
+        if (activeNetwork == null) {
+            return false;
+        }
+        NetworkCapabilities caps = mConnectivityManager.getNetworkCapabilities(activeNetwork);
+        if (caps == null) {
+            return false;
+        }
+
+        return !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_ROAMING);
     }
 
     /**


### PR DESCRIPTION
Stack trace from a "Huawei Mate 20 (HWHMA), Android 9" Google Play crash log. Somehow, NetworkCapabilities is null after network is available for use. Checking more thoroughly now.

Misc: isRoamingData is inverted.