### PR TITLE
Modify testMode flag in controller to skip edge-cloud image verification

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -153,9 +153,10 @@ func updateAppFields(in *edgeproto.App, revision int32) error {
 			if len(parts) < 2 || !strings.Contains(parts[0], ".") {
 				return fmt.Errorf("imagepath should be full registry URL: <domain-name>/<registry-path>")
 			}
-			if !*testMode {
-				err := cloudcommon.ValidateDockerRegistryPath(in.ImagePath, *vaultAddr)
-				if err != nil {
+			if err := cloudcommon.ValidateDockerRegistryPath(in.ImagePath, *vaultAddr); err != nil {
+				if *testMode {
+					log.DebugLog(log.DebugLevelApi, "Warning, could not validate docker registry path.", "err", err)
+				} else {
 					return err
 				}
 			}
@@ -167,9 +168,10 @@ func updateAppFields(in *edgeproto.App, revision int32) error {
 	}
 
 	if in.ImageType == edgeproto.ImageType_IMAGE_TYPE_QCOW {
-		if !*testMode {
-			err := cloudcommon.ValidateVMRegistryPath(in.ImagePath, *vaultAddr)
-			if err != nil {
+		if err := cloudcommon.ValidateVMRegistryPath(in.ImagePath, *vaultAddr); err != nil {
+			if *testMode {
+				log.DebugLog(log.DebugLevelApi, "Warning, could not validate VM registry path.", "err", err)
+			} else {
 				return err
 			}
 		}

--- a/integration/process/process_defs.go
+++ b/integration/process/process_defs.go
@@ -16,18 +16,17 @@ type Etcd struct {
 	cmd            *exec.Cmd
 }
 type Controller struct {
-	Common          `yaml:",inline"`
-	EtcdAddrs       string
-	ApiAddr         string
-	HttpAddr        string
-	NotifyAddr      string
-	VaultAddr       string
-	InfluxAddr      string
-	TLS             TLSCerts
-	ShortTimeouts   bool
-	cmd             *exec.Cmd
-	TestMode        bool
-	SkipImageVerify bool
+	Common        `yaml:",inline"`
+	EtcdAddrs     string
+	ApiAddr       string
+	HttpAddr      string
+	NotifyAddr    string
+	VaultAddr     string
+	InfluxAddr    string
+	TLS           TLSCerts
+	ShortTimeouts bool
+	cmd           *exec.Cmd
+	TestMode      bool
 }
 type Dme struct {
 	Common      `yaml:",inline"`

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -110,9 +110,6 @@ func (p *Controller) StartLocal(logfile string, opts ...StartOp) error {
 	if p.TestMode {
 		args = append(args, "-testMode")
 	}
-	if p.SkipImageVerify {
-		args = append(args, "--skipImageVerify")
-	}
 
 	var envs []string
 	if options.RolesFile != "" {

--- a/setup-env/e2e-tests/setups/local_dind.yml
+++ b/setup-env/e2e-tests/setups/local_dind.yml
@@ -64,7 +64,7 @@ controllers:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
-  skipimageverify: true
+  testmode: true
 
 dmes:
 - name: dme1


### PR DESCRIPTION
DIND was broken due to the controller unable to start without VersionTag.
Had couple of ideas that I was considering:
   1. Have versionTag default to "latest" which is always present
      - decided against it since this would mean we still need to keep global registry secret somewhere in edge-cloud repo
   2. Have a special versionTag like "current" which would mean it's local and no need to check the registry
      - didn't want to overload the command line option
   4. Use testMode option
      - this option has some other side effects, and also seems like overloading an option
   3. Have a separate option that would allow us to skip the versionTag existence for the purpose of local testing
       - which is what I decided on eventually and this is the change here.
