### PR TITLE
Initial PredictiveQOS classes and test case.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -21,6 +21,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -470,7 +472,7 @@ public class EngineCallTest {
 
         if (findCloudletReply != null) {
             // Temporary.
-            assertEquals("App's expected test cloudlet FQDN doesn't match.", "mobiledgexmobiledgexsdkdemo10.westindia-mexdemo.azure.mobiledgex.net", findCloudletReply.getFqdn());
+            assertEquals("App's expected test cloudlet FQDN doesn't match.", "mobiledgexmobiledgexsdkdemo10.mexdemo-app-cluster.koreacentral-mexdemo.azure.mobiledgex.net", findCloudletReply.getFqdn());
         } else {
             assertFalse("No findCloudlet response!", false);
         }
@@ -514,7 +516,7 @@ public class EngineCallTest {
         }
 
         // Temporary.
-        assertEquals("Fully qualified domain name not epected.", "mobiledgexmobiledgexsdkdemo10.westindia-mexdemo.azure.mobiledgex.net", result.getFqdn());
+        assertEquals("Fully qualified domain name not expected.", "mobiledgexmobiledgexsdkdemo10.mexdemo-app-cluster.koreacentral-mexdemo.azure.mobiledgex.net", result.getFqdn());
 
     }
 
@@ -913,7 +915,7 @@ public class EngineCallTest {
 
             assertEquals(0, list.getVer());
             assertEquals(AppClient.AppInstListReply.AIStatus.AI_SUCCESS, list.getStatus());
-            assertEquals(3, list.getCloudletsCount()); // NOTE: This is entirely test server dependent.
+            assertEquals(1, list.getCloudletsCount()); // NOTE: This is entirely test server dependent.
             for (int i = 0; i < list.getCloudletsCount(); i++) {
                 Log.v(TAG, "Cloudlet: " + list.getCloudlets(i).toString());
             }
@@ -963,7 +965,7 @@ public class EngineCallTest {
 
             assertEquals(0, list.getVer());
             assertEquals(AppClient.AppInstListReply.AIStatus.AI_SUCCESS, list.getStatus());
-            assertEquals(3, list.getCloudletsCount()); // NOTE: This is entirely test server dependent.
+            assertEquals(1, list.getCloudletsCount()); // NOTE: This is entirely test server dependent.
             for (int i = 0; i < list.getCloudletsCount(); i++) {
                 Log.v(TAG, "Cloudlet: " + list.getCloudlets(i).toString());
             }
@@ -981,4 +983,60 @@ public class EngineCallTest {
             enableMockLocation(context,false);
         }
     }
+
+    @Test
+    public void getQosPositionKpiTest() {
+        Context context = InstrumentationRegistry.getContext();
+
+        MatchingEngine me = new MatchingEngine(context);
+        me.setMatchingEngineLocationAllowed(true);
+        me.setAllowSwitchIfNoSubscriberInfo(true);
+
+        enableMockLocation(context,true);
+        Location location = MockUtils.createLocation("getQosPositionKpiTest", 122.3321, 47.6062);
+        MeLocation meLoc = new MeLocation(me);
+
+        try {
+            setMockLocation(context, location);
+            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
+            assertFalse("Mock'ed Location is missing!", location == null);
+
+            registerClient(context, me.retrieveNetworkCarrierName(context), me);
+
+            double totalDistanceKm = 200;
+            double increment = 0.1;
+            double direction = 45d;
+
+            ArrayList<AppClient.QosPosition> kpiRequests = MockUtils.createQosPositionArray(location, direction, totalDistanceKm, increment);
+
+            AppClient.QosPositionKpiRequest request = me.createQoSKPIRequest(kpiRequests);
+            assertFalse("SessionCookie must not be empty.", request.getSessionCookie().isEmpty());
+
+
+            ChannelIterator<AppClient.QosPositionKpiReply> responseIterator = me.getQosPositionKpi(request, hostOverride, portOverride, GRPC_TIMEOUT_MS);
+            // A stream of QosPositionKpiReply(s), with a non-stream block of responses.
+            long total = 0;
+            while (responseIterator.hasNext()) {
+                AppClient.QosPositionKpiReply aR = responseIterator.next();
+                for (int i = 0; i < aR.getPositionResultsCount(); i++) {
+                    System.out.println(aR.getPositionResults(i));
+                }
+                total += aR.getPositionResultsCount();
+            }
+            assertEquals((long)(kpiRequests.size()), total);
+        } catch (ExecutionException ee) {
+            Log.i(TAG, Log.getStackTraceString(ee));
+            assertFalse("queryQosKpiTest: ExecutionException!", true);
+        } catch (StatusRuntimeException sre) {
+            Log.i(TAG, Log.getStackTraceString(sre));
+            assertFalse("queryQosKpiTest: StatusRuntimeException!", true);
+        } catch (InterruptedException ie) {
+            Log.i(TAG, Log.getStackTraceString(ie));
+            assertFalse("queryQosKpiTest: InterruptedException!", true);
+        } finally {
+            enableMockLocation(context,false);
+        }
+
+    }
+
 }

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/ChannelIterator.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/ChannelIterator.java
@@ -1,0 +1,36 @@
+package com.mobiledgex.matchingengine;
+
+import java.util.Iterator;
+
+import io.grpc.ManagedChannel;
+
+/**
+ * Simple Iterator wrapper that keeps a GRPC channel reference alive to read data from that channel.
+ * This holds a channel resource until no longer referenced.
+ * @param <T>
+ */
+public class ChannelIterator<T> implements Iterator<T> {
+
+    private ManagedChannel mManagedChannel;
+    private Iterator<T> mIterator;
+
+    public ChannelIterator (ManagedChannel channel, Iterator<T> iterator) {
+        mManagedChannel = channel;
+        mIterator = iterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return mIterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+        return mIterator.next();
+    }
+
+    @Override
+    public void remove() {
+        mIterator.remove();
+    }
+}

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
@@ -29,7 +29,7 @@ public class FindCloudlet implements Callable {
         mMatchingEngine = matchingEngine;
     }
 
