### PR TITLE
EDGECLOUD-1233: CreateCloudlet should give an error when not sending physical name

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -184,10 +184,8 @@ func (s *CloudletApi) CreateCloudlet(in *edgeproto.Cloudlet, cb edgeproto.Cloudl
 		in.NotifySrvAddr = "127.0.0.1:51001"
 	}
 
-	if in.PlatformType == edgeproto.PlatformType_PLATFORM_TYPE_OPENSTACK {
-		if in.PhysicalName == "" {
-			return errors.New("Must specify physicalname for Openstack deployment")
-		}
+	if in.PhysicalName == "" {
+		in.PhysicalName = in.Key.Name
 	}
 
 	pfConfig := edgeproto.PlatformConfig{}

--- a/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
+++ b/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
@@ -91,6 +91,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51105
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: gcp-cloud-5
 - key:
     operatorkey:
       name: tmus
@@ -105,6 +106,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51101
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-1
 - key:
     operatorkey:
       name: tmus
@@ -119,6 +121,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51102
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-2
 - key:
     operatorkey:
       name: tmus
@@ -132,6 +135,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51103
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-3
 - key:
     operatorkey:
       name: azure
@@ -146,6 +150,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51104
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: azure-cloud-4
 
 apps:
 - key:

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
@@ -65,6 +65,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51001
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-1
 
 apps:
 - key:

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
@@ -16,6 +16,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51001
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-1
 flavors:
 - key:
     name: x1.tiny

--- a/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
@@ -99,6 +99,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51101
   flavor:
     name: x1.small
+  physicalname: tmus-cloud-1
 - key:
     operatorkey:
       name: tmus
@@ -113,6 +114,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51102
   flavor:
     name: x1.small
+  physicalname: tmus-cloud-2
 - key:
     operatorkey:
       name: azure
@@ -127,6 +129,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51104
   flavor:
     name: x1.small
+  physicalname: azure-cloud-4
 - key:
     operatorkey:
       name: gcp
@@ -141,6 +144,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51105
   flavor:
     name: x1.small
+  physicalname: gcp-cloud-5
 
 apps:
 - key:

--- a/setup-env/e2e-tests/data/appdata_show.yml
+++ b/setup-env/e2e-tests/data/appdata_show.yml
@@ -89,6 +89,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51101
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-1
 - key:
     operatorkey:
       name: tmus
@@ -102,6 +103,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51102
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-2
 - key:
     operatorkey:
       name: tmus
@@ -115,6 +117,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51103
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-3
 - key:
     operatorkey:
       name: azure
@@ -128,6 +131,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51104
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: azure-cloud-4
 - key:
     operatorkey:
       name: gcp
@@ -141,6 +145,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51105
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: gcp-cloud-5
 
 apps:
 - key:

--- a/setup-env/e2e-tests/data/appdata_show_after_update.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_update.yml
@@ -95,6 +95,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51101
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-1
 - key:
     operatorkey:
       name: tmus
@@ -108,6 +109,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51102
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-2
 - key:
     operatorkey:
       name: tmus
@@ -121,6 +123,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51103
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-3
 - key:
     operatorkey:
       name: azure
@@ -134,6 +137,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51104
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: azure-cloud-4
 - key:
     operatorkey:
       name: gcp
@@ -147,6 +151,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51105
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: gcp-cloud-5
 
 apps:
 - key:

--- a/setup-env/e2e-tests/data/appdata_show_after_update_all.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_update_all.yml
@@ -89,6 +89,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51101
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-1
 - key:
     operatorkey:
       name: tmus
@@ -102,6 +103,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51102
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-2
 - key:
     operatorkey:
       name: tmus
@@ -115,6 +117,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51103
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: tmus-cloud-3
 - key:
     operatorkey:
       name: azure
@@ -128,6 +131,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51104
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: azure-cloud-4
 - key:
     operatorkey:
       name: gcp
@@ -141,6 +145,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51105
   flavor:
     name: DefaultPlatformFlavor
+  physicalname: gcp-cloud-5
 
 apps:
 - key:

--- a/setup-env/e2e-tests/data/crm_info.yml
+++ b/setup-env/e2e-tests/data/crm_info.yml
@@ -100,6 +100,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51001
   flavor:
     name: x1.medium
+  physicalname: tmus-cloud-1
 - key:
     operatorkey:
       name: tmus
@@ -120,6 +121,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51002
   flavor:
     name: x1.medium
+  physicalname: tmus-cloud-2
 
 apps:
 - key:

--- a/setup-env/e2e-tests/data/show10.yml
+++ b/setup-env/e2e-tests/data/show10.yml
@@ -370,6 +370,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51002
   flavor:
     name: x1.tiny
+  physicalname: tmus-cloud-2
 - key:
     operatorkey:
       name: tmus
@@ -384,6 +385,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51005
   flavor:
     name: x1.tiny
+  physicalname: tmus-cloud-5
 - key:
     operatorkey:
       name: tmus
@@ -398,6 +400,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51006
   flavor:
     name: x1.tiny
+  physicalname: tmus-cloud-6
 - key:
     operatorkey:
       name: azure
@@ -412,6 +415,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51009
   flavor:
     name: x1.tiny
+  physicalname: azure-cloud-9
 - key:
     operatorkey:
       name: gcp
@@ -426,6 +430,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51010
   flavor:
     name: x1.tiny
+  physicalname: gcp-cloud-10
 - key:
     operatorkey:
       name: tmus
@@ -440,6 +445,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51001
   flavor:
     name: x1.tiny
+  physicalname: tmus-cloud-1
 - key:
     operatorkey:
       name: tmus
@@ -454,6 +460,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51003
   flavor:
     name: x1.tiny
+  physicalname: tmus-cloud-3
 - key:
     operatorkey:
       name: tmus
@@ -468,6 +475,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51004
   flavor:
     name: x1.tiny
+  physicalname: tmus-cloud-4
 - key:
     operatorkey:
       name: tmus
@@ -482,6 +490,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51007
   flavor:
     name: x1.tiny
+  physicalname: tmus-cloud-7
 - key:
     operatorkey:
       name: tmus
@@ -496,6 +505,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51008
   flavor:
     name: x1.tiny
+  physicalname: tmus-cloud-8
 
 apps:
 - key:

--- a/setup-env/e2e-tests/data/show2.yml
+++ b/setup-env/e2e-tests/data/show2.yml
@@ -82,6 +82,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51002
   flavor:
     name: x1.medium
+  physicalname: tmus-cloud-2
 - key:
     operatorkey:
       name: tmus
@@ -96,6 +97,7 @@ cloudlets:
   notifysrvaddr: 127.0.0.1:51001
   flavor:
     name: x1.medium
+  physicalname: tmus-cloud-1
 
 apps:
 - key:

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -211,6 +211,7 @@ var CloudletData = []edgeproto.Cloudlet{
 		Flavor:        FlavorData[0].Key,
 		NotifySrvAddr: "127.0.0.1:51001",
 		CrmOverride:   edgeproto.CRMOverride_IGNORE_CRM,
+		PhysicalName:  "SanJoseSite",
 	},
 	edgeproto.Cloudlet{
 		Key: edgeproto.CloudletKey{
@@ -227,6 +228,7 @@ var CloudletData = []edgeproto.Cloudlet{
 		Flavor:        FlavorData[0].Key,
 		NotifySrvAddr: "127.0.0.1:51002",
 		CrmOverride:   edgeproto.CRMOverride_IGNORE_CRM,
+		PhysicalName:  "NewYorkSite",
 	},
 	edgeproto.Cloudlet{
 		Key: edgeproto.CloudletKey{
@@ -243,6 +245,7 @@ var CloudletData = []edgeproto.Cloudlet{
 		PlatformType:  edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
 		NotifySrvAddr: "127.0.0.1:51003",
 		CrmOverride:   edgeproto.CRMOverride_IGNORE_CRM,
+		PhysicalName:  "SanFranciscoSite",
 	},
 	edgeproto.Cloudlet{
 		Key: edgeproto.CloudletKey{
@@ -259,6 +262,7 @@ var CloudletData = []edgeproto.Cloudlet{
 		PlatformType:  edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
 		NotifySrvAddr: "127.0.0.1:51004",
 		CrmOverride:   edgeproto.CRMOverride_IGNORE_CRM,
+		PhysicalName:  "HawaiiSite",
 	},
 }
 var ClusterInstData = []edgeproto.ClusterInst{


### PR DESCRIPTION
* `physical name` is only support for Openstack based deployments. 