### PR TITLE
automatically add image pull secret name

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -130,7 +130,7 @@ func createOrUpdateAppInst(client pc.PlatformClient, names *KubeNames, app *edge
 	if err != nil {
 		return err
 	}
-	mf, err = MergeEnvVars(mf, app.Configs, app.ImagePath)
+	mf, err = MergeEnvVars(mf, app.Configs, names.ImagePullSecret)
 	if err != nil {
 		log.DebugLog(log.DebugLevelMexos, "failed to merge env vars", "error", err)
 	}

--- a/cloud-resource-manager/k8smgmt/kubenames.go
+++ b/cloud-resource-manager/k8smgmt/kubenames.go
@@ -23,6 +23,7 @@ type KubeNames struct {
 	KconfName         string
 	KconfEnv          string
 	DeploymentType    string
+	ImagePullSecret   string
 }
 
 func GetKconfName(clusterInst *edgeproto.ClusterInst) string {

--- a/cloudcommon/registry.go
+++ b/cloudcommon/registry.go
@@ -17,12 +17,11 @@ import (
 )
 
 const (
-	BasicAuth          = "basic"
-	TokenAuth          = "token"
-	ApiKeyAuth         = "apikey"
-	DockerHub          = "docker.io"
-	DockerHubRegistry  = "registry-1.docker.io"
-	MobiledgexRegistry = "docker.mobiledgex.net"
+	BasicAuth         = "basic"
+	TokenAuth         = "token"
+	ApiKeyAuth        = "apikey"
+	DockerHub         = "docker.io"
+	DockerHubRegistry = "registry-1.docker.io"
 )
 
 type RegistryAuth struct {


### PR DESCRIPTION
EDGECLOUD-1477 

When deploying apps from an external kubernetes manifests, the developer is not aware of what our image pull secret name is, and really should not have to be.   During EA program onboarding of apps, we ran into problems because of this and the apps would not start.

This PR will check if the imagepath is in the mobiledge registry, and if so will add our image pull secret name if not already present.