### PR TITLE
fix nginx l7 restart

### DIFF
--- a/cloud-resource-manager/platform/pc/pc.go
+++ b/cloud-resource-manager/platform/pc/pc.go
@@ -35,17 +35,17 @@ type Sudo bool
 var SudoOn Sudo = true
 
 // NoSudo means dont run in sudo mode
-var NoSudo Sudo = true
+var NoSudo Sudo = false
 
 // Some utility functions
 
 // WriteFile writes the file contents optionally in sudo mode
 func WriteFile(client PlatformClient, file string, contents string, kind string, sudo Sudo) error {
-	log.DebugLog(log.DebugLevelMexos, "write file", "kind", kind)
+	log.DebugLog(log.DebugLevelMexos, "write file", "kind", kind, "sudo", sudo)
 
 	cmd := fmt.Sprintf("cat <<EOF > %s \n%s\nEOF", file, contents)
 	if sudo {
-		cmd = fmt.Sprintf("sudo bash -c '%s'", cmd)
+		cmd = fmt.Sprintf("sudo bash -c %s", cmd)
 	}
 
 	out, err := client.Output(cmd)


### PR DESCRIPTION
EDGECLOUD-1506

L7 Nginx container was restarting because the config file was partially truncated.   I broke this with my changes to pc.WriteFile a while ago as follows:
- When using sudo, there's a quote around the contents.  If the contents themselves contain single quotes, it gets cut off after the quote
- Definition of "NoSudo" which I added last minute was set to true 