### PR TITLE
fix writefile for GCP

### DIFF
--- a/cloud-resource-manager/platform/pc/local.go
+++ b/cloud-resource-manager/platform/pc/local.go
@@ -18,7 +18,7 @@ type LocalClient struct {
 
 // Output returns the output of the command run on the remote host.
 func (s *LocalClient) Output(command string) (string, error) {
-	cmd := exec.Command("sh", "-c", command)
+	cmd := exec.Command("bash", "-c", command)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }


### PR DESCRIPTION
CreateAppInst is broken for GCP and probably azure.  The reason is pc.WriteFile uses a redirect operator <<< which is not supported in ubuntu dash shell. You get this:

Syntax error: redirection unexpected

Fix is to switch to bash for local output.
