### PR TITLE
EDGECLOUD-1006: VM AppInstances are missing the public_port and fqdn_prefix field

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -466,9 +466,6 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		} else if !cloudcommon.IsClusterInstReqd(&app) {
 			in.Uri = cloudcommon.GetVMAppFQDN(&in.Key, &in.Key.ClusterInstKey.CloudletKey)
 			for ii, _ := range ports {
-				if setL7Port(&ports[ii], &in.Key) {
-					continue
-				}
 				ports[ii].PublicPort = ports[ii].InternalPort
 			}
 		} else if ipaccess == edgeproto.IpAccess_IP_ACCESS_SHARED && !app.InternalPorts {


### PR DESCRIPTION
* Have added code to show public_port
* Do we really have to show FQDN prefix? As IP assigned to VM is dedicated to VM itself.