### PR TITLE
EDGECLOUD-1181 fix MC panic in jwk

### DIFF
--- a/vault/jwk.go
+++ b/vault/jwk.go
@@ -83,6 +83,7 @@ func (s *JWKS) GoUpdate(done chan struct{}) {
 			err := s.updateKeys()
 			if done != nil {
 				close(done)
+				done = nil
 			}
 			if err != nil {
 				log.InfoLog("jwks update keys", "path", s.Path, "metapath", s.Metapath, "err", err)


### PR DESCRIPTION
I added a channel to detect when the first jwk update was done, but on a second iteration it causes a panic when trying to close it twice. This fixes it.