### PR TITLE
remove check for upgrade required in checkCloudletReady

### DIFF
--- a/controller/cloudletinfo_api.go
+++ b/controller/cloudletinfo_api.go
@@ -140,17 +140,6 @@ func (s *CloudletInfoApi) checkCloudletReady(key *edgeproto.CloudletKey) error {
 		return fmt.Errorf("Cloudlet %v is in failed upgrade state, please upgrade it manually", key)
 	}
 
-	upgradeReq, err := isCloudletUpgradeRequired(key)
-	if err != nil {
-		if !*testMode {
-			return fmt.Errorf("Cloudlet %v version check failed: %v", key, err)
-		}
-	}
-	// Ignore cloudlet version check in testMode
-	if !*testMode && upgradeReq {
-		return fmt.Errorf("Cloudlet %v version is outdated, please upgrade it", key)
-	}
-
 	// For testing, state is Errors due to openstack limits not found.
 	// Errors state does indicate it is online, so consider it ok.
 	state := s.getCloudletState(key)


### PR DESCRIPTION
Removing the newly added check for isCloudletUpgradeRequired within checkCloudletReady a follows:
- This is failing in Andy's test setup and blocking QA.   The root cause I'm not sure but tracked in ec-1518.  The error is  "version check failed"
- Discussed this with Jon, and we agreed that just because the controller is upgraded does not mean we should block all CRM actions until the CRM is upgraded.  The controller can be patched without needing a multitude of CRMs to have to get updated.   We should perhaps enhance this in future to check if the schema changed and then we can say an update is required before any changes to apps can happen