### PR TITLE
EDGECLOUD-1679: CreateApp with artifactory I dont have access to should give more meaningful error

### DIFF
--- a/cloudcommon/registry.go
+++ b/cloudcommon/registry.go
@@ -216,10 +216,8 @@ func SendHTTPReq(ctx context.Context, method, regUrl string, vaultConfig *vault.
 				return resp, nil
 			}
 			log.SpanLog(ctx, log.DebugLevelApi, "unable to handle www-auth", "err", err)
-		} else {
-			err = fmt.Errorf("Access denied to registry path")
 		}
-		return nil, err
+		return nil, fmt.Errorf("Access denied to registry path")
 	case http.StatusForbidden:
 		resp.Body.Close()
 		return nil, fmt.Errorf("Invalid credentials to access URL: %s", regUrl)


### PR DESCRIPTION
* HandleWWWAuth is mainly for docker V2 registry. As the bearer token is found there.
* But in general if there is an error with HandleWWWAuth, then the main error is still `Access Denied`. Hence just returning this general error, as more specific error will be present in the logs.