### PR TITLE
EDGECLOUD-1654 fix exists error message

### DIFF
--- a/objstore/objstore.go
+++ b/objstore/objstore.go
@@ -199,9 +199,9 @@ func DbKeyPrefixParse(inkey string) (region, typ, key string, err error) {
 }
 
 func NotFoundError(key string) error {
-	return fmt.Errorf("key %s not found", key)
+	return fmt.Errorf("key %s not found", DbKeyPrefixRemove(key))
 }
 
 func ExistsError(key string) error {
-	return fmt.Errorf("key %s already exists", key)
+	return fmt.Errorf("key %s already exists", DbKeyPrefixRemove(key))
 }


### PR DESCRIPTION
Remove dbkey prefix from key in error messages:

before:
Error: CreateFlavor failed: key 1/Flavor/{"name":"x1.medium"} already exists
after:
Error: CreateFlavor failed: key {"name":"x1.medium"} already exists