### PR TITLE
EDGECLOUD-590 mc audit api

### DIFF
--- a/cloudcommon/deployment.go
+++ b/cloudcommon/deployment.go
@@ -67,7 +67,7 @@ func IsValidDeploymentManifest(appDeploymentType, command, manifest string, port
 			return fmt.Errorf("parse kubernetes deployment yaml failed, %v", err)
 		}
 		// check that any ports specified on App are part of manifest
-		objPorts := make(map[dme.AppPort]struct{})
+		objPorts := make(map[string]struct{})
 		for _, obj := range objs {
 			ksvc, ok := obj.(*v1.Service)
 			if !ok {
@@ -81,7 +81,7 @@ func IsValidDeploymentManifest(appDeploymentType, command, manifest string, port
 					continue
 				}
 				appPort.InternalPort = int32(kp.TargetPort.IntValue())
-				objPorts[appPort] = struct{}{}
+				objPorts[appPort.String()] = struct{}{}
 			}
 		}
 		missingPorts := []string{}
@@ -90,7 +90,7 @@ func IsValidDeploymentManifest(appDeploymentType, command, manifest string, port
 			if appPort.Proto == dme.LProto_L_PROTO_HTTP {
 				appPort.Proto = dme.LProto_L_PROTO_TCP
 			}
-			if _, found := objPorts[appPort]; found {
+			if _, found := objPorts[appPort.String()]; found {
 				continue
 			}
 			protoStr, _ := edgeproto.LProtoStr(appPort.Proto)

--- a/d-match-engine/dme-proto/app-client.swagger.json
+++ b/d-match-engine/dme-proto/app-client.swagger.json
@@ -152,7 +152,7 @@
           "200": {
             "description": "A successful response.(streaming responses)",
             "schema": {
-              "$ref": "#/definitions/distributed_match_engineQosPositionKpiReply"
+              "$ref": "#/x-stream-definitions/distributed_match_engineQosPositionKpiReply"
             }
           }
         },
@@ -945,6 +945,57 @@
           "title": "token used for location verification, app must retrieve from TokenServerURI"
         }
       }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "runtimeStreamError": {
+      "type": "object",
+      "properties": {
+        "grpc_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "http_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "http_status": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  },
+  "x-stream-definitions": {
+    "distributed_match_engineQosPositionKpiReply": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "$ref": "#/definitions/distributed_match_engineQosPositionKpiReply"
+        },
+        "error": {
+          "$ref": "#/definitions/runtimeStreamError"
+        }
+      },
+      "title": "Stream result of distributed_match_engineQosPositionKpiReply"
     }
   }
 }

--- a/gensupport/support.go
+++ b/gensupport/support.go
@@ -357,7 +357,7 @@ func RunParseCheck(g *generator.Generator, file *generator.FileDescriptor) {
 	}
 	content := g.Buffer
 	g.Buffer = new(bytes.Buffer)
-	g.P("package ", file.PackageName())
+	g.P("package ", file.FileDescriptorProto.GetPackage())
 	g.Write(content.Bytes())
 
 	fset := token.NewFileSet()

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -686,7 +686,7 @@ func (p *Jaeger) StartLocal(logfile string, opts ...StartOp) error {
 		"-p", "16686:16686",
 		"-p", "14268:14268",
 		"-p", "9411:9411",
-		"jaegertracing/all-in-one:1.12",
+		"jaegertracing/all-in-one:1.13",
 	}
 	var err error
 	p.cmd, err = StartLocal(p.Name, p.GetExeName(), args, nil, logfile)

--- a/log/jaeger.go
+++ b/log/jaeger.go
@@ -26,13 +26,14 @@ var spanString = contextKey{}
 var noPanicOrphanedSpans bool
 var lastLog map[string]time.Time
 var lastLogMux sync.Mutex
+var SpanServiceName string
 
 // Use JAEGER_AGEN_HOST and JAEGER_AGENT_PORT to send UDP traces
 // to different host:port (otherwise uses localhost:6831).
 func InitTracer() {
 	lastLog = make(map[string]time.Time)
 
-	name := filepath.Base(os.Args[0])
+	SpanServiceName = filepath.Base(os.Args[0])
 	cfg := &config.Configuration{
 		Sampler: &config.SamplerConfig{
 			Type:  jaeger.SamplerTypeProbabilistic,
@@ -40,7 +41,7 @@ func InitTracer() {
 		},
 		Reporter: &config.ReporterConfig{},
 	}
-	t, closer, err := cfg.New(name, config.Logger(zap.NewLogger(slogger.Desugar())))
+	t, closer, err := cfg.New(SpanServiceName, config.Logger(zap.NewLogger(slogger.Desugar())))
 	if err != nil {
 		panic(fmt.Sprintf("ERROR: cannot init Jaeger: %v\n", err))
 	}

--- a/log/spanlog.go
+++ b/log/spanlog.go
@@ -154,3 +154,11 @@ func getSpanMsg(s *Span, lineno, msg string) string {
 	}
 	return traceid + "\t" + lineno + "\t" + msg
 }
+
+func NoLogSpan(span opentracing.Span) {
+	ext.SamplingPriority.Set(span, 0)
+}
+
+func ForceLogSpan(span opentracing.Span) {
+	ext.SamplingPriority.Set(span, 1)
+}


### PR DESCRIPTION
Minor changes for infra changes. Changes to AppPort map and support.go are related to updating protobufs from 1.0.0 to 1.2.1, which we may need to do at some point (esp if we want to include another go project that uses 1.2+). But ultimately I didn't need to import the jaeger protobufs, so I was able to avoid the upgrade (which had a bunch of other issues).