### PR TITLE
wait for appinst delete

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -13,13 +13,17 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+const WaitDeleted string = "WaitDeleted"
+const WaitRunning string = "WaitRunning"
+
 // This is half of the default controller AppInst timeout
 var maxWait = 15 * time.Minute
 
-// WaitForAppInst waits for pods to either start or result in an error
-func WaitForAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.App) error {
+// WaitForAppInst waits for pods to either start or result in an error if WaitRunning specified,
+// or if WaitDeleted is specified then wait for them to all disappear.
+func WaitForAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.App, waitFor string) error {
 	// wait half as long as the total controller wait time, which includes all tasks
-	log.DebugLog(log.DebugLevelMexos, "waiting for appinst pods", "appName", app.Key.Name, "maxWait", maxWait)
+	log.DebugLog(log.DebugLevelMexos, "waiting for appinst pods", "appName", app.Key.Name, "maxWait", maxWait, "waitFor", waitFor)
 	start := time.Now()
 
 	// it might be nicer to pull the state directly rather than parsing it, but the states displayed
@@ -69,6 +73,8 @@ func WaitForAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.A
 							fallthrough
 						case "ContainerCreating":
 							log.DebugLog(log.DebugLevelMexos, "still waiting for pod", "podName", podName, "state", podState)
+						case "Terminating":
+							log.DebugLog(log.DebugLevelMexos, "pod is terminating", "podName", podName, "state", podState)
 						default:
 							// try to find out what error was
 							// TODO: pull events and send
@@ -83,12 +89,22 @@ func WaitForAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.A
 							return fmt.Errorf("Pod is unexpected state: %s", podState)
 						}
 					} else {
+						if waitFor == WaitDeleted && strings.Contains(line, "No resources found") {
+							break
+						}
 						return fmt.Errorf("unable to parse kubectl output: [%s]", line)
 					}
 				}
-				if podCount == runningCount {
-					log.DebugLog(log.DebugLevelMexos, "all pods up", "deployment name", deployment.ObjectMeta.Name)
-					break
+				if waitFor == WaitDeleted {
+					if podCount == 0 {
+						log.DebugLog(log.DebugLevelMexos, "all pods gone", "deployment name", deployment.ObjectMeta.Name)
+						break
+					}
+				} else {
+					if podCount == runningCount {
+						log.DebugLog(log.DebugLevelMexos, "all pods up", "deployment name", deployment.ObjectMeta.Name)
+						break
+					}
 				}
 				elapsed := time.Since(start)
 				if elapsed >= (maxWait) {
@@ -145,7 +161,10 @@ func DeleteAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.Ap
 		}
 	}
 	log.DebugLog(log.DebugLevelMexos, "deleted deployment", "name", names.AppName)
-	return nil
+	//Note wait for deletion of appinst can be done here in a generic place, but wait for creation is split
+	// out in each platform specific task so that we can optimize the time taken for create by allowing the
+	// wait to be run in parallel with other tasks
+	return WaitForAppInst(client, names, app, WaitDeleted)
 }
 
 func GetAppInstRuntime(client pc.PlatformClient, names *KubeNames, app *edgeproto.App, appInst *edgeproto.AppInst) (*edgeproto.AppInstRuntime, error) {

--- a/cloud-resource-manager/platform/dind/dind-appinst.go
+++ b/cloud-resource-manager/platform/dind/dind-appinst.go
@@ -46,7 +46,7 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	if appDeploymentType == cloudcommon.AppDeploymentTypeKubernetes {
 		err = k8smgmt.CreateAppInst(client, names, app, appInst)
 		if err == nil {
-			err = k8smgmt.WaitForAppInst(client, names, app)
+			err = k8smgmt.WaitForAppInst(client, names, app, k8smgmt.WaitRunning)
 		}
 	} else if appDeploymentType == cloudcommon.AppDeploymentTypeHelm {
 		err = k8smgmt.CreateHelmAppInst(client, names, clusterInst, app, appInst)


### PR DESCRIPTION
EDGECLOUD-877

If an appinst is deleted and then quickly re-created it may fail.  The reason is that the create checks the state and it may be in "terminating"

The fix is to not return from delete until the pod is actually gone.  Uses the wait waitForAppinst as Create uses. Added an extra parameter to this function to differentiate create vs delete.

Note that waitForAppInst in the create is done in per-platform specific code so that we can optimize the waiting by doing it in parallel with other tasks.  But in the delete case we just keep it simple and do it all in serial, this means the wait can be done in just one location

There is also an infra portion to this fix.