### PR TITLE
remove jaeger reporter for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ testutil/*_testutil.go
 link-gogo-protobuf
 link-grpc-gateway
 version/version.go
+d-match-engine/dme-proto/*.proto

--- a/log/jaeger.go
+++ b/log/jaeger.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mobiledgex/edge-cloud/tls"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -68,6 +69,10 @@ func InitTracer(tlsCertFile string) {
 			Type:  jaeger.SamplerTypeProbabilistic,
 			Param: 0.001,
 		},
+	}
+	if strings.HasSuffix(os.Args[0], ".test") {
+		// unit test, don't bother reporting
+		reporter = jaeger.NewNullReporter()
 	}
 
 	// Create tracer


### PR DESCRIPTION
Removes jaeger reporter for unit tests. Gets rid of all of the connection failed output messages for unit tests, and speeds things up slightly.