### PR TITLE
EDGECLOUD-1029 controllers can talk to each other under kubernetes

### DIFF
--- a/cloud-resource-manager/platform/dind/dind-cluster.go
+++ b/cloud-resource-manager/platform/dind/dind-cluster.go
@@ -69,9 +69,9 @@ func (s *Platform) CreateDINDCluster(clusterName, kconfName string) error {
 	os.Setenv("DIND_LABEL", clusterName)
 	os.Setenv("CLUSTER_ID", GetClusterID(clusterID))
 	cluster := NewClusterFor(clusterName, clusterID)
-	log.DebugLog(log.DebugLevelMexos, "CreateDINDCluster via dind-cluster-v1.13.sh", "name", clusterName, "clusterid", clusterID)
+	log.DebugLog(log.DebugLevelMexos, "CreateDINDCluster via dind-cluster-v1.14.sh", "name", clusterName, "clusterid", clusterID)
 
-	out, err := sh.Command("dind-cluster-v1.13.sh", "up").Command("tee", "/tmp/dind.log").CombinedOutput()
+	out, err := sh.Command("dind-cluster-v1.14.sh", "up").Command("tee", "/tmp/dind.log").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ERROR creating Dind Cluster: [%s] %v", out, err)
 	}
@@ -128,11 +128,11 @@ func (s *Platform) DeleteDINDCluster(name string) error {
 	os.Setenv("CLUSTER_ID", GetClusterID(cluster.ClusterID))
 	log.DebugLog(log.DebugLevelMexos, "DeleteDINDCluster", "name", name)
 
-	out, err = sh.Command("dind-cluster-v1.13.sh", "clean").CombinedOutput()
+	out, err = sh.Command("dind-cluster-v1.14.sh", "clean").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s %v", out, err)
 	}
-	log.DebugLog(log.DebugLevelMexos, "Finished dind-cluster-v1.13.sh clean", "name", name, "out", out)
+	log.DebugLog(log.DebugLevelMexos, "Finished dind-cluster-v1.14.sh clean", "name", name, "out", out)
 	return nil
 }
 

--- a/cloudcommon/registry.go
+++ b/cloudcommon/registry.go
@@ -29,6 +29,7 @@ type RegistryAuth struct {
 	Token    string `json:"token"`
 	ApiKey   string `json:"apikey"`
 	Hostname string `json:"hostname"`
+	Port     string `json:"port"`
 }
 
 type RegistryTags struct {
@@ -66,6 +67,9 @@ func GetRegistryAuth(imgUrl, vaultAddr string) (*RegistryAuth, error) {
 		return nil, err
 	}
 	auth.Hostname = hostname[0]
+	if len(hostname) > 1 {
+		auth.Port = hostname[1]
+	}
 	if auth.Username != "" && auth.Password != "" {
 		auth.AuthType = BasicAuth
 	} else if auth.Token != "" {

--- a/controller/controller_api.go
+++ b/controller/controller_api.go
@@ -89,6 +89,7 @@ func (s *ControllerApi) RunJobs(run func(arg interface{}, addr string) error, ar
 					joberr = err
 				}
 				mux.Unlock()
+				log.DebugLog(log.DebugLevelApi, "run job failed", "addr", ctrlAddr, "err", err)
 			}
 			wg.Done()
 		}(ctrl.Key.Addr)

--- a/controller/node_api.go
+++ b/controller/node_api.go
@@ -84,6 +84,9 @@ func (s *NodeApi) ShowNode(in *edgeproto.Node, cb edgeproto.NodeApi_ShowNodeServ
 		defer cancel()
 
 		stream, err := cmd.ShowNodeLocal(ctx, in)
+		if err != nil {
+			return err
+		}
 		for {
 			obj, err := stream.Recv()
 			if err == io.EOF {

--- a/deploygen/kube.go
+++ b/deploygen/kube.go
@@ -131,6 +131,13 @@ func (g *kubeBasicGen) kubeApp() {
 	if g.app.Command != "" {
 		cs = strings.Split(g.app.Command, " ")
 	}
+	registrySecret := g.app.ImageHost
+	hostname := strings.Split(g.app.ImageHost, ":")
+	if len(hostname) > 1 {
+		// docker-registry secret name use for
+		// "kubectl create secret docker-registry" cannot include ":"
+		registrySecret = hostname[0] + "-" + hostname[1]
+	}
 	data := appData{
 		Name:           util.DNSSanitize(g.app.Name + "-deployment"),
 		DNSName:        util.DNSSanitize(g.app.Name),
@@ -138,7 +145,7 @@ func (g *kubeBasicGen) kubeApp() {
 		Ports:          g.ports,
 		ImagePath:      g.app.ImagePath,
 		Command:        cs,
-		RegistrySecret: g.app.ImageHost,
+		RegistrySecret: registrySecret,
 	}
 	buf := bytes.Buffer{}
 	if g.app.ScaleWithCluster {

--- a/install-dind.sh
+++ b/install-dind.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [ ! -e  /usr/local/bin/dind-cluster-v1.13.sh ]; then
-   wget https://github.com/kubernetes-sigs/kubeadm-dind-cluster/releases/download/v0.1.0/dind-cluster-v1.13.sh
-   mv dind-cluster-v1.13.sh /usr/local/bin/
-   chmod +x /usr/local/bin/dind-cluster-v1.13.sh
+if [ ! -e  /usr/local/bin/dind-cluster-v1.14.sh ]; then
+   wget https://github.com/kubernetes-sigs/kubeadm-dind-cluster/releases/download/v0.3.0/dind-cluster-v1.14.sh
+   mv dind-cluster-v1.14.sh /usr/local/bin/
+   chmod +x /usr/local/bin/dind-cluster-v1.14.sh
 else
-   echo "dind-cluster-v1.13.sh already installed"
+   echo "dind-cluster-v1.14 already installed"
 fi

--- a/setup-env/e2e-tests/setups/local_multi.yml
+++ b/setup-env/e2e-tests/setups/local_multi.yml
@@ -56,7 +56,7 @@ etcds:
 controllers:
 - name: ctrl1
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
-  apiaddr: "0.0.0.0:55001"
+  apiaddr: "127.0.0.1:55001"
   httpaddr: "0.0.0.0:36001"
   notifyaddr: "127.0.0.1:37001"
   tls:
@@ -68,7 +68,7 @@ controllers:
 
 - name: ctrl2
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
-  apiaddr: "0.0.0.0:55002"
+  apiaddr: "127.0.0.1:55002"
   httpaddr: "0.0.0.0:36002"
   notifyaddr: "127.0.0.1:37002"
   tls:


### PR DESCRIPTION
The issue with RunCommand only working intermittently was because Controllers couldn't talk to each other while running under Kubernetes. Controllers figure out how to talk to each other by writing their externalApiAddr to etcd so other controllers can figure out their IP. When under kubernetes this was getting set to 0.0.0.0. Controllers need to be able to talk directly each other, and not through a load balancer.

To fix, controller resolves it's own host name (which kubernetes sets to the CNI IP in /etc/hosts), and replaces 0.0.0.0 with that. Note this conflicts with running controller locally with e2e tests, because the edge-cloud TLS cert is only valid for 127.0.0.1 and 0.0.0.0, and not whatever real IP the laptop/machine has. So controller only does this hostname lookup if externalApiAddr is 0.0.0.0, and not for 127.0.0.1.

I also fixed an issue with not being able to pull images from a registry if a port was specified in the imagepath. This also only works with kubernetes 1.14, not 1.13.