### PR TITLE
EDGECLOUD-2043 autoprov bug fixes

### DIFF
--- a/controller/autoprovpolicy_api.go
+++ b/controller/autoprovpolicy_api.go
@@ -8,6 +8,7 @@ import (
 	influxq "github.com/mobiledgex/edge-cloud/controller/influxq_client"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 )
 
@@ -154,7 +155,7 @@ func (s *AutoProvPolicyApi) Recv(ctx context.Context, msg *edgeproto.AutoProvCou
 		target := msg.Counts[0]
 		log.SpanLog(ctx, log.DebugLevelMetrics, "auto-prov count recv immedate", "target", target)
 		go func() {
-			span := log.StartSpan(log.DebugLevelMetrics, "AutoProvCreateAppInst")
+			span := log.StartSpan(log.DebugLevelMetrics, "AutoProvCreateAppInst", opentracing.ChildOf(log.SpanFromContext(ctx).Context()))
 			ctx := log.ContextWithSpan(context.Background(), span)
 			stream := streamoutAppInst{
 				ctx:      ctx,

--- a/d-match-engine/dme-common/autoprov_dmestats.go
+++ b/d-match-engine/dme-common/autoprov_dmestats.go
@@ -106,7 +106,7 @@ func (s *AutoProvStats) Increment(ctx context.Context, appKey *edgeproto.AppKey,
 	}
 	stats.count++
 	log.SpanLog(ctx, log.DebugLevelMetrics, "autoprovstats increment", "key", key, "idx", idx, "deployClientCount", deployClientCount, "intervalCount", intervalCount, "stats count", stats.count, "stats last count", stats.lastCount)
-	if uint32(stats.count-stats.lastCount) == deployClientCount && intervalCount <= 1 {
+	if uint32(stats.count-stats.lastCount) >= deployClientCount && intervalCount <= 1 {
 		// special case, duration is the same as the interval,
 		// and deploy count met, so stats upstream to handle
 		// this immediately.

--- a/d-match-engine/dme-common/match-engine.go
+++ b/d-match-engine/dme-common/match-engine.go
@@ -46,6 +46,7 @@ type DmeApp struct {
 	AndroidPackageName string
 	OfficialFqdn       string
 	AutoProvPolicy     *AutoProvPolicy
+	Deployment         string
 }
 
 type DmeCloudlet struct {
@@ -132,6 +133,7 @@ func AddApp(in *edgeproto.App) {
 	app.AuthPublicKey = in.AuthPublicKey
 	app.AndroidPackageName = in.AndroidPackageName
 	app.OfficialFqdn = in.OfficialFqdn
+	app.Deployment = in.Deployment
 	clearAutoProvStats := false
 	if app.AutoProvPolicy != nil && in.AutoProvPolicy == "" {
 		clearAutoProvStats = true
@@ -522,7 +524,7 @@ func findClosestForCarrier(ctx context.Context, carrierName string, key edgeprot
 				// make sure there's a free reservable ClusterInst
 				// on the cloudlet. if cinsts exists there is at
 				// least one free.
-				cinstKey := tbl.FreeReservableClusterInsts.GetForCloudlet(&cl.Key)
+				cinstKey := tbl.FreeReservableClusterInsts.GetForCloudlet(&cl.Key, app.Deployment)
 				if cinstKey == nil {
 					continue
 				}

--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/notify"
 	"github.com/mobiledgex/edge-cloud/tls"
 	"github.com/mobiledgex/edge-cloud/util"
+	"github.com/mobiledgex/edge-cloud/vault"
 	"github.com/mobiledgex/edge-cloud/version"
 	"github.com/segmentio/ksuid"
 	"google.golang.org/grpc"
@@ -54,6 +55,7 @@ var statsShards = flag.Uint("statsShards", 10, "number of shards (locks) in memo
 var cookieExpiration = flag.Duration("cookieExpiration", time.Hour*24, "Cookie expiration time")
 var region = flag.String("region", "local", "region name")
 var solib = flag.String("plugin", "", "plugin file")
+var testMode = flag.Bool("testMode", false, "Run controller in test mode")
 
 // TODO: carrier arg is redundant with OperatorKey.Name in myCloudletKey, and
 // should be replaced by it, but requires dealing with carrier-specific
@@ -307,6 +309,12 @@ func main() {
 	err = dmecommon.InitVault(*vaultAddr, *region)
 	if err != nil {
 		log.FatalLog("Failed to init vault", "err", err)
+	}
+	if *testMode {
+		// init JWK so Vault not required
+		dmecommon.Jwks.Keys[0] = &vault.JWK{
+			Secret: "secret",
+		}
 	}
 
 	dmecommon.SetupMatchEngine()


### PR DESCRIPTION
The prune function of the free-reservable-clusterinsts-cache was incorrect. It would flush valid objects. This was causing a bug to appear if the notify connection was reset (via dme or controller restart) - auto-prov would fail because it didn't have the reservable cluster inst in the local cache.

I also noticed that autoprov would try to deploy a docker app inside a k8s cluster, which would fail. So added a deployment type check when looking for an appropriate reservable cluster inst.