### PR TITLE
EDGECLOUD-879 allow cluster creation without worker nodes

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -154,10 +154,6 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 		if in.NumMasters > 1 {
 			return fmt.Errorf("NumMasters cannot be greater than 1")
 		}
-		// TODO: support zero nodes
-		if in.NumNodes == 0 {
-			return fmt.Errorf("Zero NumNodes not supported yet")
-		}
 	} else if in.Deployment == cloudcommon.AppDeploymentTypeDocker {
 		if in.NumMasters != 0 || in.NumNodes != 0 {
 			return fmt.Errorf("NumMasters and NumNodes not applicable for deployment type %s", cloudcommon.AppDeploymentTypeDocker)


### PR DESCRIPTION
removed check for 0 worker nodes. Code to allow master to do work if no worker nodes present was already in place in infra/mexos/cluster.go:244