-    public boolean setRequest(FindCloudletRequest request, String host,  int port, long timeoutInMilliseconds) {
+    public boolean setRequest(FindCloudletRequest request, String host, int port, long timeoutInMilliseconds) {
         if (request == null) {
             throw new IllegalArgumentException("Request object must not be null.");
         } else if (!mMatchingEngine.isMatchingEngineLocationAllowed()) {
@@ -93,7 +93,6 @@ public class FindCloudlet implements Callable {
             }
         }
 
-        // Let MatchingEngine know of the latest cookie.
         mMatchingEngine.setFindCloudletResponse(reply);
         return reply;
     }

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -20,6 +20,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -38,6 +39,10 @@ import distributed_match_engine.AppClient.GetLocationRequest;
 import distributed_match_engine.AppClient.GetLocationReply;
 import distributed_match_engine.AppClient.AppInstListRequest;
 import distributed_match_engine.AppClient.AppInstListReply;
+import distributed_match_engine.AppClient.QosPositionKpiRequest;
+import distributed_match_engine.AppClient.QosPositionKpiReply;
+import distributed_match_engine.AppClient.QosPosition;
+
 
 import distributed_match_engine.AppClient.DynamicLocGroupRequest;
 import distributed_match_engine.AppClient.DynamicLocGroupReply;
@@ -414,6 +419,13 @@ public class MatchingEngine {
                 .setLgId(1001L) // FIXME: NOT IMPLEMENTED
                 .setCommType(commType)
                 .setUserData(userData == null ? "" : userData)
+                .build();
+    }
+
+    public QosPositionKpiRequest createQoSKPIRequest(List<QosPosition> requests) {
+        return QosPositionKpiRequest.newBuilder()
+                .setSessionCookie(mSessionCookie)
+                .addAllPositions(requests)
                 .build();
     }
 
@@ -804,6 +816,25 @@ public class MatchingEngine {
         GetAppInstList getAppInstList = new GetAppInstList(this);
         getAppInstList.setRequest(request, host, port, timeoutInMilliseconds);
         return submit(getAppInstList);
+    }
+
+    /**
+     * Request QOS values from a list of PositionKPIRequests, and returns a stream Iterator of predicted QOS values.
+     * @param request
+     * @param host
+     * @param port
+     * @param timeoutInMilliseconds
+     * @return
+     * @throws InterruptedException
+     * @throws ExecutionException
+     */
+    public ChannelIterator<QosPositionKpiReply> getQosPositionKpi(QosPositionKpiRequest request, String host, int port,
+                                                   long timeoutInMilliseconds)
+            throws InterruptedException, ExecutionException {
+
+        QosPositionKpi qosPositionKpi = new QosPositionKpi(this);
+        qosPositionKpi.setRequest(request, host, port, timeoutInMilliseconds);
+        return qosPositionKpi.call();
     }
 
     //

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPositionKpi.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPositionKpi.java
@@ -1,0 +1,104 @@
+package com.mobiledgex.matchingengine;
+
+import android.util.Log;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+
+import distributed_match_engine.MatchEngineApiGrpc;
+import distributed_match_engine.AppClient;
+import distributed_match_engine.AppClient.QosPositionKpiRequest;
+import distributed_match_engine.AppClient.QosPositionKpiReply;
+
+public class QosPositionKpi implements Callable {
+    public static final String TAG = "QueryQosKpi";
+    private MatchingEngine mMatchingEngine;
+    private AppClient.QosPositionKpiRequest mQosPositionKpiRequest;
+    private String mHost;
+    private int mPort;
+    private long mTimeoutInMilliseconds;
+
+    QosPositionKpi(MatchingEngine matchingEngine) {
+        mMatchingEngine = matchingEngine;
+    }
+
+    boolean setRequest(QosPositionKpiRequest qosPositionKpiRequest, String host, int port, long timeoutInMilliseconds) throws IllegalArgumentException {
+        if (!mMatchingEngine.isMatchingEngineLocationAllowed()) {
+            Log.e(TAG, "MobiledgeX location is disabled.");
+            mQosPositionKpiRequest = null;
+            return false;
+        }
+
+        if (qosPositionKpiRequest == null) {
+            throw new IllegalArgumentException("Missing " + TAG + " Argument!");
+        }
+
+        if (qosPositionKpiRequest.getPositionsCount() == 0) {
+            throw new IllegalArgumentException("PredictiveQos Request missing entries!");
+        }
+
+        if (host == null || host.equals("")) {
+            throw new IllegalArgumentException("Host destination is required.");
+        }
+        if (port < 0) {
+            throw new IllegalArgumentException("Port number must be positive.");
+        }
+        if (timeoutInMilliseconds <= 0) {
+            throw new IllegalArgumentException("PredictiveQos Request timeout must be positive.");
+        }
+        mTimeoutInMilliseconds = timeoutInMilliseconds;
+
+        mHost = host;
+        mPort = port == 0 ? mMatchingEngine.getPort() : port; // Using engine default port.
+
+        mQosPositionKpiRequest = qosPositionKpiRequest;
+
+        return true;
+    }
+
+    @Override
+    public ChannelIterator<QosPositionKpiReply> call() throws MissingRequestException, StatusRuntimeException, InterruptedException, ExecutionException {
+        if (mQosPositionKpiRequest == null) {
+            throw new MissingRequestException("Usage error: QueryQosKpi does not have a request object to use MatchingEngine!");
+        }
+
+        Iterator<QosPositionKpiReply> response;
+        ManagedChannel channel;
+        NetworkManager nm = null;
+        try {
+            channel = mMatchingEngine.channelPicker(mHost, mPort);
+            MatchEngineApiGrpc.MatchEngineApiBlockingStub stub = MatchEngineApiGrpc.newBlockingStub(channel);
+
+            nm = mMatchingEngine.getNetworkManager();
+            nm.switchToCellularInternetNetworkBlocking();
+
+            response = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
+                    .getQosPositionKpi(mQosPositionKpiRequest);
+        } catch (MatchingEngineKeyStoreException mkse) {
+            throw new ExecutionException("Exception calling QueryQosKpi: ", mkse);
+        } catch (MatchingEngineTrustStoreException mtse) {
+            throw new ExecutionException("Exception calling QueryQosKpi: ", mtse);
+        } catch (KeyManagementException kme) {
+            throw new ExecutionException("Exception calling QueryQosKpi: ", kme);
+        } catch (NoSuchAlgorithmException nsa) {
+            throw new ExecutionException("Exception calling QueryQosKpi: ", nsa);
+        } catch (IOException ioe) {
+            throw new ExecutionException("Exception calling QueryQosKpi: ", ioe);
+        } finally {
+            if (nm != null) {
+                nm.resetNetworkToDefault();
+            }
+        }
+
+        return new ChannelIterator<>(channel, response);
+    }
+}


### PR DESCRIPTION
PredictiveQoS Android SDK API and Test code only using the GRPC interface currently presented on mexdemo.dme.mobiledgex.com.

Channel lifetime: The answer for now, is to make the SDK API user handle the stream closed exception instead of trying to guess what the backend is going to do with the QosPositionKpiReply stream.

This version does not have HealthCheck API.

The app side implementation is probably better in some other App than the "Simple" example app.