### PR TITLE
EDGECLOUD-1884 healthcheck failing immediately on appinst create

### DIFF
--- a/cloud-resource-manager/proxy/envoy.go
+++ b/cloud-resource-manager/proxy/envoy.go
@@ -199,6 +199,7 @@ static_resources:
         unhealthy_threshold: 3
         healthy_threshold: 3
         tcp_health_check: {}
+        no_traffic_interval: 5s
 {{- end}}
 admin:
   access_log_path: "/var/log/admin.log"


### PR DESCRIPTION
By default Envoy would only probe backend server every 60s if there is no traffic to it.
Set the health check probe interval without any traffic to also be 5 secs, since in our case it's irrelevant whether the is active traffic to an appInst