### PR TITLE
fix case where CRM runs locally but for a remote cloudlet

### DIFF
--- a/cloud-resource-manager/platform/pc/pc.go
+++ b/cloud-resource-manager/platform/pc/pc.go
@@ -53,7 +53,9 @@ func WriteFile(client PlatformClient, file string, contents string, kind string,
 	// If we are running on a mac and we are trying to run base64 decode replace "-d" with "-D"
 	decodeCmd := "base64 -d"
 	if runtime.GOOS == "darwin" {
-		decodeCmd = "base64 -D"
+		if _, isLocalClient := client.(*LocalClient); isLocalClient {
+			decodeCmd = "base64 -D"
+		}
 	}
 	cmd := fmt.Sprintf("%s <<< %s > %s", decodeCmd, dat, file)
 	if sudo {


### PR DESCRIPTION
The check for running base64 with "-D" instead of "-d" for mac (DIND) needs to be bypassed when the CRM runs on Mac, but we are not running a local ssh client.  In that case the RootLB is running the command and it needs the linux argument not the mac one.