### PR TITLE
EDGECLOUD-1609 Failed to delete heat stack on cloudlet deletion as vault RoleId/SecretId is missing

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -221,6 +221,7 @@ func (s *CloudletApi) CreateCloudlet(in *edgeproto.Cloudlet, cb edgeproto.Cloudl
 
 	if in.PhysicalName == "" {
 		in.PhysicalName = in.Key.Name
+		cb.Send(&edgeproto.Result{Message: "Setting physicalname to match cloudlet name"})
 	}
 
 	if in.Version == "" {
@@ -673,9 +674,11 @@ func (s *CloudletApi) UpgradeCloudlet(ctx context.Context, in *edgeproto.Cloudle
 }
 
 func (s *CloudletApi) DeleteCloudlet(in *edgeproto.Cloudlet, cb edgeproto.CloudletApi_DeleteCloudletServer) error {
-	pfConfig := edgeproto.PlatformConfig{}
-	pfConfig.VaultAddr = *vaultAddr
-	return s.deleteCloudletInternal(DefCallContext(), in, &pfConfig, cb)
+	pfConfig, err := getPlatformConfig(cb.Context(), in)
+	if err != nil {
+		return err
+	}
+	return s.deleteCloudletInternal(DefCallContext(), in, pfConfig, cb)
 }
 
 func (s *CloudletApi) deleteCloudletInternal(cctx *CallContext, in *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, cb edgeproto.CloudletApi_DeleteCloudletServer) error {


### PR DESCRIPTION
* Platform config was missing CRM role-id/secret-id, added the code to fix this
* Also added a message to notify end-user that physicalname defaults to cloudlet name