### PR TITLE
EDGECLOUD-767 EDGECLOUD-798 CreateApp kubernetes manifest checks

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -231,10 +231,14 @@ func (s *AppApi) CreateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 	if err != nil {
 		return &edgeproto.Result{}, err
 	}
+	ports, err := edgeproto.ParseAppPorts(in.AccessPorts)
+	if err != nil {
+		return &edgeproto.Result{}, err
+	}
 	if in.DeploymentManifest != "" {
-		err = cloudcommon.IsValidDeploymentManifest(in.Deployment, in.Command, in.DeploymentManifest)
+		err = cloudcommon.IsValidDeploymentManifest(in.Deployment, in.Command, in.DeploymentManifest, ports)
 		if err != nil {
-			return &edgeproto.Result{}, fmt.Errorf("invalid deploymentment manifest %v", err)
+			return &edgeproto.Result{}, fmt.Errorf("invalid deploymentment manifest, %v", err)
 		}
 	}
 

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -70,7 +70,6 @@ func GetTLSClientDialOption(serverAddr string, tlsCertFile string, skipVerify bo
 // Skipverify is only to be used for internal connections such as GRPCGW to GRPC.
 func GetTLSClientConfig(serverAddr string, tlsCertFile string, caCertFile string, skipVerify bool) (*tls.Config, error) {
 	if tlsCertFile == "" {
-		fmt.Println("No TLS cert file")
 		return nil, nil
 	}
 	certPool, err := GetClientCertPool(tlsCertFile, caCertFile)


### PR DESCRIPTION
767: check that kubernetes manifest is "valid". We do this by parsing the manifest to make sure it's parsable.
798: check that ports specified in AccessPorts are present in kubernetes manifest. We do this by parsing the AccessPorts, then checking they are present in the parsed kubernetes manifest.
Extra: removed annoying "no TLS specified" message that kept appearing when using edgectl without tls.