### PR TITLE
EDGECLOUD-1308 fix order of special args in cmd.go files

### DIFF
--- a/gencmd/cloudlet.cmd.go
+++ b/gencmd/cloudlet.cmd.go
@@ -812,8 +812,8 @@ var CloudletComments = map[string]string{
 	"envvar":                              "Single Key-Value pair of env var to be passed to CRM",
 }
 var CloudletSpecialArgs = map[string]string{
-	"errors": "StringArray",
 	"envvar": "StringToString",
+	"errors": "StringArray",
 }
 var EnvVarEntryRequiredArgs = []string{}
 var EnvVarEntryOptionalArgs = []string{

--- a/gensupport/args.go
+++ b/gensupport/args.go
@@ -2,6 +2,7 @@ package gensupport
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
@@ -145,7 +146,13 @@ func GenerateMessageArgs(g *generator.Generator, support *PluginSupport, desc *g
 
 	// generate special args
 	g.P("var ", message.Name, "SpecialArgs = map[string]string{")
-	for arg, argType := range specialArgs {
+	keys := make([]string, 0, len(specialArgs))
+	for arg, _ := range specialArgs {
+		keys = append(keys, arg)
+	}
+	sort.Strings(keys)
+	for _, arg := range keys {
+		argType := specialArgs[arg]
 		g.P("\"", strings.ToLower(arg), "\": \"", argType, "\",")
 	}
 	g.P("}")


### PR DESCRIPTION
Sorts items in special args map definition so random code changes don't end up changing the cmd output files for no reason (previous order was indeterministic).