### PR TITLE
EDGECLOUD-1903 cannot delete AppInst in UPDATE_ERROR

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -1002,7 +1002,7 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			return err
 		}
 
-		if !cctx.Undo && in.State != edgeproto.TrackedState_READY && in.State != edgeproto.TrackedState_CREATE_ERROR && in.State != edgeproto.TrackedState_DELETE_ERROR && !ignoreTransient(cctx, in.State) {
+		if !cctx.Undo && in.State != edgeproto.TrackedState_READY && in.State != edgeproto.TrackedState_CREATE_ERROR && in.State != edgeproto.TrackedState_DELETE_ERROR && in.State != edgeproto.TrackedState_UPDATE_ERROR && !ignoreTransient(cctx, in.State) {
 			log.SpanLog(ctx, log.DebugLevelApi, "AppInst busy, cannot delete", "state", in.State)
 			return errors.New("AppInst busy, cannot delete")
 		}

--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -110,6 +110,16 @@ func TestAppInstApi(t *testing.T) {
 	err = appInstApi.DeleteAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 	require.Nil(t, err, "delete overrides create error")
 	checkAppInstState(t, ctx, commonApi, &obj, edgeproto.TrackedState_NOT_PRESENT)
+	// check override of error UPDATE_ERROR
+	err = appInstApi.CreateAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
+	require.Nil(t, err, "create appinst")
+	checkAppInstState(t, ctx, commonApi, &obj, edgeproto.TrackedState_READY)
+	err = forceAppInstState(ctx, &obj, edgeproto.TrackedState_UPDATE_ERROR)
+	require.Nil(t, err, "force state")
+	checkAppInstState(t, ctx, commonApi, &obj, edgeproto.TrackedState_UPDATE_ERROR)
+	err = appInstApi.DeleteAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
+	require.Nil(t, err, "delete overrides create error")
+	checkAppInstState(t, ctx, commonApi, &obj, edgeproto.TrackedState_NOT_PRESENT)
 
 	// override CRM error
 	responder.SetSimulateAppCreateFailure(true)


### PR DESCRIPTION
Allow AppInst in UPDATE_ERROR state to be deleted.