### PR TITLE
EDGECLOUD-1326 Flavor details and properties parse

### DIFF
--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -64,6 +65,9 @@ var DeleteClusterInstTimeout = 20 * time.Minute
 var platformApps = map[string]bool{
 	DeveloperSamsung + ":" + SamsungEnablingLayer: true,
 }
+
+// Common regular expression for quoted strings parse
+var QuotedStringRegex = regexp.MustCompile(`"(.*?)"`)
 
 // IsPlatformApp true if the developer/app combo is a platform app
 func IsPlatformApp(devname string, appname string) bool {


### PR DESCRIPTION
Flavor properties parse (oscli.go) uses the same quoted string regex as auditlog.go. Make a common regex and use for both.