### PR TITLE
EDGECLOUD-1029 set SNI on controller connect within k8s for TLS

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -139,11 +139,14 @@ func startServices() error {
 
 	if *externalApiAddr == "" {
 		*externalApiAddr = *apiAddr
-		hostport := strings.Split(*externalApiAddr, ":")
-		if len(hostport) == 2 && hostport[0] == "0.0.0.0" {
+		host, port, err := net.SplitHostPort(*externalApiAddr)
+		if err != nil {
+			return fmt.Errorf("Failed to parse externalApiAddr %s, %v", *externalApiAddr, err)
+		}
+		if host == "0.0.0.0" {
 			addr, err := resolveExternalAddr()
 			if err == nil {
-				*externalApiAddr = addr + ":" + hostport[1]
+				*externalApiAddr = addr + ":" + port
 			}
 		}
 	}


### PR DESCRIPTION
Hopefully the last fix needed for bug 1029. Controllers with k8s could not talk to each other because target IP address was not on the list of SANs on the cert. To fix, we set the servername to a valid SAN if the remote is an IP address. While it's not safe practice to override the servername, the IP comes from etcd from another controller, so if we can trust the IP, then there's no real danger in overriding the servername. Mutual TLS still happens based on the cert keys.

There's also some changes that didn't get checked in from Matt's changeset.