### PR TITLE
EDGECLOUD-2184: Enable CORS Headers for DME REST APIs

### DIFF
--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -290,7 +290,7 @@ func allowCORS(h http.Handler) http.Handler {
 		if origin := r.Header.Get("Origin"); origin != "" {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			if r.Method == "OPTIONS" && r.Header.Get("Access-Control-Request-Method") != "" {
-				//preflight headers
+				// preflight headers
 				headers := []string{"Content-Type", "Accept"}
 				w.Header().Set("Access-Control-Allow-Headers", strings.Join(headers, ","))
 				methods := []string{"GET", "HEAD", "POST", "PUT", "DELETE"}


### PR DESCRIPTION
* Added support to allow all origin

```
❯ curl --insecure -H "Access-Control-Request-Method: POST" -H "Origin: http://example.com" -X POST  --head https://localhost:38001/v1/findcloudlet
HTTP/2 401
access-control-allow-origin: http://example.com
content-type: application/json
trailer: Grpc-Trailer-Content-Type
content-length: 84
date: Tue, 10 Mar 2020 10:04:58 GMT
```