### PR TITLE
fix error message when no OperatorCode specified

### DIFF
--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -85,7 +85,7 @@ func (a *NodeData) Sort() {
 
 func (key *OperatorCodeKey) ValidateKey() error {
 	if key.GetKeyString() == "" {
-		return errors.New("No organization specified")
+		return errors.New("No code specified")
 	}
 	return nil
 }


### PR DESCRIPTION
EDGECLOUD-2280:  I used the wrong error message when the code is not specified in CreateOperatorCode during org restructure which is breaking Andy's testcase.