### PR TITLE
use proxy within SendHTTPReqAuth

### DIFF
--- a/cloudcommon/registry.go
+++ b/cloudcommon/registry.go
@@ -90,11 +90,12 @@ func SendHTTPReqAuth(ctx context.Context, method, regUrl string, auth *RegistryA
 			// Response Header Timeout
 			ExpectContinueTimeout: 5 * time.Second,
 			ResponseHeaderTimeout: 5 * time.Second,
+			// use proxy if env vars set
+			Proxy: http.ProxyFromEnvironment,
 		},
 		// Prevent endless redirects
 		Timeout: 10 * time.Minute,
 	}
-
 	req, err := http.NewRequest(method, regUrl, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed sending request %v", err)


### PR DESCRIPTION
EDGECLOUD-1845

CreateApp with deployment=vm is not working in TELUS.  The reason is that all http/https traffic must go through the forward proxy running on CRM-GW.    It works fine for docker and for the vault but Artifactory is not using the proxy even though env var https_proxy is set.

Fix is to add http.ProxyFromEnvironment to use the proxy from the env vars if they are set.