### PR TITLE
EDGECLOUD-746 nginx metrics

### DIFF
--- a/cloud-resource-manager/nginx/nginx.go
+++ b/cloud-resource-manager/nginx/nginx.go
@@ -142,8 +142,9 @@ func CreateNginxProxy(client pc.PlatformClient, name, originIP string, ports []d
 
 func createNginxConf(client pc.PlatformClient, confname, name, l7dir, originIP string, ports []dme.AppPort, useTLS bool) error {
 	spec := ProxySpec{
-		Name:   name,
-		UseTLS: useTLS,
+		Name:   	name,
+		UseTLS: 	useTLS,
+		MetricPort: cloudcommon.NginxMetricsPort,
 	}
 	httpPorts := []HTTPSpecDetail{}
 
@@ -233,12 +234,13 @@ func reloadNginxL7(client pc.PlatformClient) error {
 }
 
 type ProxySpec struct {
-	Name    string
-	L4, L7  bool
-	UDPSpec []*UDPSpecDetail
-	TCPSpec []*TCPSpecDetail
-	L7Port  int32
-	UseTLS  bool
+	Name    	string
+	L4, L7  	bool
+	UDPSpec 	[]*UDPSpecDetail
+	TCPSpec 	[]*TCPSpecDetail
+	L7Port  	int32
+	UseTLS  	bool
+	MetricPort  int32
 }
 
 type TCPSpecDetail struct {
@@ -287,8 +289,8 @@ http {
         include /etc/nginx/L7/*.conf;
 	}
 	server {
-		listen 127.0.0.1:65121;
-		server_name 127.0.0.1:65121;
+		listen 127.0.0.1:{{.MetricPort}};
+		server_name 127.0.0.1:{{.MetricPort}};
 		location /nginx_metrics {
 			stub_status;
 			allow 127.0.0.1;
@@ -315,8 +317,8 @@ stream {
 }
 http {
 	server {
-		listen 127.0.0.1:65121;
-		server_name 127.0.0.1:65121;
+		listen 127.0.0.1:{{.MetricPort}};
+		server_name 127.0.0.1:{{.MetricPort}};
 	    location /nginx_metrics {
 			allow 127.0.0.1;
 			deny all;

--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -42,6 +42,7 @@ var NetworkSchemePrivateIP = "privateip"
 // Metrics common variables - TODO move to edge-cloud-infra after metrics-exporter chagnes
 var DeveloperMetricsDbName = "metrics"
 var MEXPrometheusAppName = "MEXPrometheusAppName"
+var NginxMetricsPort = int32(65121)
 
 // DIND script to pull from kubeadm-dind-cluster
 var DindScriptName = "dind-cluster-v1.14.sh"

--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -493,8 +493,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 					// rootLB has its own ports it uses
 					// before any apps are even present.
 					iport := ports[ii].InternalPort
-					if iport != 22 &&
-						iport != cloudcommon.RootLBL7Port {
+					if iport != 22 && iport != cloudcommon.RootLBL7Port && iport != cloudcommon.NginxMetricsPort{
 						eport = iport
 					}
 				}


### PR DESCRIPTION
Added a metrics page to the nginx conf files which will listen on port 9091. This means that no appinst will be able to use port 9091, similar to how we block port 9090 for prometheus. This PR also exposes the nginx access log for future metrics that will require scraping from it (client ips and server side latency). There is a corresponding PR in infra here: https://github.com/mobiledgex/edge-cloud-infra/pull/329