### PR TITLE
EDGECLOUD-1802 crmoverride delete tests

### DIFF
--- a/controller/main_test.go
+++ b/controller/main_test.go
@@ -119,6 +119,9 @@ func TestController(t *testing.T) {
 	require.NotNil(t, err)
 	// test that delete works after removing dependencies
 	for _, inst := range testutil.AppInstData {
+		if testutil.IsAutoClusterAutoDeleteApp(&inst.Key) {
+			continue
+		}
 		stream, err := appInstClient.DeleteAppInst(ctx, &inst)
 		err = testutil.AppInstReadResultStream(stream, err)
 		require.Nil(t, err)

--- a/notify/notify_tree_test.go
+++ b/notify/notify_tree_test.go
@@ -94,9 +94,9 @@ func TestNotifyTree(t *testing.T) {
 	// crms at all levels get all flavors
 	// mid level gets the appInsts and clusterInsts for all below it.
 	// low level only gets the ones for itself.
-	checkClientCache(t, low21, 3, 3, 4, 1)
-	checkClientCache(t, low22, 3, 2, 2, 1)
-	checkClientCache(t, mid2, 3, 5, 6, 2)
+	checkClientCache(t, low21, 3, 3, 5, 1)
+	checkClientCache(t, low22, 3, 2, 3, 1)
+	checkClientCache(t, mid2, 3, 5, 8, 2)
 
 	// Add info objs to low nodes
 	low11.handler.AppInstInfoCache.Update(ctx, &testutil.AppInstInfoData[0], 0)

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -1,6 +1,9 @@
 package testutil
 
 import (
+	fmt "fmt"
+	"strings"
+
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/util"
@@ -461,28 +464,28 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 	},
 }
 var AppInstData = []edgeproto.AppInst{
-	edgeproto.AppInst{
+	edgeproto.AppInst{ // 0
 		Key: edgeproto.AppInstKey{
 			AppKey:         AppData[0].Key,
 			ClusterInstKey: ClusterInstData[0].Key,
 		},
 		CloudletLoc: CloudletData[0].Location,
 	},
-	edgeproto.AppInst{
+	edgeproto.AppInst{ // 1
 		Key: edgeproto.AppInstKey{
 			AppKey:         AppData[0].Key,
 			ClusterInstKey: ClusterInstData[3].Key,
 		},
 		CloudletLoc: CloudletData[0].Location,
 	},
-	edgeproto.AppInst{
+	edgeproto.AppInst{ // 2
 		Key: edgeproto.AppInstKey{
 			AppKey:         AppData[0].Key,
 			ClusterInstKey: ClusterInstData[1].Key,
 		},
 		CloudletLoc: CloudletData[1].Location,
 	},
-	edgeproto.AppInst{
+	edgeproto.AppInst{ // 3
 		Key: edgeproto.AppInstKey{
 			AppKey: AppData[1].Key,
 			// ClusterInst is ClusterInstAutoData[0]
@@ -490,7 +493,7 @@ var AppInstData = []edgeproto.AppInst{
 		},
 		CloudletLoc: CloudletData[1].Location,
 	},
-	edgeproto.AppInst{
+	edgeproto.AppInst{ // 4
 		Key: edgeproto.AppInstKey{
 			AppKey: AppData[2].Key,
 			// ClusterInst is ClusterInstAutoData[1]
@@ -498,14 +501,14 @@ var AppInstData = []edgeproto.AppInst{
 		},
 		CloudletLoc: CloudletData[2].Location,
 	},
-	edgeproto.AppInst{
+	edgeproto.AppInst{ // 5
 		Key: edgeproto.AppInstKey{
 			AppKey:         AppData[5].Key,
 			ClusterInstKey: ClusterInstData[2].Key,
 		},
 		CloudletLoc: CloudletData[2].Location,
 	},
-	edgeproto.AppInst{
+	edgeproto.AppInst{ // 6
 		Key: edgeproto.AppInstKey{
 			AppKey: AppData[6].Key,
 			// ClusterInst is ClusterInstAutoData[2]
@@ -514,20 +517,33 @@ var AppInstData = []edgeproto.AppInst{
 		CloudletLoc:         CloudletData[2].Location,
 		AutoClusterIpAccess: edgeproto.IpAccess_IP_ACCESS_DEDICATED,
 	},
-	edgeproto.AppInst{
+	edgeproto.AppInst{ // 7
 		Key: edgeproto.AppInstKey{
 			AppKey:         AppData[6].Key,
 			ClusterInstKey: ClusterInstData[0].Key,
 		},
 		CloudletLoc: CloudletData[0].Location,
 	},
-
-	edgeproto.AppInst{
+	edgeproto.AppInst{ // 8
 		Key: edgeproto.AppInstKey{
 			AppKey:         AppData[7].Key,
 			ClusterInstKey: ClusterInstData[0].Key,
 		},
 		CloudletLoc: CloudletData[0].Location,
+	},
+	edgeproto.AppInst{ // 9
+		Key: edgeproto.AppInstKey{
+			AppKey:         AppData[9].Key, //auto-delete app
+			ClusterInstKey: ClusterInstData[0].Key,
+		},
+		CloudletLoc: CloudletData[0].Location,
+	},
+	edgeproto.AppInst{ // 10
+		Key: edgeproto.AppInstKey{
+			AppKey:         AppData[9].Key, //auto-delete app
+			ClusterInstKey: ClusterInstAutoData[0].Key,
+		},
+		CloudletLoc: CloudletData[1].Location,
 	},
 }
 var AppInstInfoData = []edgeproto.AppInstInfo{
@@ -1150,4 +1166,16 @@ var PrivacyPolicyErrorData = []edgeproto.PrivacyPolicy{
 			},
 		},
 	},
+}
+
+func IsAutoClusterAutoDeleteApp(key *edgeproto.AppInstKey) bool {
+	if !strings.HasPrefix(key.ClusterInstKey.ClusterKey.Name, "autocluster") {
+		return false
+	}
+	for _, app := range AppData {
+		if app.Key.Matches(&key.AppKey) {
+			return app.DelOpt == edgeproto.DeleteType_AUTO_DELETE
+		}
+	}
+	panic(fmt.Sprintf("App definition not found for %v", key))
 }


### PR DESCRIPTION
Adds unit tests to check crmoverride working for delete AppInst and delete ClusterInst cases, where things are in a bad state.

The fix for the problem described in the bug report was actually fixed as part of https://github.com/mobiledgex/edge-cloud/pull/778 since I hit it there during testing.

I did hit one other issue as a result of the unit tests, where an autocluster was not deleted when deleting the app because the crmoverride caused the delete function to exit early before cleaning up the autocluster. That's the only fix in this PR.