### PR TITLE
EDGECLOUD-1711: CreateCloudlet failing because it is using local region for the vault path

### DIFF
--- a/cloudcommon/services.go
+++ b/cloudcommon/services.go
@@ -34,6 +34,7 @@ func getCrmProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig
 	testMode := false
 	span := ""
 	cleanupMode := false
+	region := ""
 	if pfConfig != nil {
 		for k, v := range pfConfig.EnvVar {
 			envVars[k] = v
@@ -44,6 +45,7 @@ func getCrmProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig
 		testMode = pfConfig.TestMode
 		span = pfConfig.Span
 		cleanupMode = pfConfig.CleanupMode
+		region = pfConfig.Region
 	}
 	for envKey, envVal := range cloudlet.EnvVar {
 		envVars[envKey] = envVal
@@ -69,6 +71,7 @@ func getCrmProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig
 		Span:         span,
 		CleanupMode:  cleanupMode,
 		Version:      cloudlet.Version,
+		Region:       region,
 	}, opts, nil
 }
 

--- a/integration/process/process_defs.go
+++ b/integration/process/process_defs.go
@@ -63,6 +63,7 @@ type Crm struct {
 	Span          string
 	CleanupMode   bool
 	Version       string
+	Region        string
 }
 type LocApiSim struct {
 	Common  `yaml:",inline"`

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -378,6 +378,10 @@ func (p *Crm) GetArgs(opts ...StartOp) []string {
 		args = append(args, "--version")
 		args = append(args, p.Version)
 	}
+	if p.Region != "" {
+		args = append(args, "--region")
+		args = append(args, p.Region)
+	}
 	options := StartOptions{}
 	options.ApplyStartOptions(opts...)
 	if options.Debug != "" {


### PR DESCRIPTION
* Missed adding region argument to crmserver
* Similar change done in edge-cloud-infra repo for shepherd service: https://github.com/mobiledgex/edge-cloud-infra/pull/530