### PR TITLE
Old android crashes on subscription listener

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/app/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation project(":matchingengine")
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:1.4.2'
+    //implementation 'com.mobiledgex:matchingengine:1.4.4'
     // Dependencies of Matching Engine, if using Maven:
     //implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     //implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/FirstTimeUseActivity.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/FirstTimeUseActivity.java
@@ -22,7 +22,7 @@ public class FirstTimeUseActivity extends AppCompatActivity {
     private RequestPermissions mRpUtil;
     private AppCompatActivity self;
     private SharedPreferences prefs;
-    private String prefKeyAllowMEX;
+    private String prefKeyAllowMatchingEngineLocation;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -32,7 +32,7 @@ public class FirstTimeUseActivity extends AppCompatActivity {
         mRpUtil = new RequestPermissions();
         self = this;
         prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        prefKeyAllowMEX = getResources().getString(R.string.preference_mex_location_verification);
+        prefKeyAllowMatchingEngineLocation = getResources().getString(R.string.preference_matching_engine_location_verification);
 
         TextView devLocationWhy = findViewById(R.id.permission_location_device_why);
         devLocationWhy.setOnClickListener(new View.OnClickListener() {
@@ -69,7 +69,7 @@ public class FirstTimeUseActivity extends AppCompatActivity {
             }
         });
 
-        Button ok = findViewById(R.id.okbutton);
+        Button ok = findViewById(R.id.ok_button);
         ok.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -92,12 +92,11 @@ public class FirstTimeUseActivity extends AppCompatActivity {
     }
 
     private boolean shouldFinish(Activity activity) {
-        final String prefKeyAllowMEX = getResources().getString(R.string.preference_mex_location_verification);
-        boolean mexLocationAllowed = prefs.getBoolean(prefKeyAllowMEX, false);
+        boolean mobiledgeXLocationAllowed = prefs.getBoolean(prefKeyAllowMatchingEngineLocation, false);
 
-        Log.d(TAG, "mexLocationallowed: " + mexLocationAllowed);
+        Log.d(TAG, "mobiledgeXLocationAllowed: " + mobiledgeXLocationAllowed);
         Log.d(TAG, "Needs More Permissions: " + mRpUtil.getNeededPermissions(self).size());
-        if (mexLocationAllowed &&
+        if (mobiledgeXLocationAllowed &&
             (mRpUtil.getNeededPermissions(activity).size() == 0)) {
 
             // Nothing to ask for. Close FirstTimeUseActivity.
@@ -111,7 +110,7 @@ public class FirstTimeUseActivity extends AppCompatActivity {
         if (mRpUtil.getNeededPermissions(appCompatActivity).size() > 0) {
             mRpUtil.requestMultiplePermissions(appCompatActivity);
         }
-        if (!prefs.getBoolean(prefKeyAllowMEX, false)) {
+        if (!prefs.getBoolean(prefKeyAllowMatchingEngineLocation, false)) {
             new EnhancedLocationDialog().show(appCompatActivity.getSupportFragmentManager(), "dialog");
         }
     }

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
@@ -11,6 +11,7 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.telephony.CarrierConfigManager;
+import android.telephony.SubscriptionInfo;
 import android.util.Log;
 import android.view.View;
 import android.view.Menu;
@@ -77,14 +78,14 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         mFusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
         mLocationRequest = new LocationRequest();
 
-        // Restore mex location preference, defaulting to false:
+        // Restore app's matching engine location preference, defaulting to false:
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         PreferenceManager.setDefaultValues(this, R.xml.location_preferences, false);
 
-        boolean mexLocationAllowed = prefs.getBoolean(getResources()
-                .getString(R.string.preference_mex_location_verification),
+        boolean matchingEngineLocationAllowed = prefs.getBoolean(getResources()
+                .getString(R.string.preference_matching_engine_location_verification),
                 false);
-        MatchingEngine.setMexLocationAllowed(mexLocationAllowed);
+        MatchingEngine.setMatchingEngineLocationAllowed(matchingEngineLocationAllowed);
 
         // Watch allowed preference:
         prefs.registerOnSharedPreferenceChangeListener(this);
@@ -124,7 +125,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         Toolbar myToolbar = findViewById(R.id.toolbar);
         setSupportActionBar(myToolbar);
 
-        // Open dialog for MEX if this is the first time the app is created:
+        // Open dialog for MobiledgeX MatchingEngine if this is the first time the app is created:
         String firstTimeUsePrefKey = getResources().getString(R.string.preference_first_time_use);
         boolean firstTimeUse = prefs.getBoolean(firstTimeUsePrefKey, true);
 
@@ -167,9 +168,12 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         if (mRpUtil.getNeededPermissions(this).size() > 0) {
             // Opens a UI. When it returns, onResume() is called again.
             mRpUtil.requestMultiplePermissions(this);
-        } else if (mMatchingEngine == null) {
+            return;
+        }
+
+        if (mMatchingEngine == null) {
             // Permissions available. Create a MobiledgeX MatchingEngine instance (could also use Application wide instance).
-            mMatchingEngine = new MatchingEngine(this); // Using ApplicationContext for app wide usage.
+            mMatchingEngine = new MatchingEngine(this);
         }
 
         if (mDoLocationUpdates) {
@@ -186,14 +190,14 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     @Override
     public void onSaveInstanceState(Bundle savedInstanceState) {
         super.onSaveInstanceState(savedInstanceState);
-        savedInstanceState.putBoolean(MatchingEngine.MEX_LOCATION_PERMISSION, MatchingEngine.isMexLocationAllowed());
+        savedInstanceState.putBoolean(MatchingEngine.MATCHING_ENGINE_LOCATION_PERMISSION, MatchingEngine.isMatchingEngineLocationAllowed());
     }
 
     @Override
     public void onRestoreInstanceState(Bundle restoreInstanceState) {
         super.onRestoreInstanceState(restoreInstanceState);
         if (restoreInstanceState != null) {
-            MatchingEngine.setMexLocationAllowed(restoreInstanceState.getBoolean(MatchingEngine.MEX_LOCATION_PERMISSION));
+            MatchingEngine.setMatchingEngineLocationAllowed(restoreInstanceState.getBoolean(MatchingEngine.MATCHING_ENGINE_LOCATION_PERMISSION));
         }
     }
 
@@ -224,11 +228,11 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        final String prefKeyAllowMEX = getResources().getString(R.string.preference_mex_location_verification);
+        final String prefKeyAllowMatchingEngine = getResources().getString(R.string.preference_matching_engine_location_verification);
 
-        if (key.equals(prefKeyAllowMEX)) {
-            boolean mexLocationAllowed = sharedPreferences.getBoolean(prefKeyAllowMEX, false);
-            MatchingEngine.setMexLocationAllowed(mexLocationAllowed);
+        if (key.equals(prefKeyAllowMatchingEngine)) {
+            boolean locationAllowed = sharedPreferences.getBoolean(prefKeyAllowMatchingEngine, false);
+            MatchingEngine.setMatchingEngineLocationAllowed(locationAllowed);
         }
     }
 
@@ -245,7 +249,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     Log.w(TAG, "getLastLocation:exception", task.getException());
                     someText = "Last location not found, or has never been used. Location cannot be verified using 'getLastLocation()'. " +
                             "Use the requestLocationUpdates() instead if applicable for location verification.";
-                    TextView tv = findViewById(R.id.mex_verified_location_content);
+                    TextView tv = findViewById(R.id.mobiledgex_verified_location_content);
                     tv.setText(someText);
                 }
             }
@@ -259,14 +263,31 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 Location location = aTask.getResult();
                 // Location found. Create a request:
                 try {
+                    someText = "";
+                    // If no carrierName, or active Subscription networks, the app should use the public cloud instead.
+                    List<SubscriptionInfo> subList = mMatchingEngine.getActiveSubscriptionInfoList();
+                    if (subList != null && subList.size() > 0) {
+                        for(SubscriptionInfo info: subList) {
+                            if (info.getCarrierName().equals("Android")) {
+                                someText += "Emulator Active Subscription Network: " + info.toString() + "\n";
+                            } else {
+                                someText += "Active Subscription network: " + info.toString() + "\n";
+                            }
+                        }
+                        mMatchingEngine.setNetworkSwitchingEnabled(true);
+                    } else {
+                        // This example will continue to execute anyway, as Demo DME may still be reachable to discover nearby edge cloudlets.
+                        someText += "No active cellular networks: app should use public cloud instead of the edgecloudlet at this time.\n";
+                        mMatchingEngine.setNetworkSwitchingEnabled(false);
+                    }
+
                     SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
-                    boolean mexAllowed = prefs.getBoolean(getResources().getString(R.string.preference_mex_location_verification), false);
+                    boolean locationVerificationAllowed = prefs.getBoolean(getResources().getString(R.string.preference_matching_engine_location_verification), false);
 
                     //String carrierName = mMatchingEngine.retrieveNetworkCarrierName(ctx); // Regular use case
                     String carrierName = "mexdemo";                                         // Override carrierName
-                    //String carrierName = mMatchingEngine.retrieveNetworkCarrierName(ctx); // Regular use case
                     if (carrierName == null) {
-                        someText = "No carrier Info!";
+                        someText += "No carrier Info!\n";
                     }
                     String host = mMatchingEngine.generateDmeHostAddress(carrierName);      // Override carrier specific host name
                     int port = mMatchingEngine.getPort(); // Keep same port.
@@ -283,8 +304,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                                     host, port, 10000);
 
                     if (registerStatus.getStatus() != AppClient.ReplyStatus.RS_SUCCESS) {
-                        someText = "Registration Failed. Error: " + registerStatus.getStatus();
-                        TextView tv = findViewById(R.id.mex_verified_location_content);
+                        someText += "Registration Failed. Error: " + registerStatus.getStatus();
+                        TextView tv = findViewById(R.id.mobiledgex_verified_location_content);
                         tv.setText(someText);
                         return;
                     }
@@ -296,7 +317,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         AppClient.VerifyLocationReply verifiedLocation =
                                 mMatchingEngine.verifyLocation(verifyRequest, host, port, 10000);
 
-                        someText = "[Location Verified: Tower: " + verifiedLocation.getTowerStatus() +
+                        someText += "[Location Verified: Tower: " + verifiedLocation.getTowerStatus() +
                                 ", GPS LocationStatus: " + verifiedLocation.getGpsLocationStatus() +
                                 ", Location Accuracy: " + verifiedLocation.getGpsLocationAccuracyKm() + " ]\n";
 
@@ -350,7 +371,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         }
                     } else {
                         someText = "Cannot create request object.\n";
-                        if (!mexAllowed) {
+                        if (!locationVerificationAllowed) {
                             someText += " Reason: Enhanced location is disabled.\n";
                         }
                     }
@@ -372,7 +393,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     ctx.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            TextView tv = findViewById(R.id.mex_verified_location_content);
+                            TextView tv = findViewById(R.id.mobiledgex_verified_location_content);
                             tv.setText(someText);
                         }
                     });
@@ -382,11 +403,11 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         String causeMessage = ee.getCause().getMessage();
                         someText = "Network connection failed: " + causeMessage;
                         Log.e(TAG, someText);
-                        // Handle network error with failover logic. MEX requests over cellular is needed to talk to the DME.
+                        // Handle network error with failover logic. MobiledgeX MatchingEngine requests over cellular is needed to talk to the DME.
                         ctx.runOnUiThread(new Runnable() {
                             @Override
                             public void run() {
-                                TextView tv = findViewById(R.id.mex_verified_location_content);
+                                TextView tv = findViewById(R.id.mobiledgex_verified_location_content);
                                 tv.setText(someText);
                             }
                         });

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/layout/activity_first_time_use.xml
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/layout/activity_first_time_use.xml
@@ -9,8 +9,9 @@
 
     <ImageView
         android:id="@+id/permission_icon"
-        android:layout_width="300px"
-        android:layout_height="300px"
+        android:layout_width="300dp"
+        android:layout_height="300dp"
+        android:contentDescription="@string/permissions_needed"
         android:gravity="center"
         android:src="@android:color/holo_blue_dark"
         android:visibility="visible"
@@ -30,6 +31,9 @@
         android:textSize="24sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/imageView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/permission_icon" />
 
 
@@ -37,6 +41,7 @@
         android:id="@+id/imageView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:contentDescription="@string/access_device_location_permission_icon"
         android:src="@android:drawable/ic_menu_mylocation"
         app:layout_constraintBottom_toTopOf="@+id/permission_device_location"
         app:layout_constraintEnd_toStartOf="@+id/permission_device_location"
@@ -56,13 +61,14 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/imageView"
         app:layout_constraintTop_toBottomOf="@+id/imageView"
-        app:layout_constraintTop_toTopOf="@id/imageView" />
+        app:layout_constraintTop_toTopOf="@id/imageView"/>
 
     <TextView
         android:id="@+id/permission_location_device_why"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:clickable="true"
+        android:focusable="true"
         android:text="@string/why"
         android:textColor="?attr/colorPrimary"
         android:textSize="18sp"
@@ -74,6 +80,7 @@
         android:id="@+id/imageView2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:contentDescription="@string/verify_location_with_carrier_permission_icon"
         android:src="@android:drawable/ic_menu_mylocation"
         app:layout_constraintBottom_toTopOf="@+id/permission_carrier_location"
         app:layout_constraintEnd_toStartOf="@+id/permission_carrier_location"
@@ -93,25 +100,26 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/imageView2"
         app:layout_constraintTop_toBottomOf="@+id/imageView2"
-        app:layout_constraintTop_toTopOf="@id/imageView2"/>
+        app:layout_constraintTop_toTopOf="@id/imageView2" />
 
     <TextView
         android:id="@+id/permission_location_carrier_why"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:clickable="true"
+        android:focusable="true"
         android:text="@string/why"
         android:textColor="?attr/colorPrimary"
         android:textSize="18sp"
-        app:layout_constraintBottom_toTopOf="@+id/okbutton"
+        app:layout_constraintBottom_toTopOf="@+id/ok_button"
         app:layout_constraintLeft_toLeftOf="@+id/permission_carrier_location"
         app:layout_constraintTop_toBottomOf="@+id/permission_carrier_location" />
 
     <Button
-        android:id="@+id/okbutton"
+        android:id="@+id/ok_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="OK"
+        android:text="@string/button_ok_text"
         app:layout_constraintBottom_toTopOf="@+id/permission_icon"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/layout/content_main.xml
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/layout/content_main.xml
@@ -13,14 +13,14 @@
         android:layout_width="wrap_content"
         android:layout_height="15dp"
         android:text="@string/location_default_text"
-        app:layout_constraintBottom_toTopOf="@+id/mex_verified_location_content"
+        app:layout_constraintBottom_toTopOf="@+id/mobiledgex_verified_location_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/mex_verified_location_content"
+        android:id="@+id/mobiledgex_verified_location_content"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/click_me_for_cloudlets_text"

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/values/strings.xml
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/values/strings.xml
@@ -6,14 +6,19 @@
     <!-- Strings related to Settings -->
     <string name="action_settings">Settings</string>
     <string name="preference_first_time_use">first_time_use</string>
+    <string name="permissions_needed">Permissions Needed</string>
+
     <string name="enhanced_location_permission">This application uses enhanced features of carrier networks to validate your device location. Please enable in app settings.</string>
-    <string name="preference_mex_location_verification">location_verification</string>
-    <string name="preference_mex_location_verification_title">Location Verification</string>
-    <string name="preference_mex_location_verification_summary">Enhanced Network Location Services</string>
+    <string name="preference_matching_engine_location_verification">location_verification</string>
+    <string name="preference_matching_engine_location_verification_title">Location Verification</string>
+    <string name="preference_matching_engine_location_verification_summary">Enhanced Network Location Services</string>
 
     <string name="needed_permissions_text">We need these permissions to make everything work:</string>
     <string name="location_permission_summary">Access Device Location Permission Summary</string>
     <string name="location_carrier_permission_summary">Verify Location with Carrier Location Permission Summary</string>
+
+    <string name="access_device_location_permission_icon">Access Device Location Permission Icon</string>
+    <string name="verify_location_with_carrier_permission_icon">Verify Location with Carrier Permission Icon</string>
     <string name="why">Why?</string>
 
     <string name="location_device_permission_title">Device Location Verification</string>
@@ -22,4 +27,6 @@
     <string name="location_carrier_permission_explanation">Location with Carrier Supplied Location Permission Explanation</string>
 
     <string name="title_activity_settings">Settings</string>
+    <string name="button_ok_text">OK</string>
+
 </resources>

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/xml/location_preferences.xml
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/xml/location_preferences.xml
@@ -6,8 +6,8 @@
     android:id="@+id/mex_preference_screen">
 
     <SwitchPreference
-        android:key="@string/preference_mex_location_verification"
-        android:title="@string/preference_mex_location_verification_title"
-        android:summary="@string/preference_mex_location_verification_summary"
+        android:key="@string/preference_matching_engine_location_verification"
+        android:title="@string/preference_matching_engine_location_verification_title"
+        android:summary="@string/preference_matching_engine_location_verification_summary"
         android:defaultValue="false"/>
 </PreferenceScreen>

--- a/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/xml/pref_headers.xml
+++ b/edge-mvp/android/EmptyMatchEngineApp/app/src/main/res/xml/pref_headers.xml
@@ -3,6 +3,6 @@
     <header
         android:fragment="com.mobiledgex.emptymatchengineapp.SettingsActivity$LocationSettingsFragment"
         android:icon="@android:drawable/ic_menu_compass"
-        android:title="@string/preference_mex_location_verification_summary"/>
+        android:title="@string/preference_matching_engine_location_verification_summary"/>
 
 </preference-headers>

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "1.4.2"
+        versionName "1.4.4"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -8,7 +8,7 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.google.android.gms.location.FusedLocationProviderClient;
-import com.mobiledgex.matchingengine.util.MexLocation;
+import com.mobiledgex.matchingengine.util.MeLocation;
 
 import org.junit.Test;
 import org.junit.Before;
@@ -192,10 +192,10 @@ public class EngineCallTest {
     public void registerClientTest() {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
         Location location;
         AppClient.RegisterClientReply reply = null;
         String appName = applicationName;
@@ -205,7 +205,7 @@ public class EngineCallTest {
 
         try {
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             AppClient.RegisterClientRequest request = MockUtils.createMockRegisterClientRequest(developerName, appName, me);
@@ -240,10 +240,10 @@ public class EngineCallTest {
     public void registerClientFutureTest() {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
         Location location;
         Future<AppClient.RegisterClientReply> registerReplyFuture;
         AppClient.RegisterClientReply reply = null;
@@ -253,7 +253,7 @@ public class EngineCallTest {
 
         try {
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             AppClient.RegisterClientRequest request = MockUtils.createMockRegisterClientRequest(developerName, applicationName, me);
@@ -285,9 +285,9 @@ public class EngineCallTest {
     public void mexDisabledTest() {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(false);
+        me.setMatchingEngineLocationAllowed(false);
         me.setAllowSwitchIfNoSubscriberInfo(true);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
 
         Location loc = MockUtils.createLocation("mexDisabledTest", 122.3321, 47.6062);
         boolean allRun = false;
@@ -295,7 +295,7 @@ public class EngineCallTest {
         try {
             enableMockLocation(context, true);
             setMockLocation(context, loc);
-            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            Location location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             try {
                 // Non-Mock.
                 AppClient.RegisterClientRequest registerClientRequest = me.createRegisterClientRequest(
@@ -386,21 +386,21 @@ public class EngineCallTest {
      * non-cellular communications.
      */
     @Test
-    public void mexNetworkingDisabledTest() {
+    public void meNetworkingDisabledTest() {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
         me.setNetworkSwitchingEnabled(false);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
 
-        Location loc = MockUtils.createLocation("mexNetworkingDisabledTest", 122.3321, 47.6062);
+        Location loc = MockUtils.createLocation("meNetworkingDisabledTest", 122.3321, 47.6062);
 
         AppClient.RegisterClientReply registerClientReply = null;
         try {
             enableMockLocation(context, true);
             setMockLocation(context, loc);
-            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            Location location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
 
             AppClient.RegisterClientRequest registerClientRequest = MockUtils.createMockRegisterClientRequest(
                     developerName,
@@ -413,13 +413,13 @@ public class EngineCallTest {
             }
         } catch (ExecutionException ee) {
             Log.e(TAG, Log.getStackTraceString(ee));
-            assertFalse("mexNetworkingDisabledTest: ExecutionException!", true);
+            assertFalse("meNetworkingDisabledTest: ExecutionException!", true);
         } catch (StatusRuntimeException sre) {
             Log.e(TAG, Log.getStackTraceString(sre));
             assertTrue("mexNetworkDisabledTest: registerClient non-null, and somehow succeeded!",registerClientReply == null);
         } catch (InterruptedException ie) {
             Log.e(TAG, Log.getStackTraceString(ie));
-            assertFalse("mexNetworkingDisabledTest: InterruptedException!", true);
+            assertFalse("meNetworkingDisabledTest: InterruptedException!", true);
         } finally {
             enableMockLocation(context,false);
             me.setNetworkSwitchingEnabled(true);
@@ -432,9 +432,9 @@ public class EngineCallTest {
         AppClient.RegisterClientReply registerClientReply = null;
         AppClient.FindCloudletReply findCloudletReply = null;
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
 
         Location loc = MockUtils.createLocation("findCloudletTest", 122.3321, 47.6062);
 
@@ -442,7 +442,7 @@ public class EngineCallTest {
         try {
             enableMockLocation(context, true);
             setMockLocation(context, loc);
-            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            Location location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
 
             String carrierName = MockUtils.getCarrierName(context);
             registerClient(context, me.retrieveNetworkCarrierName(context), me);
@@ -482,16 +482,16 @@ public class EngineCallTest {
         Future<AppClient.FindCloudletReply> response;
         AppClient.FindCloudletReply result = null;
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
 
         Location loc = MockUtils.createLocation("findCloudletTest", 122.3321, 47.6062);
 
         try {
             enableMockLocation(context, true);
             setMockLocation(context, loc);
-            Location location = mexLoc.getBlocking(context, 10000);
+            Location location = meLoc.getBlocking(context, 10000);
 
             String carrierName = MockUtils.getCarrierName(context);
             registerClient(context, carrierName, me);
@@ -523,16 +523,16 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getTargetContext();
 
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
         AppClient.VerifyLocationReply verifyLocationReply = null;
 
         try {
             enableMockLocation(context, true);
             Location mockLoc = MockUtils.createLocation("verifyLocationTest", 122.3321, 47.6062);
             setMockLocation(context, mockLoc);
-            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            Location location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
 
             String carrierName = MockUtils.getCarrierName(context);
             registerClient(context, carrierName, me);
@@ -573,9 +573,9 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getTargetContext();
 
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
         AppClient.VerifyLocationReply verifyLocationReply = null;
         Future<AppClient.VerifyLocationReply> verifyLocationReplyFuture = null;
         Future<AppClient.VerifyLocationRequest> verifyLocationRequestFuture = null;
@@ -584,7 +584,7 @@ public class EngineCallTest {
             enableMockLocation(context, true);
             Location mockLoc = MockUtils.createLocation("verifyLocationFutureTest", 122.3321, 47.6062);
             setMockLocation(context, mockLoc);
-            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            Location location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
 
             String carrierName = MockUtils.getCarrierName(context);
             registerClient(context, carrierName, me);
@@ -627,14 +627,14 @@ public class EngineCallTest {
 
 
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
 
         AppClient.VerifyLocationReply verifyLocationReply = null;
         try {
             setMockLocation(context, mockLoc); // North Pole.
-            Location location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            Location location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             String carrierName = MockUtils.getCarrierName(context);
@@ -671,9 +671,9 @@ public class EngineCallTest {
     public void getLocationTest() {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
         Location location;
         AppClient.GetLocationReply getLocationReply = null;
 
@@ -683,7 +683,7 @@ public class EngineCallTest {
         String carrierName = MockUtils.getCarrierName(context);
         try {
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
 
@@ -726,10 +726,10 @@ public class EngineCallTest {
     public void getLocationFutureTest() {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
         Location location;
         Future<AppClient.GetLocationReply> getLocationReplyFuture;
         AppClient.GetLocationReply getLocationReply = null;
@@ -742,7 +742,7 @@ public class EngineCallTest {
             // Directly create request for testing:
             // Passed in Location (which is a callback interface)
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
 
@@ -785,19 +785,19 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getContext();
 
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
         AppClient.DynamicLocGroupReply dynamicLocGroupReply = null;
 
         enableMockLocation(context,true);
         Location location = MockUtils.createLocation("createDynamicLocationGroupAddTest", 122.3321, 47.6062);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
 
         String carrierName = MockUtils.getCarrierName(context);
         try {
             setMockLocation(context, location);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             registerClient(context, carrierName, me);
@@ -835,19 +835,19 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getContext();
 
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
         AppClient.DynamicLocGroupReply dynamicLocGroupReply = null;
 
         enableMockLocation(context,true);
         Location location = MockUtils.createLocation("createDynamicLocationGroupAddTest", 122.3321, 47.6062);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
 
         String carrierName = MockUtils.getCarrierName(context);
         try {
             setMockLocation(context, location);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             registerClient(context, carrierName, me);
@@ -887,18 +887,18 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getContext();
 
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
         AppClient.AppInstListReply appInstListReply = null;
 
         enableMockLocation(context,true);
         Location location = MockUtils.createLocation("getCloudletListTest", 122.3321, 47.6062);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
 
         try {
             setMockLocation(context, location);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse("Mock'ed Location is missing!", location == null);
 
             registerClient(context, MockUtils.getCarrierName(context), me);
@@ -938,16 +938,16 @@ public class EngineCallTest {
         Context context = InstrumentationRegistry.getContext();
 
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
         enableMockLocation(context,true);
         Location location = MockUtils.createLocation("getAppInstListFutureTest", 122.3321, 47.6062);
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
 
         try {
             setMockLocation(context, location);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse("Mock'ed Location is missing!", location == null);
 
             registerClient(context, me.retrieveNetworkCarrierName(context), me);

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/LimitsTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/LimitsTest.java
@@ -12,7 +12,7 @@ import android.telephony.TelephonyManager;
 import android.util.Log;
 
 import com.google.android.gms.location.FusedLocationProviderClient;
-import com.mobiledgex.matchingengine.util.MexLocation;
+import com.mobiledgex.matchingengine.util.MeLocation;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -151,10 +151,10 @@ public class LimitsTest {
     public void basicLatencyTest() {
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context, Executors.newFixedThreadPool(20));
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
         Location location;
         AppClient.VerifyLocationReply verifyLocationReply1 = null;
         AppClient.VerifyLocationReply verifyLocationReply2 = null;
@@ -167,7 +167,7 @@ public class LimitsTest {
         long elapsed2[] = new long[20];
         try {
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             long sum1 = 0, sum2 = 0;
@@ -240,10 +240,10 @@ public class LimitsTest {
         final String TAG = "basicLatencyTestConcurrent";
         Context context = InstrumentationRegistry.getTargetContext();
         MatchingEngine me = new MatchingEngine(context);
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
         Location location;
         AppClient.VerifyLocationReply verifyLocationReply1 = null;
 
@@ -256,7 +256,7 @@ public class LimitsTest {
         final AppClient.VerifyLocationReply responses[] = new AppClient.VerifyLocationReply[elapsed2.length];
         try {
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             long sum2 = 0;
@@ -369,10 +369,10 @@ public class LimitsTest {
         MatchingEngine me = new MatchingEngine(context, Executors.newWorkStealingPool(threadPoolSize));
 
         final long start = System.currentTimeMillis();
-        me.setMexLocationAllowed(true);
+        me.setMatchingEngineLocationAllowed(true);
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
-        MexLocation mexLoc = new MexLocation(me);
+        MeLocation meLoc = new MeLocation(me);
         Location location;
 
         enableMockLocation(context,true);
@@ -383,7 +383,7 @@ public class LimitsTest {
         final AppClient.VerifyLocationReply responses[] = new AppClient.VerifyLocationReply[elapsed.length];
         try {
             setMockLocation(context, loc);
-            location = mexLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
             assertFalse(location == null);
 
             long sum = 0;

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AddUserToGroup.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AddUserToGroup.java
@@ -33,8 +33,8 @@ public class AddUserToGroup implements Callable {
                               String host, int port, long timeoutInMilliseconds) {
         if (request == null) {
             throw new IllegalArgumentException("Request object must not be null.");
-        } else if (!mMatchingEngine.isMexLocationAllowed()) {
-            Log.e(TAG, "Mex MatchEngine is disabled.");
+        } else if (!mMatchingEngine.isMatchingEngineLocationAllowed()) {
+            Log.e(TAG, "MatchingEngine location is disabled.");
             mRequest = null;
             return false;
         }
@@ -73,9 +73,9 @@ public class AddUserToGroup implements Callable {
                     .addUserToGroup(mRequest);
 
             // Nothing a sdk user can do below but read the exception cause:
-        } catch (MexKeyStoreException mkse) {
+        } catch (MatchingEngineKeyStoreException mkse) {
             throw new ExecutionException("Exception calling AddUserToGroup: ", mkse);
-        } catch (MexTrustStoreException mtse) {
+        } catch (MatchingEngineTrustStoreException mtse) {
             throw new ExecutionException("Exception calling AddUserToGroup: ", mtse);
         } catch (KeyManagementException kme) {
             throw new ExecutionException("Exception calling AddUserToGroup: ", kme);

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
@@ -32,8 +32,8 @@ public class FindCloudlet implements Callable {
     public boolean setRequest(FindCloudletRequest request, String host,  int port, long timeoutInMilliseconds) {
         if (request == null) {
             throw new IllegalArgumentException("Request object must not be null.");
-        } else if (!mMatchingEngine.isMexLocationAllowed()) {
-            Log.e(TAG, "Mex Location is disabled.");
+        } else if (!mMatchingEngine.isMatchingEngineLocationAllowed()) {
+            Log.e(TAG, "MatchingEngine location is disabled.");
             mRequest = null;
             return false;
         }
@@ -73,9 +73,9 @@ public class FindCloudlet implements Callable {
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .findCloudlet(mRequest);
             // Nothing a sdk user can do below but read the exception cause:
-        } catch (MexKeyStoreException mkse) {
+        } catch (MatchingEngineKeyStoreException mkse) {
             throw new ExecutionException("Exception calling FindCloudlet: ", mkse);
-        } catch (MexTrustStoreException mtse) {
+        } catch (MatchingEngineTrustStoreException mtse) {
             throw new ExecutionException("Exception calling FindCloudlet: ", mtse);
         } catch (KeyManagementException kme) {
             throw new ExecutionException("Exception calling FindCloudlet: ", kme);

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetAppInstList.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetAppInstList.java
@@ -33,8 +33,8 @@ public class GetAppInstList implements Callable {
                               int port, long timeoutInMilliseconds) {
         if (request == null) {
             throw new IllegalArgumentException("Request object must not be null.");
-        } else if (!mMatchingEngine.isMexLocationAllowed()) {
-            Log.e(TAG, "Mex Location is disabled.");
+        } else if (!mMatchingEngine.isMatchingEngineLocationAllowed()) {
+            Log.e(TAG, "MatchingEngine location is disabled.");
             mRequest = null;
             return false;
         }
@@ -76,9 +76,9 @@ public class GetAppInstList implements Callable {
 
 
             // Nothing a sdk user can do below but read the exception cause:
-        } catch (MexKeyStoreException mkse) {
+        } catch (MatchingEngineKeyStoreException mkse) {
             throw new ExecutionException("Exception calling GetAppInstList: ", mkse);
-        } catch (MexTrustStoreException mtse) {
+        } catch (MatchingEngineTrustStoreException mtse) {
             throw new ExecutionException("Exception calling GetAppInstList: ", mtse);
         } catch (KeyManagementException kme) {
             throw new ExecutionException("Exception calling GetAppInstList: ", kme);

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetLocation.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetLocation.java
@@ -9,7 +9,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import distributed_match_engine.AppClient;
 import distributed_match_engine.AppClient.GetLocationRequest;
 import distributed_match_engine.AppClient.GetLocationReply;
 import distributed_match_engine.MatchEngineApiGrpc;
@@ -34,8 +33,8 @@ public class GetLocation implements Callable {
                               long timeoutInMilliseconds) {
         if (request == null) {
             throw new IllegalArgumentException("Request object must not be null.");
-        } else if (!mMatchingEngine.isMexLocationAllowed()) {
-            Log.e(TAG, "Mex Location is disabled.");
+        } else if (!mMatchingEngine.isMatchingEngineLocationAllowed()) {
+            Log.e(TAG, "MatchingEngine location is disabled.");
             mRequest = null;
             return false;
         }
@@ -76,9 +75,9 @@ public class GetLocation implements Callable {
                     .getLocation(mRequest);
 
             // Nothing a sdk user can do below but read the exception cause:
-        } catch (MexKeyStoreException mkse) {
+        } catch (MatchingEngineKeyStoreException mkse) {
             throw new ExecutionException("Exception calling GetLocation: ", mkse);
-        } catch (MexTrustStoreException mtse) {
+        } catch (MatchingEngineTrustStoreException mtse) {
             throw new ExecutionException("Exception calling GetLocation: ", mtse);
         } catch (KeyManagementException kme) {
             throw new ExecutionException("Exception calling GetLocation: ", kme);

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngineKeyStoreException.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngineKeyStoreException.java
@@ -1,0 +1,7 @@
+package com.mobiledgex.matchingengine;
+
+public class MatchingEngineKeyStoreException extends Exception {
+    public MatchingEngineKeyStoreException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngineTrustStoreException.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngineTrustStoreException.java
@@ -1,0 +1,7 @@
+package com.mobiledgex.matchingengine;
+
+public class MatchingEngineTrustStoreException extends Exception {
+    public MatchingEngineTrustStoreException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MexKeyStoreException.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MexKeyStoreException.java
@@ -1,7 +1,0 @@
-package com.mobiledgex.matchingengine;
-
-public class MexKeyStoreException extends Exception {
-    public MexKeyStoreException(String message, Exception cause) {
-        super(message, cause);
-    }
-}

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MexTrustStoreException.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MexTrustStoreException.java
@@ -1,7 +1,0 @@
-package com.mobiledgex.matchingengine;
-
-public class MexTrustStoreException extends Exception {
-    public MexTrustStoreException(String message, Exception cause) {
-        super(message, cause);
-    }
-}

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
@@ -32,8 +32,8 @@ public class RegisterClient implements Callable {
     public boolean setRequest(AppClient.RegisterClientRequest request, String host, int port, long timeoutInMilliseconds) {
         if (request == null) {
             throw new IllegalArgumentException("Request object must not be null.");
-        } else if (!mMatchingEngine.isMexLocationAllowed()) {
-            Log.e(TAG, "Mex Location is disabled.");
+        } else if (!mMatchingEngine.isMatchingEngineLocationAllowed()) {
+            Log.e(TAG, "MatchingEngine location is disabled.");
             mRequest = null;
             return false;
         }
@@ -76,9 +76,9 @@ public class RegisterClient implements Callable {
                     .registerClient(mRequest);
 
             // Nothing a sdk user can do below but read the exception cause:
-        } catch (MexKeyStoreException mkse) {
+        } catch (MatchingEngineKeyStoreException mkse) {
             throw new ExecutionException("Exception calling RegisterClient: ", mkse);
-        } catch (MexTrustStoreException mtse) {
+        } catch (MatchingEngineTrustStoreException mtse) {
             throw new ExecutionException("Exception calling RegisterClient: ", mtse);
         } catch (KeyManagementException kme) {
             throw new ExecutionException("Exception calling RegisterClient: ", kme);

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
@@ -39,8 +39,8 @@ public class VerifyLocation implements Callable {
                               String host, int port, long timeoutInMilliseconds) {
         if (request == null) {
             throw new IllegalArgumentException("Request object must not be null.");
-        } else if (!mMatchingEngine.isMexLocationAllowed()) {
-            Log.e(TAG, "Mex Location is disabled.");
+        } else if (!mMatchingEngine.isMatchingEngineLocationAllowed()) {
+            Log.e(TAG, "MatchingEngine location is disabled.");
             mRequest = null;
             return false;
         }
@@ -126,9 +126,9 @@ public class VerifyLocation implements Callable {
                     .verifyLocation(grpcRequest);
 
             // Nothing a sdk user can do below but read the exception cause:
-        } catch (MexKeyStoreException mkse) {
+        } catch (MatchingEngineKeyStoreException mkse) {
             throw new ExecutionException("Exception calling VerifyLocation: ", mkse);
-        } catch (MexTrustStoreException mtse) {
+        } catch (MatchingEngineTrustStoreException mtse) {
             throw new ExecutionException("Exception calling VerifyLocation: ", mtse);
         } catch (KeyManagementException kme) {
             throw new ExecutionException("Exception calling VerifyLocation: ", kme);

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/util/MeLocation.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/util/MeLocation.java
@@ -18,9 +18,9 @@ import java.util.concurrent.Future;
 import android.util.Log;
 
 
-
-public class MexLocation {
-    private static final String TAG = "MexLocation";
+// Simple util class for last known location.
+public class MeLocation {
+    private static final String TAG = "MeLocation";
     private MatchingEngine mMatchingEngine;
     private Location mLocation;
     private volatile boolean mWaitingForNotify = false;
@@ -96,7 +96,7 @@ public class MexLocation {
     }
 
 
-    public MexLocation(MatchingEngine matchingEngine) {
+    public MeLocation(MatchingEngine matchingEngine) {
         mMatchingEngine = matchingEngine;
     }
 


### PR DESCRIPTION
Update example code to check before trying to call DME. If there's no active subscriptions, there's no network path to MobiledgeX DME typically, and should fail. No reason to find cloudlet, or verify location, the app should use public cloud at this point.

Updated the rest of the UI: Mex --> MatchingEngine.

Fixed the First Time Use example XML so that it compiles on newer ADKs (lint complains the text is not horizontally anchored). Offending text is now horizontally centered. 