### PR TITLE
Temp fix for EC-1267 and permanent fix for EC-1264

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -166,7 +166,8 @@ func UpdateAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.Ap
 
 func DeleteAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.App, appInst *edgeproto.AppInst) error {
 	log.DebugLog(log.DebugLevelMexos, "deleting app", "name", names.AppName)
-	cmd := fmt.Sprintf("%s kubectl delete -f %s.yaml", names.KconfEnv, names.AppName)
+	file := names.AppName + names.AppRevision + ".yaml"
+	cmd := fmt.Sprintf("%s kubectl delete -f %s", names.KconfEnv, file)
 	out, err := client.Output(cmd)
 	if err != nil {
 		if strings.Contains(string(out), "not found") {

--- a/cloud-resource-manager/nginx/nginx.go
+++ b/cloud-resource-manager/nginx/nginx.go
@@ -278,15 +278,17 @@ http {
 {{- end}}
         include /etc/nginx/L7/*.conf;
 	}
-	server {
-		listen 127.0.0.1:{{.MetricPort}};
-		server_name 127.0.0.1:{{.MetricPort}};
-		location /nginx_metrics {
-			stub_status;
-			allow 127.0.0.1;
-			deny all;
-		}
-	}
+	# Temp fix for EDGECLOUD-1267.  Metrics port has to be unique for 
+	# each nginx instance.
+	#server {
+	#	listen 127.0.0.1:{{.MetricPort}};
+	#	server_name 127.0.0.1:{{.MetricPort}};
+	#	location /nginx_metrics {
+	#		stub_status;
+	#		allow 127.0.0.1;
+	#		deny all;
+	#	}
+	#}
 }
 {{- end}}
 
@@ -305,17 +307,19 @@ stream {
 	}
 	{{- end}}
 }
-http {
-	server {
-		listen 127.0.0.1:{{.MetricPort}};
-		server_name 127.0.0.1:{{.MetricPort}};
-	    location /nginx_metrics {
-			allow 127.0.0.1;
-			deny all;
-			stub_status;
-    	}
-	}
-}
+# Temp fix for EDGECLOUD-1266.  Metrics port has to be unique for
+# each nginx instance
+#http {
+	#server {
+	#	listen 127.0.0.1:{{.MetricPort}};
+	#	server_name 127.0.0.1:{{.MetricPort}};
+	#	location /nginx_metrics {
+	#		allow 127.0.0.1;
+	#		deny all;
+	#		stub_status;
+	#	}
+	#}
+#}
 {{- end}}
 `
 


### PR DESCRIPTION
1) Quick temp fix for EDGECLOUD-1267 : currently when deploying apps nginx goes into a restart loop because each nginx instance tries to listen on the same metrics port, including the L7.  So no k8s apps work right now, this is a quick fix to stabilize the basic functionality and a longer term fix will be needed for metrics
2) Simple fix for EDGECLOUD-1264 in which k8s delete does not work after appinst update.