### PR TITLE
EDGECLOUD-1439 unable to create a helm appinst with a dot in the app name

### DIFF
--- a/cloud-resource-manager/k8smgmt/helm.go
+++ b/cloud-resource-manager/k8smgmt/helm.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
-	"github.com/mobiledgex/edge-cloud/util"
 )
 
 // this is an initial set of supported helm install options
@@ -112,13 +111,6 @@ func getHelmRepoAndChart(imagePath string) (string, string, error) {
 	return "", chart, nil
 }
 
-func getHelmAppName(app *edgeproto.App) string {
-	if app == nil {
-		return ""
-	}
-	return util.DNSSanitize(app.Key.Name + "v" + app.Key.Version)
-}
-
 func CreateHelmAppInst(client pc.PlatformClient, names *KubeNames, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst) error {
 	log.DebugLog(log.DebugLevelMexos, "create kubernetes helm app", "clusterInst", clusterInst, "kubeNames", names)
 
@@ -157,7 +149,7 @@ func CreateHelmAppInst(client pc.PlatformClient, names *KubeNames, clusterInst *
 	}
 	log.DebugLog(log.DebugLevelMexos, "Helm options", "helmOpts", helmOpts)
 	cmd = fmt.Sprintf("%s helm install %s %s --name %s %s", names.KconfEnv, chart, helmArgs,
-		getHelmAppName(app), helmOpts)
+		names.HelmAppName, helmOpts)
 	out, err = client.Output(cmd)
 	if err != nil {
 		return fmt.Errorf("error deploying helm chart, %s, %s, %v", cmd, out, err)
@@ -174,7 +166,7 @@ func UpdateHelmAppInst(client pc.PlatformClient, names *KubeNames, app *edgeprot
 		return err
 	}
 	log.DebugLog(log.DebugLevelMexos, "Helm options", "helmOpts", helmOpts)
-	cmd := fmt.Sprintf("%s helm upgrade %s %s %s", names.KconfEnv, helmOpts, getHelmAppName(app), names.AppImage)
+	cmd := fmt.Sprintf("%s helm upgrade %s %s %s", names.KconfEnv, helmOpts, names.HelmAppName, names.AppImage)
 	out, err := client.Output(cmd)
 	if err != nil {
 		return fmt.Errorf("error updating helm chart, %s, %s, %v", cmd, out, err)
@@ -183,9 +175,9 @@ func UpdateHelmAppInst(client pc.PlatformClient, names *KubeNames, app *edgeprot
 	return nil
 }
 
-func DeleteHelmAppInst(client pc.PlatformClient, names *KubeNames, clusterInst *edgeproto.ClusterInst, app *edgeproto.App) error {
+func DeleteHelmAppInst(client pc.PlatformClient, names *KubeNames, clusterInst *edgeproto.ClusterInst) error {
 	log.DebugLog(log.DebugLevelMexos, "delete kubernetes helm app")
-	cmd := fmt.Sprintf("%s helm delete --purge %s", names.KconfEnv, getHelmAppName(app))
+	cmd := fmt.Sprintf("%s helm delete --purge %s", names.KconfEnv, names.HelmAppName)
 	out, err := client.Output(cmd)
 	if err != nil {
 		return fmt.Errorf("error deleting helm chart, %s, %s, %v", cmd, out, err)

--- a/cloud-resource-manager/k8smgmt/kubenames.go
+++ b/cloud-resource-manager/k8smgmt/kubenames.go
@@ -13,6 +13,7 @@ import (
 
 type KubeNames struct {
 	AppName           string
+	HelmAppName       string
 	AppURI            string
 	AppImage          string
 	AppRevision       string
@@ -62,6 +63,8 @@ func GetKubeNames(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appIns
 	kubeNames.ClusterName = NormalizeName(clusterInst.Key.ClusterKey.Name + clusterInst.Key.Developer)
 	kubeNames.K8sNodeNameSuffix = GetK8sNodeNameSuffix(&clusterInst.Key)
 	kubeNames.AppName = NormalizeName(app.Key.Name)
+	// Helm app name has to conform to DNS naming standards
+	kubeNames.HelmAppName = util.DNSSanitize(app.Key.Name + "v" + app.Key.Version)
 	kubeNames.AppURI = appInst.Uri
 	if app.Revision > 0 {
 		// if revision is zero, skip this for backwards compatibility

--- a/cloud-resource-manager/platform/dind/dind-appinst.go
+++ b/cloud-resource-manager/platform/dind/dind-appinst.go
@@ -95,7 +95,7 @@ func (s *Platform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 	if appDeploymentType == cloudcommon.AppDeploymentTypeKubernetes {
 		err = k8smgmt.DeleteAppInst(client, names, app, appInst)
 	} else if appDeploymentType == cloudcommon.AppDeploymentTypeHelm {
-		err = k8smgmt.DeleteHelmAppInst(client, names, clusterInst, app)
+		err = k8smgmt.DeleteHelmAppInst(client, names, clusterInst)
 	} else {
 		err = fmt.Errorf("invalid deployment type %s for dind", appDeploymentType)
 	}


### PR DESCRIPTION
Helm release name requirements are DNS-like. Added DNS name normalization as well as app version to the release name.