### PR TITLE
Include the autoprov binary in the edge-cloud image

### DIFF
--- a/docker/Dockerfile.edge-cloud
+++ b/docker/Dockerfile.edge-cloud
@@ -71,17 +71,19 @@ RUN chmod +x /usr/local/bin/edge-cloud-entrypoint.sh \
 	     /usr/local/bin/test-edgectl.sh \
 	     /usr/local/bin/vault-cert
 
-COPY --from=build /go/bin/controller /usr/local/bin
-COPY --from=build /go/bin/crmserver /usr/local/bin
-COPY --from=build /go/bin/dme-server /usr/local/bin
-COPY --from=build /go/bin/cluster-svc /usr/local/bin
-COPY --from=build /go/bin/edgectl /usr/local/bin
-COPY --from=build /go/bin/tok-srv-sim /usr/local/bin
-COPY --from=build /go/bin/loc-api-sim /usr/local/bin
-COPY --from=build /go/bin/mc /usr/local/bin
-COPY --from=build /go/bin/shepherd /usr/local/bin
-COPY --from=build /go/bin/mcctl /usr/local/bin
-COPY --from=build /go/bin/resource-tracker /usr/local/bin
+COPY --from=build /go/bin/controller \
+		  /go/bin/crmserver \
+		  /go/bin/dme-server \
+		  /go/bin/cluster-svc \
+		  /go/bin/edgectl \
+		  /go/bin/tok-srv-sim \
+		  /go/bin/loc-api-sim \
+		  /go/bin/mc \
+		  /go/bin/shepherd \
+		  /go/bin/mcctl \
+		  /go/bin/resource-tracker \
+		  /go/bin/autoprov \
+		  /usr/local/bin/
 COPY --from=build /go/plugins /plugins
 
 COPY --from=build /go/src/github.com/mobiledgex/edge-cloud/edgeproto/doc/*.json /usr/local/doc/internal/


### PR DESCRIPTION
Also minor rework of the Dockerfile to reduce the number of layers
created.  We rebuilt all golang binaries for each build anyway, and so
there's no advantage as far as layer caching is concerned to copying
each binary in a separate step.