### PR TITLE
fix tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
-	github.com/uber/prototool v1.8.0 // indirect
+	github.com/uber/prototool v1.8.1 // indirect
 	github.com/ugorji/go v1.1.4 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/xanzy/go-gitlab v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -485,6 +485,8 @@ github.com/uber/prototool v1.7.0 h1:Ovi+LHB4CX6p1BpDSx5HHbsUV/HJhf0B13DvM0Czvf0=
 github.com/uber/prototool v1.7.0/go.mod h1:0o3beySzHomA5oaVIGTR9z5lkPtjy4mbFuDpqIaNyT4=
 github.com/uber/prototool v1.8.0 h1:AByDUuTG5nphja3+APWR04YPUjp7Ac0fZp/St1RKHlY=
 github.com/uber/prototool v1.8.0/go.mod h1:E+xJFE/vf87XeqHbKM4uGQMrJ7NyKQb0+G7NtqHBgYs=
+github.com/uber/prototool v1.8.1 h1:wlba8JLLuyTn0a7W6AqLrecGypFkrGOb+TwciSrW/rg=
+github.com/uber/prototool v1.8.1/go.mod h1:E+xJFE/vf87XeqHbKM4uGQMrJ7NyKQb0+G7NtqHBgYs=
 github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -582,6 +584,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqYSEQ0KWqdWLu3xuZJts=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/setup-env/setup-mex/setup-mex.go
+++ b/setup-env/setup-mex/setup-mex.go
@@ -3,7 +3,6 @@ package setupmex
 // consists of utilities used to deploy, start, stop MEX processes either locally or remotely via Ansible.
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -175,14 +174,6 @@ func ReadSetupFile(setupfile string, deployment interface{}, vars map[string]str
 				fmt.Fprintf(os.Stderr, "One or more fatal unmarshal errors in %s", setupfile)
 				return false
 			}
-		}
-	}
-	// TODO: currently support just one influx.json
-	for _, v := range util.Deployment.Influxs {
-		creds_file := "/tmp/influx.json"
-		creds_json, err := json.Marshal(v.Auth)
-		if err == nil {
-			ioutil.WriteFile(creds_file, creds_json, 0644)
 		}
 	}
 	//equals sign is not well handled in yaml so it is url encoded and changed after loading
@@ -458,6 +449,11 @@ func StartProcesses(processName string, outputDir string) bool {
 		opts = append(opts, process.WithCleanStartup())
 	}
 
+	for _, p := range util.Deployment.Influxs {
+		if !StartLocal(processName, outputDir, p, opts...) {
+			return false
+		}
+	}
 	for _, p := range util.Deployment.Vaults {
 		opts = append(opts, process.WithRolesFile(rolesfile))
 		if !StartLocal(processName, outputDir, p, opts...) {
@@ -465,11 +461,6 @@ func StartProcesses(processName string, outputDir string) bool {
 		}
 	}
 	for _, p := range util.Deployment.Etcds {
-		if !StartLocal(processName, outputDir, p, opts...) {
-			return false
-		}
-	}
-	for _, p := range util.Deployment.Influxs {
 		if !StartLocal(processName, outputDir, p, opts...) {
 			return false
 		}


### PR DESCRIPTION
unit-tests and infra e2e tests were failing if /tmp/influx.json didn't exist, which was only being created by "make test" in edge-cloud.
- create /tmp/influx.json in influxdb process
- start influxdb before vault, so the file exists