### PR TITLE
DaemonSet AppInst wait for pods ready

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -49,7 +49,6 @@ func WaitForAppInst(client pc.PlatformClient, names *KubeNames, app *edgeproto.A
 					name = deployment.ObjectMeta.Name
 				} else {
 					name = daemonset.ObjectMeta.Name
-
 				}
 				log.DebugLog(log.DebugLevelMexos, "get pods", "name", name)
 


### PR DESCRIPTION
EDGECLOUD-906

AppInst creation for daemonsets (used in ScaleWithCluster) completes before the pods actually come inservice.   Fix this by handling the daemonset case