### PR TITLE
EDGECLOUD-1749 avoid triggering updates to go.mod for new projects

### DIFF
--- a/Makefile.tools
+++ b/Makefile.tools
@@ -10,4 +10,5 @@ all:
 	go install ${GOGOPROTO}/protoc-gen-gogo
 	go install ${GOGOPROTO}/protoc-gen-gogofast
 	go install ${GRPCGATEWAY}/protoc-gen-grpc-gateway
-	go get github.com/uber/prototool/cmd/prototool
+	(cd ~/go; go install github.com/uber/prototool/cmd/prototool)
+	(cd ~/go/src/github.com/grpc-ecosystem/grpc-gateway; go install ./protoc-gen-swagger)


### PR DESCRIPTION
Change make tools to avoid updating versions in go.mod. Running "go get" or "go install" within the context of edge-cloud will cause go to re-evaluated all dependency versions, which causes some grpc/protobuf related code to break due to incompatibility with newer versions.