### PR TITLE
Predictive qos improvements to Android SDK

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "1.4.4"
+        versionName "1.4.6"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/edge-mvp/android/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -818,8 +818,47 @@ public class MatchingEngine {
         return submit(getAppInstList);
     }
 
+
     /**
-     * Request QOS values from a list of PositionKPIRequests, and returns a stream Iterator of predicted QOS values.
+     * Request QOS values from a list of PositionKPIRequests, and returns a stream Iterator of
+     * predicted QOS values.
+     * @param request
+     * @param timeoutInMilliseconds
+     * @return
+     * @throws InterruptedException
+     * @throws ExecutionException
+     */
+    public ChannelIterator<QosPositionKpiReply> getQosPositionKpi(QosPositionKpiRequest request,
+                                                                  long timeoutInMilliseconds)
+            throws InterruptedException, ExecutionException {
+
+        String carrierName = retrieveNetworkCarrierName(mContext);
+        QosPositionKpi qosPositionKpi = new QosPositionKpi(this);
+        qosPositionKpi.setRequest(request,generateDmeHostAddress(carrierName), getPort(), timeoutInMilliseconds);
+        return qosPositionKpi.call();
+    }
+
+    /**
+     * Request QOS values from a list of PositionKPIRequests, and returns an asynchronous Future
+     * for a stream Iterator of predicted QOS values.
+     * @param request
+     * @param timeoutInMilliseconds
+     * @return
+     * @throws InterruptedException
+     * @throws ExecutionException
+     */
+    public Future<ChannelIterator<QosPositionKpiReply>> getQosPositionKpiFuture(QosPositionKpiRequest request,
+                                                                  long timeoutInMilliseconds)
+            throws InterruptedException, ExecutionException {
+
+        String carrierName = retrieveNetworkCarrierName(mContext);
+        QosPositionKpi qosPositionKpi = new QosPositionKpi(this);
+        qosPositionKpi.setRequest(request,generateDmeHostAddress(carrierName), getPort(), timeoutInMilliseconds);
+        return submit(qosPositionKpi);
+    }
+    /**
+     * Request QOS values from a list of PositionKPIRequests, and returns a stream Iterator of
+     * predicted QOS values.
      * @param request
      * @param host
      * @param port
@@ -828,13 +867,36 @@ public class MatchingEngine {
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    public ChannelIterator<QosPositionKpiReply> getQosPositionKpi(QosPositionKpiRequest request, String host, int port,
-                                                   long timeoutInMilliseconds)
+    public ChannelIterator<QosPositionKpiReply> getQosPositionKpi(QosPositionKpiRequest request,
+                                                                  String host, int port,
+                                                                  long timeoutInMilliseconds)
             throws InterruptedException, ExecutionException {
 
         QosPositionKpi qosPositionKpi = new QosPositionKpi(this);
         qosPositionKpi.setRequest(request, host, port, timeoutInMilliseconds);
         return qosPositionKpi.call();
+    }
+
+    /**
+     * Request QOS values from a list of PositionKPIRequests, and returns an asynchronous Future
+     * for a stream Iterator of predicted QOS values.
+     *
+     * @param request
+     * @param host
+     * @param port
+     * @param timeoutInMilliseconds
+     * @return
+     * @throws InterruptedException
+     * @throws ExecutionException
+     */
+    public Future<ChannelIterator<QosPositionKpiReply>> getQosPositionKpiFuture(QosPositionKpiRequest request,
+                                                                                String host, int port,
+                                                                                long timeoutInMilliseconds)
+            throws InterruptedException, ExecutionException {
+
+        QosPositionKpi qosPositionKpi = new QosPositionKpi(this);
+        qosPositionKpi.setRequest(request, host, port, timeoutInMilliseconds);
+        return submit(qosPositionKpi);
     }
 
     //


### PR DESCRIPTION
Predictive QoSPositionKpi {default, (host, port)}, synchronous, Future} versions in Android v1.4.6. Tests added for Future version using host and port. The only thing calling this is the test cases. UI work needs to be done in some non-trivial app.