### PR TITLE
Shepherd not in edge-cloud entrypoint in docker

### DIFF
--- a/docker/edge-cloud-entrypoint.sh
+++ b/docker/edge-cloud-entrypoint.sh
@@ -45,6 +45,10 @@ case "$1" in
 	shift
 	test-edgectl.sh $*
 	;;
+    shepherd)
+	shift
+	shepherd $*
+	;;
     version)
 	shift
 	cat /version.txt


### PR DESCRIPTION
Follow-up to the commit adding the shepherd binary to docker.