### PR TITLE
EDGECLOUD-2068: add extra check for OS flavors with Opt. resources

### DIFF
--- a/controller/restagtable_api.go
+++ b/controller/restagtable_api.go
@@ -185,7 +185,7 @@ func (s *ResTagTableApi) isOptResOSFlavor(ctx context.Context, stm concurrency.S
 		return false // can't be no properties at all.
 	}
 	if cl.ResTagMap == nil {
-		log.InfoLog("Cloudlet %s has no OptResMap to support Optional resource mappings\n", cl.Key.Name)
+		log.SpanLog(ctx, log.DebugLevelApi, "No OptResMap for", "cloudlet", cl.Key.Name)
 		return false
 	}
 	tagtblkey := cl.ResTagMap["gpu"]
@@ -194,7 +194,7 @@ func (s *ResTagTableApi) isOptResOSFlavor(ctx context.Context, stm concurrency.S
 	if err != nil || tbl == nil {
 		// gpu requested and
 		// no gpu table, osFlavor fails
-		log.InfoLog("No OptResTagTable %s found for cloudlet %s\n", tagtblkey.Name, cl.Key.Name)
+		log.SpanLog(ctx, log.DebugLevelApi, "No ResTagTable", "named", cl.Key.Name, "for cloudlet", cl.Key.Name)
 		return false
 	}
 	// look in flavor.PropMap for hits
@@ -261,7 +261,6 @@ func (s *ResTagTableApi) optResLookup(ctx context.Context, stm concurrency.STM, 
 				for flav_key, flav_val := range flavor.PropMap {
 					// How many resources are supplied by this os flavor?
 					alias = strings.Split(flav_val, ":")
-					log.InfoLog("optResLookup", "alias", alias)
 					if len(alias) == 2 {
 						if numres, err = strconv.Atoi(alias[1]); err != nil {
 							return "", "", false, fmt.Errorf("Non-numeric count found in os flavor props for %s", flavor.Name)
@@ -292,9 +291,7 @@ func (s *ResTagTableApi) optResLookup(ctx context.Context, stm concurrency.STM, 
 		flavor_found:
 			az, _ = s.findAZmatch("gpu", cli)
 			img, _ = s.findImagematch("gpu", cli)
-
-			log.InfoLog("OptResLookup", "mex flavor", nodeflavor.Key.Name, "os flavor", flavor.Name)
-
+			log.SpanLog(ctx, log.DebugLevelApi, "Mapped", "mex flavor:", nodeflavor.Key.Name, "os flavor:", flavor.Name)
 			return az, img, true, nil
 
 			// Other resources TBI
@@ -303,7 +300,7 @@ func (s *ResTagTableApi) optResLookup(ctx context.Context, stm concurrency.STM, 
 		case int32(edgeproto.OptResNames_NIC):
 			break
 		default:
-			log.InfoLog("Unhandled resource", "res", res)
+			log.SpanLog(ctx, log.DebugLevelApi, "Unhandled resource", "res", res)
 		}
 	}
 	return "", "", false, nil
@@ -317,7 +314,8 @@ func (s *ResTagTableApi) GetVMSpec(ctx context.Context, stm concurrency.STM, nod
 	var az, img string
 
 	flavorList = cli.Flavors
-	log.InfoLog("GetVMSpec with closest flavor available", "flavorList", flavorList, "nodeflavor", nodeflavor)
+	log.SpanLog(ctx, log.DebugLevelApi, "GetVMSpec with closest flavor available", "flavorList", flavorList, "nodeflavor", nodeflavor)
+
 	sort.Slice(flavorList[:], func(i, j int) bool {
 		if flavorList[i].Vcpus < flavorList[j].Vcpus {
 			return true
@@ -366,7 +364,7 @@ func (s *ResTagTableApi) GetVMSpec(ctx context.Context, stm concurrency.STM, nod
 		vmspec.FlavorName = flavor.Name
 		vmspec.AvailabilityZone = az
 		vmspec.ImageName = img
-		log.InfoLog("Found closest flavor", "flavor", flavor, "vmspec", vmspec)
+		log.SpanLog(ctx, log.DebugLevelApi, "Found closest flavor", "flavor", flavor, "vmspec", vmspec)
 
 		return &vmspec, nil
 	}


### PR DESCRIPTION
Once a nominal mex flavor is matched (no Optional Resources requested) ensure the selected flavor does not offer an Optional resource, instead skip it to find the intended match (order independent)