### PR TITLE
fix e2e test sporadic failure

### DIFF
--- a/setup-env/e2e-tests/testfiles/find_cloudlet_autoprov.yml
+++ b/setup-env/e2e-tests/testfiles/find_cloudlet_autoprov.yml
@@ -30,6 +30,14 @@ tests:
     yaml2: "{{datadir}}/appdata_no_appinst_autoprov_show.yml"
     filetype: appdata
 
+- name: check influx stats for auto-provisioning
+  actions: [sleep=1.1,influxapi]
+  apifile: "{{datadir}}/influx_autoprov_query.yml"
+  compareyaml:
+    yaml1: "{{outputdir}}/show-commands.yml"
+    yaml2: "{{datadir}}/influx_autoprov_data.yml"
+    filetype: influxdata
+
 - name: delete provisioning, verify it is empty
   actions: [ctrlapi-delete,ctrlapi-show]
   apifile: "{{datadir}}/appdata_no_appinst.yml"
@@ -37,11 +45,3 @@ tests:
     yaml1: "{{outputdir}}/show-commands.yml"
     yaml2: "{{datadir}}/appdata_empty.yml"
     filetype: appdata
-
-- name: check influx stats for auto-provisioning
-  actions: [sleep=0.4,influxapi]
-  apifile: "{{datadir}}/influx_autoprov_query.yml"
-  compareyaml:
-    yaml1: "{{outputdir}}/show-commands.yml"
-    yaml2: "{{datadir}}/influx_autoprov_data.yml"
-    filetype: influxdata


### PR DESCRIPTION
This fixes a sporadic timing failure in the find_cloudlet auto prov stats test. The stats are pushed up every second, but if the timing is unlucky, the app data is deleted which clears the stats before the last entry is pushed to influxdb. The solution is to wait 1 sec before querying and do the delete after the query is complete.