### PR TITLE
EDGECLOUD-1771 spaces in cloudlet name

### DIFF
--- a/docker/edge-cloud-entrypoint.sh
+++ b/docker/edge-cloud-entrypoint.sh
@@ -11,51 +11,51 @@ fi
 case "$1" in
     controller)
 	shift
-	controller $*
+	controller "$@"
 	;;
     cluster-svc)
 	shift
-	cluster-svc $*
+	cluster-svc "$@"
 	;;
     crmserver)
 	shift
-	crmserver $*
+	crmserver "$@"
 	;;
     dme-server)
 	shift
-	dme-server $*
+	dme-server "$@"
 	;;
     edgectl)
 	shift
-	edgectl $*
+	edgectl "$@"
 	;;
     loc-api-sim)
 	shift
-	loc-api-sim $*
+	loc-api-sim "$@"
 	;;
     mc)
 	shift
-	mc $*
+	mc "$@"
 	;;
     mcctl)
 	shift
-	mcctl $*
+	mcctl "$@"
 	;;
     notifyroot)
 	shift
-	notifyroot $*
+	notifyroot "$@"
 	;;
     tok-srv-sim)
 	shift
-	tok-srv-sim $*
+	tok-srv-sim "$@"
 	;;
     test-edgectl)
 	shift
-	test-edgectl.sh $*
+	test-edgectl.sh "$@"
 	;;
     shepherd)
 	shift
-	shepherd $*
+	shepherd "$@"
 	;;
     dump-docs)
 	shift
@@ -72,7 +72,7 @@ case "$1" in
 	;;
     bash)
 	shift
-	/bin/bash $*
+	/bin/bash "$@"
 	;;
     *)
 	echo invalid program $1

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -436,14 +436,11 @@ func (p *Crm) LookupArgs() string { return "--cloudletKey " + p.CloudletKey }
 func (p *Crm) String(opts ...StartOp) string {
 	cmd_str := p.GetExeName()
 	args := p.GetArgs(opts...)
-	key := true
 	for _, v := range args {
-		if key {
+		if strings.HasPrefix(v, "-") {
 			cmd_str += " " + v
-			key = false
 		} else {
 			cmd_str += " '" + v + "'"
-			key = true
 		}
 	}
 	return cmd_str


### PR DESCRIPTION
This one was convoluted. The CRM command line arg 
```'{"operator_key":{"name":"tmus"},"name":"andy cloudlet"}'```
was getting split out on the space in the cloudlet name, so the json unmarshal call was only parsing
```{"operator_key":{"name":"tmus"},"name":"andy```

This string gets created in the controller, gets escaped with single quotes in process_local, gets concatenated to a single string in a docker run command, gets passed via ssh to the platform VM, gets processed by docker run, gets passed to the bash script edge-cloud-entrypoint.sh inside the docker container, before it the crm process gets it. Finally figured out the problem was the entry point script using $* was not honoring the quoted argument containing the space. It needs to be "$@" ($@ honors the original separate args but doesn't quote them when passing them on, so it still ends up getting split on the space).

Also fixed the quote func, as some args are single args like --testMode, so quoting based on position is not accurate.