### PR TITLE
EDGECLOUD-1518: Fix cloudlet state check to not ignore error state

### DIFF
--- a/controller/cloudletinfo_api.go
+++ b/controller/cloudletinfo_api.go
@@ -164,8 +164,6 @@ func (s *CloudletInfoApi) checkCloudletReady(key *edgeproto.CloudletKey) error {
 		return fmt.Errorf("Cloudlet %v is in failed upgrade state, please upgrade it manually", key)
 	}
 
-	// For testing, state is Errors due to openstack limits not found.
-	// Errors state does indicate it is online, so consider it ok.
 	state := s.getCloudletState(key)
 	if state == edgeproto.CloudletState_CLOUDLET_STATE_READY {
 		return nil


### PR DESCRIPTION
* We use fake platform for testing, and so following Error check can be removed 
* Passes unit tests and regression tests