### PR TITLE
EDGECLOUD-1222

### DIFF
--- a/cloud-resource-manager/nginx/nginx.go
+++ b/cloud-resource-manager/nginx/nginx.go
@@ -118,7 +118,7 @@ func CreateNginxProxy(client pc.PlatformClient, name, originIP string, ports []d
 		"-v", errlogFile + ":/var/log/nginx/error.log",
 		"-v", accesslogFile + ":/var/log/nginx/access.log",
 		"-v", nconfName + ":/etc/nginx/nginx.conf",
-		"nginx"}...)
+		"docker.mobiledgex.net/mobiledgex/mobiledgex_public/nginx-with-curl"}...)
 	cmd := "docker " + strings.Join(cmdArgs, " ")
 	log.DebugLog(log.DebugLevelMexos, "nginx docker command", "name", name,
 		"cmd", cmd)
@@ -132,8 +132,8 @@ func CreateNginxProxy(client pc.PlatformClient, name, originIP string, ports []d
 
 func createNginxConf(client pc.PlatformClient, confname, name, l7dir, originIP string, ports []dme.AppPort, useTLS bool) error {
 	spec := ProxySpec{
-		Name:   	name,
-		UseTLS: 	useTLS,
+		Name:       name,
+		UseTLS:     useTLS,
 		MetricPort: cloudcommon.NginxMetricsPort,
 	}
 	httpPorts := []HTTPSpecDetail{}
@@ -224,13 +224,13 @@ func reloadNginxL7(client pc.PlatformClient) error {
 }
 
 type ProxySpec struct {
-	Name    	string
-	L4, L7  	bool
-	UDPSpec 	[]*UDPSpecDetail
-	TCPSpec 	[]*TCPSpecDetail
-	L7Port  	int32
-	UseTLS  	bool
-	MetricPort  int32
+	Name       string
+	L4, L7     bool
+	UDPSpec    []*UDPSpecDetail
+	TCPSpec    []*TCPSpecDetail
+	L7Port     int32
+	UseTLS     bool
+	MetricPort int32
 }
 
 type TCPSpecDetail struct {

--- a/docker_nginx/Dockerfile
+++ b/docker_nginx/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+RUN apt-get --assume-yes update && apt-get --assume-yes install curl


### PR DESCRIPTION
I created an nginx container with curl pre-installed and uploaded it to the mobiledgex registry and updated nginx.go to use that container rather than the official nginx container that we were previously using. This allows shepherd to be able to have access to the nginx containers for metrics and the like without have to install curl on it itself, in the cases where rootlb does not have external network access. 