### PR TITLE
EDGECLOUD-1030 no image paths needed by default for open-source

### DIFF
--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -23,11 +23,6 @@ func TestAppInstApi(t *testing.T) {
 	testinit()
 	reduceInfoTimeouts()
 
-	tMode := true
-	testMode = &tMode
-	dockerRegistry := "docker.mobiledgex.net"
-	registryFQDN = &dockerRegistry
-
 	dummy := dummyEtcd{}
 	dummy.Start()
 

--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -222,15 +222,6 @@ func (s *CloudletApi) CreateCloudlet(in *edgeproto.Cloudlet, cb edgeproto.Cloudl
 		in.PhysicalName = in.Key.Name
 	}
 
-	if isOperatorInfraCloudlet(in) {
-		if *cloudletVMImagePath == "" {
-			return fmt.Errorf("cloudletVMImagePath is required for cloudlet bringup on Operator infra")
-		}
-		if *cloudletRegistryPath == "" {
-			return fmt.Errorf("cloudletRegistryPath is required for cloudlet bringup on Operator infra")
-		}
-	}
-
 	return s.createCloudletInternal(DefCallContext(), in, cb)
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -104,9 +104,6 @@ func validateFields(ctx context.Context) error {
 	if *versionTag == "" {
 		return fmt.Errorf("Version tag is required")
 	}
-	if *registryFQDN == "" {
-		return fmt.Errorf("registryFQDN is required")
-	}
 	if *artifactoryFQDN == "" {
 		return fmt.Errorf("artifactoryFQDN is required")
 	}
@@ -130,16 +127,12 @@ func validateFields(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-	} else {
-		return fmt.Errorf("cloudletRegistryPath is required")
 	}
 	if *cloudletVMImagePath != "" {
 		err := util.ValidateImagePath(*cloudletVMImagePath)
 		if err != nil {
 			return err
 		}
-	} else {
-		return fmt.Errorf("cloudletVMImagePath is required")
 	}
 	return nil
 }

--- a/setup-env/e2e-tests/data/appdata.yml
+++ b/setup-env/e2e-tests/data/appdata.yml
@@ -182,7 +182,7 @@ apps:
       name: AcmeAppCo
     name: NoPortsApp
     version: "1.0"
-  imagepath: registry.mobiledgex.net/mobiledgex_AcmeAppCo/noportsapp:1.0
+  imagepath: http://registry.mobiledgex.net/mobiledgex_AcmeAppCo/noportsapp:1.0
   imagetype: ImageTypeDocker
   deployment: "kubernetes"
   defaultflavor:

--- a/setup-env/e2e-tests/setups/local_dind.yml
+++ b/setup-env/e2e-tests/setups/local_dind.yml
@@ -64,10 +64,6 @@ controllers:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
-  registryfqdn: "docker.mobiledgex.net"
-  artifactoryfqdn: "https://artifactory.mobiledgex.net/artifactory/"
-  cloudletregistrypath: "registry.mobiledgex.net:5000/mobiledgex/edge-cloud"
-  cloudletvmimagepath: "https://artifactory.mobiledgex.net/artifactory/baseimages/mobiledgex-v2.0.3.qcow2#md5:fc13f750dd69c389dc7641ff8e6619ce"
   testmode: true
 
 dmes:

--- a/setup-env/e2e-tests/setups/local_multi.yml
+++ b/setup-env/e2e-tests/setups/local_multi.yml
@@ -49,9 +49,6 @@ controllers:
   shorttimeouts: true
   hostname: "127.0.0.1"
   registryfqdn: "docker.mobiledgex.net"
-  artifactoryfqdn: "https://artifactory.mobiledgex.net/artifactory/"
-  cloudletregistrypath: "registry.mobiledgex.net:5000/mobiledgex/edge-cloud"
-  cloudletvmimagepath: "https://artifactory.mobiledgex.net/artifactory/baseimages/mobiledgex-v2.0.3.qcow2#md5:fc13f750dd69c389dc7641ff8e6619ce"
   testmode: true
 
 - name: ctrl2
@@ -65,9 +62,6 @@ controllers:
   shorttimeouts: true
   hostname: "127.0.0.1"
   registryfqdn: "docker.mobiledgex.net"
-  artifactoryfqdn: "https://artifactory.mobiledgex.net/artifactory/"
-  cloudletregistrypath: "registry.mobiledgex.net:5000/mobiledgex/edge-cloud"
-  cloudletvmimagepath: "https://artifactory.mobiledgex.net/artifactory/baseimages/mobiledgex-v2.0.3.qcow2#md5:fc13f750dd69c389dc7641ff8e6619ce"
   testmode: true
 
 clustersvcs:


### PR DESCRIPTION
Changes behavior for some controller command line args to make then not required.
- registryFQDN and artifactoryFQDN are not required, but if not present, then CreateApp may fail if user does not specify an ImagePath. Errors prompts user to specify one.
- cloudletRegistryPath and cloudletVMImagePath are not required, because they are only used for CreateCloudlet on openstack. Instead, they are optional (although the intent is for MobiledgeX deployments, ansible will always specify them). Defaults are hard-coded in infra for local testing.

These changes allow open-source users to run the controller and crm locally without having to specify these command line args.