### PR TITLE
ignoreCRM not working properly for UpdateClusterInst

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -396,9 +396,7 @@ func (s *ClusterInstApi) updateClusterInstInternal(cctx *CallContext, in *edgepr
 			// nothing changed
 			return nil
 		}
-		if ignoreCRM(cctx) {
-			in.State = edgeproto.TrackedState_READY
-		} else {
+		if !ignoreCRM(cctx) {
 			inbuf.State = edgeproto.TrackedState_UPDATE_REQUESTED
 		}
 		s.store.STMPut(stm, &inbuf)


### PR DESCRIPTION
EDGECLOUD-1543

When setting ignorecrm with UpdateClusterInst, the CRM starts processing as if ignorecrm were not set.  Fix is to not set UPDATE_REQUESTED state