### PR TITLE
EDGECLOUD-1160: Handle FatalLogs from CRM

### DIFF
--- a/cloud-resource-manager/platform/dind/dind.go
+++ b/cloud-resource-manager/platform/dind/dind.go
@@ -20,6 +20,7 @@ func (s *Platform) Init(platformConfig *platform.PlatformConfig, updateCallback 
 	if err != nil {
 		return err
 	}
+	updateCallback(edgeproto.UpdateTask, "Setting up Nginx L7 Proxy")
 	err = nginx.InitL7Proxy(client, nginx.WithDockerPublishPorts())
 	if err != nil {
 		return err

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -372,6 +372,10 @@ func (p *Crm) StopLocal() {
 	StopLocal(p.cmd)
 }
 
+func (p *Crm) Wait() error {
+	return p.cmd.Wait()
+}
+
 func (p *Crm) GetExeName() string { return "crmserver" }
 
 func (p *Crm) LookupArgs() string { return "--cloudletKey " + p.CloudletKey }


### PR DESCRIPTION
**Highlights:**
* CRM can crash on FatalLog. We cannot use notify framework to catch this as the crash can happen before notify client connection is setup
* Currently parsing log file to fetch FatalLog
* Another approach would be to open up a buffer and pass it to cmd.Stderr (using io.MultiWriter) and use that buffer to fetch FatalLog output. But then this can fill up memory with complete crmserver output

**Tests:**
```
❯ CreateCloudlet --key-name ashish-frankfut-test --key-operatorkey-name  TDG --location-latitude 37 --location-longitude -122  --numdynamicips 1 --platformtype PlatformTypeOpenstack --physicalname frankfurt  --flavor-name x1.medium  --deploymentlocal
message: Starting CRMServer
message: Fetching Openstack access credentials
message: Creating RootLB
message: Setting up RootLB
message: Setting up Nginx Proxy
message: Gathering Cloudlet Info
message: Cloudlet created successfully
```

```
❯ CreateCloudlet --key-name ashish-frankfut-test-2 --key-operatorkey-name  TDG --location-latitude 37 --location-longitude -122  --numdynamicips 1 --platformtype PlatformTypeOpenstack --physicalname frankfurt  --flavor-name x1.medium  --deploymentlocal
message: Starting CRMServer
message: 'Failure: ServerMgr listen failed {"err": "listen tcp 127.0.0.1:51001: bind:
  address already in use"}'
```