### PR TITLE
EDGECLOUD-2048: Fixes cloudlet upgrade

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -532,9 +532,10 @@ func (x *ShowNode) Init() {
 	x.Data = make(map[string]edgeproto.Node)
 }
 
-func getCloudletVersion(key *edgeproto.CloudletKey) (string, error) {
+func getCloudletVersion(ctx context.Context, key *edgeproto.CloudletKey) (string, error) {
 	show := ShowNode{}
 	show.Init()
+	show.Ctx = ctx
 	filter := edgeproto.Node{}
 	err := nodeApi.ShowNode(&filter, &show)
 	if err != nil {
@@ -552,8 +553,8 @@ func getCloudletVersion(key *edgeproto.CloudletKey) (string, error) {
 	return "", fmt.Errorf("Unable to find Cloudlet node")
 }
 
-func isCloudletUpgradeRequired(cloudlet *edgeproto.Cloudlet) error {
-	cloudletVersion, err := getCloudletVersion(&cloudlet.Key)
+func isCloudletUpgradeRequired(ctx context.Context, cloudlet *edgeproto.Cloudlet) error {
+	cloudletVersion, err := getCloudletVersion(ctx, &cloudlet.Key)
 	if err != nil {
 		return fmt.Errorf("unable to fetch cloudlet version: %v", err)
 	}
@@ -624,7 +625,7 @@ func (s *CloudletApi) UpdateCloudlet(in *edgeproto.Cloudlet, cb edgeproto.Cloudl
 
 	upgrade := false
 	if _, found := fmap[edgeproto.CloudletFieldContainerVersion]; found {
-		err = isCloudletUpgradeRequired(cur)
+		err = isCloudletUpgradeRequired(ctx, cur)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* Use `nodeApi.ShowNode` to get CRM node details, as right now it's just looking at the local nodecache, which won't work if there's more than one controller (horizontally scaled) because each node only knows about the nodes below it in the notify tree.
* The object (ShowNode) created here is redundant with `testutil/node_testutil.go`. This is done to avoid importing testutil package inside controller.
* Thanks @gainsley for catching this issue