### PR TITLE
fix build for edge-proto integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ build: check-vers
 	go install ./protoc-gen-notify
 	make -C ./protoc-gen-cmd
 	make -C ./log
+	make -C d-match-engine/dme-proto
 	make -C edgeproto
 	make -C testgen
 	make -C d-match-engine


### PR DESCRIPTION
Whoops, broke the build. From a clean start, dme-proto needs to be built earlier than before.