### PR TITLE
fixed command line arg bug for crm unit tests

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/crm_server_test.go
+++ b/cloud-resource-manager/cmd/crmserver/crm_server_test.go
@@ -151,7 +151,7 @@ func TestCRM(t *testing.T) {
 
 	os.Args = append(os.Args, "-cloudletKey")
 	os.Args = append(os.Args, string(bytes))
-	os.Args = append(os.Args, "-notifyCtlAddrs")
+	os.Args = append(os.Args, "-notifyAddrs")
 	os.Args = append(os.Args, notifyAddr)
 	mainDone, err := startMain(t)
 	if err != nil {


### PR DESCRIPTION
command line arg (notifyAddrs) for crm was changed and then I decided to change it back to its original when merging shepherd and forgot to fix the unit tests for it