### PR TITLE
jeager TLS support and e2e tests

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/crm_server_test.go
+++ b/cloud-resource-manager/cmd/crmserver/crm_server_test.go
@@ -141,7 +141,7 @@ func startMain(t *testing.T) (chan struct{}, error) {
 func TestCRM(t *testing.T) {
 	var err error
 	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelMexos)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -53,7 +53,7 @@ var platform pf.Platform
 func main() {
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer()
+	log.InitTracer(*tlsCertFile)
 	defer log.FinishTracer()
 
 	var span opentracing.Span

--- a/cluster-svc/cluster-svc-main.go
+++ b/cluster-svc/cluster-svc-main.go
@@ -263,7 +263,7 @@ func main() {
 	var err error
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer()
+	log.InitTracer(*tlsCertFile)
 
 	if *standalone {
 		fmt.Printf("Running in Standalone Mode with test instances\n")

--- a/controller/app_api_test.go
+++ b/controller/app_api_test.go
@@ -15,7 +15,7 @@ func TestAppApi(t *testing.T) {
 	objstore.InitRegion(1)
 	tMode := true
 	testMode = &tMode
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 
 	dummy := dummyEtcd{}

--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAppInstApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	objstore.InitRegion(1)
@@ -210,7 +210,7 @@ func ClientAppInstCachedFieldsTest(t *testing.T, ctx context.Context, appApi edg
 
 func TestAutoClusterInst(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	objstore.InitRegion(1)

--- a/controller/cloudlet_api_test.go
+++ b/controller/cloudlet_api_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCloudletApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	objstore.InitRegion(1)

--- a/controller/cloudletinfo_api_test.go
+++ b/controller/cloudletinfo_api_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCloudletInfo(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	objstore.InitRegion(1)

--- a/controller/clusterinst_api_test.go
+++ b/controller/clusterinst_api_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestClusterInstApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelNotify)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	objstore.InitRegion(1)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -147,7 +147,7 @@ func startServices() error {
 			}
 		}
 	}
-	log.InitTracer()
+	log.InitTracer(*tlsCertFile)
 	span := log.StartSpan(log.DebugLevelInfo, "main")
 	span.SetTag("level", "init")
 	defer span.Finish()

--- a/controller/main_test.go
+++ b/controller/main_test.go
@@ -25,7 +25,7 @@ func getGrpcClient(t *testing.T) (*grpc.ClientConn, error) {
 
 func TestController(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelNotify | log.DebugLevelApi)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	flag.Parse() // set defaults

--- a/d-match-engine/dme-proto/app-client.swagger.json
+++ b/d-match-engine/dme-proto/app-client.swagger.json
@@ -405,7 +405,8 @@
         },
         "end_port": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "If end_port != 0 then AppPort is a port range from internl_port -\u003e end_port inclusive."
         }
       },
       "description": "AppPort describes an L4 or L7 public access port/path mapping. This is used to track external to internal mappings for access via a shared load balancer or reverse proxy."

--- a/d-match-engine/dme-proto/appcommon.pb.go
+++ b/d-match-engine/dme-proto/appcommon.pb.go
@@ -63,7 +63,8 @@ type AppPort struct {
 	PathPrefix string `protobuf:"bytes,4,opt,name=path_prefix,json=pathPrefix,proto3" json:"path_prefix,omitempty"`
 	// FQDN prefix to append to base FQDN in FindCloudlet response. May be empty.
 	FqdnPrefix string `protobuf:"bytes,5,opt,name=fqdn_prefix,json=fqdnPrefix,proto3" json:"fqdn_prefix,omitempty"`
-	EndPort    int32  `protobuf:"varint,6,opt,name=end_port,json=endPort,proto3" json:"end_port,omitempty"`
+	// If end_port != 0 then AppPort is a port range from internl_port -> end_port inclusive.
+	EndPort int32 `protobuf:"varint,6,opt,name=end_port,json=endPort,proto3" json:"end_port,omitempty"`
 }
 
 func (m *AppPort) Reset()                    { *m = AppPort{} }

--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -300,7 +300,7 @@ func initOperator(operatorName string) (op.OperatorApiGw, error) {
 func main() {
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer()
+	log.InitTracer(*tlsCertFile)
 	defer log.FinishTracer()
 	span := log.StartSpan(log.DebugLevelInfo, "main")
 	ctx := log.ContextWithSpan(context.Background(), span)

--- a/d-match-engine/dme-server/dme-notify_test.go
+++ b/d-match-engine/dme-server/dme-notify_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNotify(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	setupMatchEngine()

--- a/integration/process/process_defs.go
+++ b/integration/process/process_defs.go
@@ -100,5 +100,11 @@ type ClusterSvc struct {
 }
 type Jaeger struct {
 	Common `yaml:",inline"`
+	TLS    TLSCerts
+	cmd    *exec.Cmd
+}
+type Traefik struct {
+	Common `yaml:",inline"`
+	TLS    TLSCerts
 	cmd    *exec.Cmd
 }

--- a/log/jaeger_reporter.go
+++ b/log/jaeger_reporter.go
@@ -1,0 +1,37 @@
+package log
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	jaeger "github.com/uber/jaeger-client-go"
+	config "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go/transport"
+)
+
+// Adapted from config.NewReporter, in order to be able to pass
+// in TLS config to http transport.
+// Unfortunately we can't pass metrics in, because jaeger.Metrics
+// is created in the NewTracer call. If the jaeger client code
+// could expose transport (or tls.Config) in their Configuration,
+// then we could avoid this duplication of NewReporter.
+func NewReporter(serviceName string, tlsConfig *tls.Config, rc *config.ReporterConfig, logger jaeger.Logger) jaeger.Reporter {
+	opts := make([]transport.HTTPOption, 0)
+	opts = append(opts, transport.HTTPBatchSize(1))
+	if tlsConfig != nil {
+		trans := &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}
+		opts = append(opts, transport.HTTPRoundTripper(trans))
+	}
+	sender := transport.NewHTTPTransport(rc.CollectorEndpoint, opts...)
+	reporter := jaeger.NewRemoteReporter(
+		sender,
+		jaeger.ReporterOptions.QueueSize(rc.QueueSize),
+		jaeger.ReporterOptions.BufferFlushInterval(rc.BufferFlushInterval),
+		jaeger.ReporterOptions.Logger(logger))
+	if rc.LogSpans && logger != nil {
+		reporter = jaeger.NewCompositeReporter(jaeger.NewLoggingReporter(logger), reporter)
+	}
+	return reporter
+}

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNotifyBasic(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/notify/notify_tree_test.go
+++ b/notify/notify_tree_test.go
@@ -28,7 +28,7 @@ const (
 // a balanced binary tree.
 func TestNotifyTree(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi)
-	log.InitTracer()
+	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/setup-env/e2e-tests/setups/local_multi.yml
+++ b/setup-env/e2e-tests/setups/local_multi.yml
@@ -101,3 +101,15 @@ dmes:
     serverkey: "{{tlsoutdir}}/mex-server.key"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
+
+traefiks:
+- name: traefik-e2e
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    serverkey: "{{tlsoutdir}}/mex-server.key"
+    cacert: "{{tlsoutdir}}/mex-ca.crt"
+  hostname: "127.0.0.1"
+
+jaegers:
+- name: jaeger-e2e
+  hostname: "127.0.0.1"

--- a/setup-env/setup-mex/setup-mex.go
+++ b/setup-env/setup-mex/setup-mex.go
@@ -466,6 +466,11 @@ func StartProcesses(processName string, outputDir string) bool {
 			return false
 		}
 	}
+	for _, p := range util.Deployment.Traefiks {
+		if !StartLocal(processName, outputDir, p, opts...) {
+			return false
+		}
+	}
 	for _, p := range util.Deployment.Controllers {
 		opts = append(opts, process.WithDebug("etcd,api,notify"))
 		if !StartLocal(processName, outputDir, p, opts...) {

--- a/setup-env/util/util.go
+++ b/setup-env/util/util.go
@@ -97,6 +97,7 @@ type DeploymentData struct {
 	Influxs     []*process.Influx     `yaml:"influxs"`
 	ClusterSvcs []*process.ClusterSvc `yaml:"clustersvcs"`
 	Jaegers     []*process.Jaeger     `yaml:"jaegers"`
+	Traefiks    []*process.Traefik    `yaml:"traefiks"`
 }
 
 type errorReply struct {
@@ -135,6 +136,9 @@ func GetAllProcesses() []process.Process {
 		all = append(all, p)
 	}
 	for _, p := range Deployment.Jaegers {
+		all = append(all, p)
+	}
+	for _, p := range Deployment.Traefiks {
 		all = append(all, p)
 	}
 	return all


### PR DESCRIPTION
Adds in TLS support for jaeger client. If TLS is specified, we set up the Reporter to use TLS.

Jaeger itself doesn't have full TLS support, so we use Traefik in the e2e tests to terminate TLS and reverse proxy to Jaeger. Both Jaeger and Traefik run as docker containers, and Traefik is set up to detect the labels on Jaeger and configure the forwarding based on Jaeger's IP on the internal docker network.

The plan is to deploy Jaeger with Traefik/Nginx fronting it for our cloud deployment.