### PR TITLE
EDGECLOUD-1771 bad names for heat stack

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -532,7 +532,7 @@ func (s *ClusterInstApi) deleteClusterInstInternal(cctx *CallContext, in *edgepr
 	}
 
 	// Delete appInsts that are set for autodelete
-	if err := appInstApi.AutoDeleteAppInsts(&in.Key, cb); err != nil {
+	if err := appInstApi.AutoDeleteAppInsts(&in.Key, cctx.Override, cb); err != nil {
 		// restore previous state since we failed pre-delete actions
 		in.State = prevState
 		s.store.Update(ctx, in, s.sync.syncWait)

--- a/util/validate.go
+++ b/util/validate.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // If new valid characters are added here, be sure to update
@@ -79,6 +80,27 @@ func K8SSanitize(name string) string {
 		",", "",
 		"!", "")
 	return strings.ToLower(r.Replace(name))
+}
+
+// alphanumeric plus -_. first char must be alpha, <= 255 chars.
+func HeatSanitize(name string) string {
+	r := strings.NewReplacer(
+		" ", "",
+		"&", "",
+		",", "",
+		"!", "")
+	str := r.Replace(name)
+	if str == "" {
+		return str
+	}
+	if !unicode.IsLetter(rune(str[0])) {
+		// first character must be alpha
+		str = "a" + str
+	}
+	if len(str) > 255 {
+		str = str[:254]
+	}
+	return str
 }
 
 func ValidObjName(name string) error {

--- a/util/validate_test.go
+++ b/util/validate_test.go
@@ -125,3 +125,27 @@ func TestVersion(t *testing.T) {
 	_, err = VersionParse("2011-1-1")
 	require.NotNil(t, err, "invalid version")
 }
+
+func TestHeatSanitize(t *testing.T) {
+	longstring := make([]rune, 300)
+	for i := range longstring {
+		longstring[i] = 'a'
+	}
+
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"foo-bar", "foo-bar"},
+		{"foo_bar1234567890", "foo_bar1234567890"},
+		{"foo.bar-baz_", "foo.bar-baz_"},
+		{"foo bar&baz,blah,!no", "foobarbazblahno"},
+		{"00foo", "a00foo"},
+		{"0jon ber,lin&", "a0jonberlin"},
+		{string(longstring), string(longstring[:254])},
+	}
+	for _, test := range tests {
+		str := HeatSanitize(test.name)
+		require.Equal(t, test.expected, str)
+	}
+}


### PR DESCRIPTION
Add HeatSanitize func to clean up names for heat stacks.

Also fixed an issue where crmoverride on DeleteClusterInst didn't carry over to Auto-AppInsts (like Prometheus), so I couldn't delete the ClusterInst without the Cloudlet in Ready state even when specifying crm override.