### PR TITLE
Explicitly add "latest" tag to edge-clould builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ build-docker:
 		-t mobiledgex/edge-cloud:${TAG} -f docker/Dockerfile.edge-cloud ..
 	docker tag mobiledgex/edge-cloud:${TAG} registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
 	docker push registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
+	docker tag mobiledgex/edge-cloud:${TAG} registry.mobiledgex.net:5000/mobiledgex/edge-cloud:latest
+	docker push registry.mobiledgex.net:5000/mobiledgex/edge-cloud:latest
 	for ADDLTAG in ${ADDLTAGS}; do \
 		docker tag mobiledgex/edge-cloud:${TAG} $$ADDLTAG; \
 		docker push $$ADDLTAG; \


### PR DESCRIPTION
With tagged nightly builds, the "latest" tag never gets updated, which frequently surprises people who expect the "latest" tag to be, well, the latest.