### PR TITLE
fix delete appinst after update

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -176,7 +176,8 @@ func UpdateAppInst(ctx context.Context, vaultConfig *vault.Config, client ssh.Cl
 
 func DeleteAppInst(ctx context.Context, client ssh.Client, names *KubeNames, app *edgeproto.App, appInst *edgeproto.AppInst) error {
 	log.SpanLog(ctx, log.DebugLevelMexos, "deleting app", "name", names.AppName)
-	file := names.AppName + names.AppRevision + ".yaml"
+	// for delete, we use the appInst revision which may be behind the app revision
+	file := names.AppName + names.AppInstRevision + ".yaml"
 	cmd := fmt.Sprintf("%s kubectl delete -f %s", names.KconfEnv, file)
 	out, err := client.Output(cmd)
 	if err != nil {

--- a/cloud-resource-manager/k8smgmt/kubenames.go
+++ b/cloud-resource-manager/k8smgmt/kubenames.go
@@ -17,6 +17,7 @@ type KubeNames struct {
 	AppURI            string
 	AppImage          string
 	AppRevision       string
+	AppInstRevision   string
 	ClusterName       string
 	K8sNodeNameSuffix string
 	OperatorName      string
@@ -67,8 +68,10 @@ func GetKubeNames(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appIns
 	kubeNames.HelmAppName = util.DNSSanitize(app.Key.Name + "v" + app.Key.Version)
 	kubeNames.AppURI = appInst.Uri
 	if app.Revision > 0 {
-		// if revision is zero, skip this for backwards compatibility
 		kubeNames.AppRevision = fmt.Sprintf("%d", app.Revision)
+	}
+	if appInst.Revision > 0 {
+		kubeNames.AppInstRevision = fmt.Sprintf("%d", appInst.Revision)
 	}
 	kubeNames.AppImage = NormalizeName(app.ImagePath)
 	kubeNames.OperatorName = NormalizeName(clusterInst.Key.CloudletKey.Organization)


### PR DESCRIPTION
EDGECLOUD-2124

If an app revision is updated but the appInst is not refreshed, DeleteAppInst will fail on that appInst.  The reason is that there will be no kube yaml file which contains the revision within the app and we don't regenerate the yaml file for delete because we want to delete exactly what was deployed.

Use the revision number in the appInst rather than the app to fix this.