### PR TITLE
default docker registry handling

### DIFF
--- a/cloudcommon/registry.go
+++ b/cloudcommon/registry.go
@@ -17,9 +17,11 @@ import (
 )
 
 const (
-	BasicAuth  = "basic"
-	TokenAuth  = "token"
-	ApiKeyAuth = "apikey"
+	BasicAuth         = "basic"
+	TokenAuth         = "token"
+	ApiKeyAuth        = "apikey"
+	DockerHub         = "docker.io"
+	DockerHubRegistry = "registry-1.docker.io"
 )
 
 type RegistryAuth struct {
@@ -253,7 +255,11 @@ func ValidateDockerRegistryPath(ctx context.Context, regUrl, vaultAddr string) e
 	} else {
 		return fmt.Errorf("Invalid tag in registry path")
 	}
-
+	if urlObj.Host == DockerHub {
+		// Even though public images are typically pulled from docker.io, the API v2 calls must be made to registry-1.docker.io
+		urlObj.Host = DockerHubRegistry
+		log.SpanLog(ctx, log.DebugLevelApi, "substituting docker hub registry for docker hub", "host", urlObj.Host)
+	}
 	regUrl = fmt.Sprintf("%s://%s/%s%s/tags/list", urlObj.Scheme, urlObj.Host, version, regPath)
 	log.SpanLog(ctx, log.DebugLevelApi, "registry api url", "url", regUrl)
 

--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -152,7 +152,8 @@ func updateAppFields(ctx context.Context, in *edgeproto.App, revision int32) err
 			parts := strings.Split(in.ImagePath, "/")
 			// Append default registry address for internal image paths
 			if len(parts) < 2 || !strings.Contains(parts[0], ".") {
-				return fmt.Errorf("imagepath should be full registry URL: <domain-name>/<registry-path>")
+				in.ImagePath = cloudcommon.DockerHub + "/" + in.ImagePath
+				log.SpanLog(ctx, log.DebugLevelApi, "Using default docker registry", "ImagePath", in.ImagePath)
 			}
 		}
 	}


### PR DESCRIPTION
EDGECLOUD-1301

The controller verifies the imagepath by making a docker v2 API call to list the image tags.  Some apps use docker.io to store their images, which is the default within docker.   So all of these are the same:

1) docker pull wurstmeister/zookeeper
2) docker pull docker.io/wurstmeister/zookeeper
3) docker pull registry-1.docker.io/wurstmeister/zookeeper

The last one is actually the one which is needed for API calls, even though most of the time developers will probably use this when populating the image path.    Most of the time I think they will use option 1, or perhaps 2 when configuring their app.  It actually took me quite a long time to figure out #3 was needed for API calls, so I don't expect them to know they need to populate the imagepath this way.

This PR:
- Uses the default docker registry of docker.io in the image path when not specified.   This is what docker does.   
- Uses registry-1.docker.io for the docker V2 API calls when the docker registry is specified or defaulted

