### PR TITLE
fix basic docker case I broke with docker-compose changes

### DIFF
--- a/cloud-resource-manager/dockermgmt/dockerapp.go
+++ b/cloud-resource-manager/dockermgmt/dockerapp.go
@@ -31,7 +31,7 @@ func CreateAppInst(client pc.PlatformClient, app *edgeproto.App, appInst *edgepr
 	image := app.ImagePath
 	name := app.Key.Name
 	if app.DeploymentManifest == "" {
-		cmd := fmt.Sprintf("docker run -d --restart=unless-stopped --network=host--name=%s %s %s", name, image, app.Command)
+		cmd := fmt.Sprintf("docker run -d --restart=unless-stopped --network=host --name=%s %s %s", name, image, app.Command)
 		log.DebugLog(log.DebugLevelMexos, "running docker run ", "cmd", cmd)
 
 		out, err := client.Output(cmd)


### PR DESCRIPTION
EDGECLOUD-844

Somehow I managed to delete a necessary space in the "docker run" command when I added the hook for docker-compose.  Adding the space back.