### PR TITLE
quick fix for unit test failure

### DIFF
--- a/controller/alert_api_test.go
+++ b/controller/alert_api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	influxq "github.com/mobiledgex/edge-cloud/controller/influxq_client"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/objstore"
 	"github.com/mobiledgex/edge-cloud/testutil"
@@ -42,4 +43,5 @@ func testinit() {
 	dockerRegistry := "docker.mobiledgex.net"
 	registryFQDN = &dockerRegistry
 	vaultConfig, _ = vault.BestConfig("")
+	services.events = influxq.NewInfluxQ("events", "user", "pass")
 }


### PR DESCRIPTION
added events influx queue to the unit test so metrics could be "written" somewhere