### PR TITLE
EDGECLOUD-1824 Fix invalid ctx when fetching restagtable + improved m…

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -1049,7 +1049,7 @@ func (s *CloudletApi) FindFlavorMatch(ctx context.Context, in *edgeproto.FlavorM
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving target flavor")
 	}
-	spec, vmerr := resTagTableApi.GetVMSpec(mexFlavor, cl, cli)
+	spec, vmerr := resTagTableApi.GetVMSpec(ctx, mexFlavor, cl, cli)
 	if vmerr != nil {
 		return nil, vmerr
 	}

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -313,7 +313,7 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 			return fmt.Errorf("flavor %s not found", in.Flavor.Name)
 		}
 		var err error
-		vmspec, err := resTagTableApi.GetVMSpec(nodeFlavor, cloudlet, info)
+		vmspec, err := resTagTableApi.GetVMSpec(ctx, nodeFlavor, cloudlet, info)
 		if err != nil {
 			return err
 		}

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -594,7 +594,7 @@ var CloudletInfoData = []edgeproto.CloudletInfo{
 				Vcpus:   uint64(10),
 				Ram:     uint64(8192),
 				Disk:    uint64(40),
-				PropMap: map[string]string{"pci": "T4:1"},
+				PropMap: map[string]string{"pci_passthrough": "alias=t4:1"},
 			},
 			&edgeproto.FlavorInfo{
 				Name:    "flavor.large-pci",


### PR DESCRIPTION
…atching + test data + cli args

What changed? 
modified:   controller/cloudlet_api.go          // GetVMSpec now takes ctx
modified:   controller/cloudlet_api_test.go // ctx for GetVMSpec + Unit tests 
modified:   controller/clusterinst_api.go   // ctx for GetVMSpec
modified:   controller/restagtable_api.go // ctx for restagtable fetch, + matching improvements 
modified:   testutil/test_data.go              // spelling of gpu resources for tests 

Made DeleteResTagTable not require tags values, in case all were removed first with RemoveResTag.
