### PR TITLE
disallow non-kubernetes on aks and gcp

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -200,7 +200,7 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 		}
 		if cloudlet.PlatformType == edgeproto.PlatformType_PLATFORM_TYPE_AZURE || cloudlet.PlatformType == edgeproto.PlatformType_PLATFORM_TYPE_GCP {
 			if in.Deployment != cloudcommon.AppDeploymentTypeKubernetes {
-				return errors.New("Only kubernetes apps can be deployed in Azure or GCP")
+				return errors.New("Only kubernetes clusters can be deployed in Azure or GCP")
 			}
 		}
 		info := edgeproto.CloudletInfo{}


### PR DESCRIPTION
EDGECLOUD-1068

When trying to deploy a docker app on aks, it will fail but in an ugly way.  Explicitly block non-k8s apps from aks or gcp.
