### PR TITLE
EDGECLOUD-865 fix runcommand for local

### DIFF
--- a/cloud-resource-manager/platform/pc/local.go
+++ b/cloud-resource-manager/platform/pc/local.go
@@ -25,10 +25,8 @@ func (s *LocalClient) Output(command string) (string, error) {
 // Shell requests a shell from the remote. If an arg is passed, it tries to
 // exec them on the server.
 func (s *LocalClient) Shell(sin io.Reader, sout, serr io.Writer, args ...string) error {
-	if len(args) == 0 {
-		args = []string{"/bin/sh"}
-	}
-	cmd := exec.Command(args[0], args[1:]...)
+	args = append([]string{"-c"}, args...)
+	cmd := exec.Command("/bin/sh", args...)
 	tty, err := pty.Start(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
Last fix for 865 fixed runcommand for openstack platforms, but broke it for the local fake platform (which broke e2e tests). Fix is to add back in the "sh" arg that got removed from the crm to fix openstack platforms.