### PR TITLE
Edge-cloud changes for the edge-proto swagger docs enhancements

### DIFF
--- a/d-match-engine/dme-proto/Makefile
+++ b/d-match-engine/dme-proto/Makefile
@@ -3,7 +3,7 @@
 GW		= $(shell go list -f '{{ .Dir }}' -m github.com/grpc-ecosystem/grpc-gateway)
 APIS		= $(shell go list -f '{{ .Dir }}' -m github.com/gogo/googleapis)
 INCLUDE		= -I. -I${GW} -I${APIS} -I${GOPATH}
-BUILTIN		= Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,Mgoogle/api/annotations.proto=github.com/gogo/googleapis/google/api,Mgoogle/protobuf/field_mask.proto=github.com/gogo/protobuf/types
+BUILTIN		= Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,Mgoogle/api/annotations.proto=github.com/gogo/googleapis/google/api,Mgoogle/protobuf/field_mask.proto=github.com/gogo/protobuf/types,Mprotoc-gen-swagger/options/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options
 PROTOS		= app-client.proto appcommon.proto dynamic-location-group.proto loc.proto
 DMEDIR		= ${GOPATH}/src/github.com/mobiledgex/edge-proto/dme
 


### PR DESCRIPTION
Build changes for this edge-proto pull request:
https://github.com/mobiledgex/edge-proto/pull/7

There are also a bunch of changes in the `d-match-engine/dme-proto/*.pb.go` because of the edge-proto change. Unsure on whether to check those in right now, or wait until the final version of the edge-proto documentation text is finalised.

Right now, this is sufficient for builds to work.