### PR TITLE
EDGECLOUD-824: Verify the image_path for VM based deployment

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -151,7 +151,7 @@ func updateAppFields(in *edgeproto.App) error {
 				return fmt.Errorf("imagepath should be full registry URL: <domain-name>/<registry-path>")
 			}
 			if !*testMode {
-				err := cloudcommon.ValidateRegistryPath(in.ImagePath, *vaultAddr)
+				err := cloudcommon.ValidateDockerRegistryPath(in.ImagePath, *vaultAddr)
 				if err != nil {
 					return err
 				}
@@ -164,6 +164,12 @@ func updateAppFields(in *edgeproto.App) error {
 	}
 
 	if in.ImageType == edgeproto.ImageType_IMAGE_TYPE_QCOW {
+		if !*testMode {
+			err := cloudcommon.ValidateVMRegistryPath(in.ImagePath, *vaultAddr)
+			if err != nil {
+				return err
+			}
+		}
 		urlInfo := strings.Split(in.ImagePath, "#")
 		if len(urlInfo) != 2 {
 			return fmt.Errorf("md5 checksum of image is required. Please append checksum to imagepath: \"<url>#md5:checksum\"")


### PR DESCRIPTION
* Refactored existing code to support this

**Tests:**
```
❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://abcd.com/test.img\#md5:1111111111111111111111111111111
Error: CreateApp failed: Invalid image path
```

```
❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://example.com/test.img\#md5:1111111111111111111111111111111
Error: CreateApp failed: Invalid image path: Not Found
```

```
❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://artifactory.mobiledgex.net/artifactory/mc-repo-Sierraware/SierraVMI-Unified_50.0.8_Demo.qcow2#b405c7ee5022d5582efa21d7b6fb35ec
Error: CreateApp failed: incorrect checksum format, valid format: "<url>#md5:checksum"
```

```
❯ CreateApp --key-name AshishVM --key-developerkey-name MEXInc --key-version 1.0 --imagetype ImageTypeQcow --defaultflavor-name x1.medium --imagepath https://artifactory.mobiledgex.net/artifactory/mc-repo-Sierraware/SierraVMI-Unified_50.0.8_Demo.qcow2#md5:b405c7ee5022d5582efa21d7b6fb35ec
{}
```