### PR TITLE
EDGECLOUD-909: Artifactory repository names with space gives error

### DIFF
--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -44,7 +44,7 @@ var FlavorData = []edgeproto.Flavor{
 var DevData = []edgeproto.Developer{
 	edgeproto.Developer{
 		Key: edgeproto.DeveloperKey{
-			Name: "Niantic, Inc",
+			Name: "NianticInc",
 		},
 	},
 	edgeproto.Developer{
@@ -54,12 +54,12 @@ var DevData = []edgeproto.Developer{
 	},
 	edgeproto.Developer{
 		Key: edgeproto.DeveloperKey{
-			Name: "1000 realities",
+			Name: "1000realities",
 		},
 	},
 	edgeproto.Developer{
 		Key: edgeproto.DeveloperKey{
-			Name: "Sierraware LLC",
+			Name: "SierrawareLLC",
 		},
 	},
 }

--- a/util/validate.go
+++ b/util/validate.go
@@ -103,9 +103,9 @@ func GitlabGroupSanitize(name string) string {
 }
 
 func ValidOrgName(name string) error {
-	re := regexp.MustCompile("^[a-zA-Z0-9_\\-., ]*$")
+	re := regexp.MustCompile("^[a-zA-Z0-9_\\-.]*$")
 	if !re.MatchString(name) {
-		return fmt.Errorf("Name can only contain letters, digits, _ . - ,")
+		return fmt.Errorf("Name can only contain letters, digits, _ . -")
 	}
 	if !ValidLDAPName(name) {
 		return fmt.Errorf("invalid characters in Name")

--- a/util/validate_test.go
+++ b/util/validate_test.go
@@ -114,4 +114,8 @@ func TestValidOrgName(t *testing.T) {
 	require.NotNil(t, err, "invalid org name")
 	err = ValidOrgName("orgname_123dev.atom")
 	require.NotNil(t, err, "invalid org name")
+	err = ValidOrgName("orgname_123dev test")
+	require.NotNil(t, err, "invalid org name")
+	err = ValidOrgName("orgname_123dev,test")
+	require.NotNil(t, err, "invalid org name")
 }


### PR DESCRIPTION
Artifactory repo names doesn't allow `,` & `space`. Since we form repo name from orgname or developer name, we have to disallow the same for Developer/OrgName.