### PR TITLE
Fix bug in docker due to no appconfig

### DIFF
--- a/cloud-resource-manager/access/access-config.go
+++ b/cloud-resource-manager/access/access-config.go
@@ -33,7 +33,8 @@ func GetAppAccessConfig(ctx context.Context, configs []*edgeproto.ConfigFile) (*
 
 	log.SpanLog(ctx, log.DebugLevelMexos, "getAppAccessConfig", "deploymentVars", deploymentVars, "varsFound", varsFound)
 	if !varsFound {
-		return nil, fmt.Errorf("unable to find replacement vars")
+		// If no deployment vars were populated, return an empty config
+		return &aac, nil
 	}
 	// Walk the Configs in the App and generate the yaml files from the helm customization ones
 	for _, v := range configs {


### PR DESCRIPTION
EDGECLOUD-1819

I broke docker-standalone apps with my change to App Configs for TLS certs and wildcard DNS.  The issue is that docker does not populate the CrmReplaceVars vars in the context. 

If and when we need App Configs for docker, we will need to populate that CrmReplaceVars, but this functionality is not implemented yet anyway.   For now the easiest and most reliable fix for any use case I may have broken here is return an empty AppConfig if there are no deployment variables set. 



 