### PR TITLE
Fix build.gradle typo: maven-release --> maven-releases.

### DIFF
--- a/edge-mvp/android/EmptyMatchEngineApp/build.gradle
+++ b/edge-mvp/android/EmptyMatchEngineApp/build.gradle
@@ -36,7 +36,7 @@ allprojects {
                 username artifactory_user
                 password artifactory_password
             }
-            url "https://artifactory.mobiledgex.net/maven-release/"
+            url "https://artifactory.mobiledgex.net/maven-releases/"
         }
         mavenLocal()
         google()


### PR DESCRIPTION
Fix typo. Apparently didn't fail due to the gradle cache still having it. Swapping repo will show all the classes are missing (old repo).