### PR TITLE
fix intermittent ctrl_restart e2e failure

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/crm_server_test.go
+++ b/cloud-resource-manager/cmd/crmserver/crm_server_test.go
@@ -121,7 +121,7 @@ func startMain(t *testing.T) (chan struct{}, error) {
 
 func TestCRM(t *testing.T) {
 	var err error
-	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelMexos)
+	log.SetDebugLevel(log.DebugLevelApi | log.DebugLevelNotify | log.DebugLevelMexos)
 	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())

--- a/cloudcommon/node/debugnode.go
+++ b/cloudcommon/node/debugnode.go
@@ -188,10 +188,11 @@ func (s *DebugNode) RecvDebugReply(ctx context.Context, reply *edgeproto.DebugRe
 		return
 	}
 
+	done := false
 	s.mux.Lock()
 	delete(call.sendNodes, reply.Node)
 	if len(call.sendNodes) == 0 {
-		close(call.done)
+		done = true
 	}
 	log.SpanLog(ctx, log.DebugLevelApi, "recv reply", "id", reply.Id, "numNodes", len(call.sendNodes), "node", reply.Node)
 	s.mux.Unlock()
@@ -201,6 +202,9 @@ func (s *DebugNode) RecvDebugReply(ctx context.Context, reply *edgeproto.DebugRe
 	}
 
 	call.callReply(ctx, reply)
+	if done {
+		close(call.done)
+	}
 }
 
 func (s *DebugNode) RunDebug(ctx context.Context, req *edgeproto.DebugRequest) string {

--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -930,7 +930,8 @@ func (s *CloudletApi) deleteCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 		}
 	}
 	cloudletPoolMemberApi.cloudletDeleted(ctx, &in.Key)
-	return err
+	cloudletInfoApi.cleanupCloudletInfo(ctx, &in.Key)
+	return nil
 }
 
 func (s *CloudletApi) ShowCloudlet(in *edgeproto.Cloudlet, cb edgeproto.CloudletApi_ShowCloudletServer) error {

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -699,6 +699,9 @@ func (p *Vault) StartLocal(logfile string, opts ...StartOp) error {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	if p.cmd.Process == nil {
+		return fmt.Errorf("failed to start vault process, see log %s", logfile)
+	}
 
 	options := StartOptions{}
 	options.ApplyStartOptions(opts...)

--- a/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
+++ b/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
@@ -159,6 +159,98 @@ cloudlets:
   physicalname: azure-cloud-4
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 39
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 40
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-3
+  state: CloudletStateReady
+  notifyid: 41
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: azure
+    name: azure-cloud-4
+  state: CloudletStateReady
+  notifyid: 42
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: gcp
+    name: gcp-cloud-5
+  state: CloudletStateReady
+  notifyid: 43
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: Samsung

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
@@ -68,6 +68,26 @@ cloudlets:
   physicalname: tmus-cloud-1
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 6
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
@@ -28,6 +28,25 @@ cloudlets:
     name: DefaultPlatformFlavor
   physicalname: tmus-cloud-1
   containerversion: 2019-10-24
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 6
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
 flavors:
 - key:
     name: x1.tiny

--- a/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
@@ -154,6 +154,80 @@ cloudlets:
   physicalname: gcp-cloud-5
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 1
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 2
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: azure
+    name: azure-cloud-4
+  state: CloudletStateReady
+  notifyid: 3
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: gcp
+    name: gcp-cloud-5
+  state: CloudletStateReady
+  notifyid: 4
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
@@ -153,6 +153,80 @@ cloudlets:
   physicalname: gcp-cloud-5
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 3
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 4
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: azure
+    name: azure-cloud-4
+  state: CloudletStateReady
+  notifyid: 5
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: gcp
+    name: gcp-cloud-5
+  state: CloudletStateReady
+  notifyid: 6
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/appdata_show.yml
+++ b/setup-env/e2e-tests/data/appdata_show.yml
@@ -156,6 +156,98 @@ cloudlets:
   physicalname: gcp-cloud-5
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 7
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 8
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-3
+  state: CloudletStateReady
+  notifyid: 9
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: azure
+    name: azure-cloud-4
+  state: CloudletStateReady
+  notifyid: 10
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: gcp
+    name: gcp-cloud-5
+  state: CloudletStateReady
+  notifyid: 11
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/appdata_show_after_refresh.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_refresh.yml
@@ -154,6 +154,98 @@ cloudlets:
   physicalname: gcp-cloud-5
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: gcp
+    name: gcp-cloud-5
+  state: CloudletStateReady
+  notifyid: 34
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 35
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 4
+    taskname: Deleting old CRMServer
+  containerversion: "2020-10-10"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 36
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 4
+    taskname: Deleting old CRMServer
+  containerversion: "2020-10-10"
+- key:
+    organization: tmus
+    name: tmus-cloud-3
+  state: CloudletStateReady
+  notifyid: 32
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: azure
+    name: azure-cloud-4
+  state: CloudletStateReady
+  notifyid: 33
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/appdata_show_after_refresh_all.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_refresh_all.yml
@@ -154,6 +154,98 @@ cloudlets:
   physicalname: gcp-cloud-5
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 35
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 4
+    taskname: Deleting old CRMServer
+  containerversion: "2020-10-10"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 36
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 4
+    taskname: Deleting old CRMServer
+  containerversion: "2020-10-10"
+- key:
+    organization: tmus
+    name: tmus-cloud-3
+  state: CloudletStateReady
+  notifyid: 32
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: azure
+    name: azure-cloud-4
+  state: CloudletStateReady
+  notifyid: 33
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: gcp
+    name: gcp-cloud-5
+  state: CloudletStateReady
+  notifyid: 34
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/appdata_show_prometheus_30s_interval.yml
+++ b/setup-env/e2e-tests/data/appdata_show_prometheus_30s_interval.yml
@@ -154,6 +154,98 @@ cloudlets:
   physicalname: gcp-cloud-5
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 10
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 11
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-3
+  state: CloudletStateReady
+  notifyid: 12
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: azure
+    name: azure-cloud-4
+  state: CloudletStateReady
+  notifyid: 13
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: gcp
+    name: gcp-cloud-5
+  state: CloudletStateReady
+  notifyid: 14
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/appdata_upgrade_show.yml
+++ b/setup-env/e2e-tests/data/appdata_upgrade_show.yml
@@ -157,6 +157,98 @@ cloudlets:
   physicalname: gcp-cloud-5
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: gcp
+    name: gcp-cloud-5
+  state: CloudletStateReady
+  notifyid: 33
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 34
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 4
+    taskname: Deleting old CRMServer
+  containerversion: "2020-10-10"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 35
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 4
+    taskname: Deleting old CRMServer
+  containerversion: "2020-10-10"
+- key:
+    organization: tmus
+    name: tmus-cloud-3
+  state: CloudletStateReady
+  notifyid: 31
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: azure
+    name: azure-cloud-4
+  state: CloudletStateReady
+  notifyid: 32
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/crm_info.yml
+++ b/setup-env/e2e-tests/data/crm_info.yml
@@ -115,6 +115,44 @@ cloudlets:
   physicalname: tmus-cloud-2
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 37
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 38
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/influx_appdata_show.yml
+++ b/setup-env/e2e-tests/data/influx_appdata_show.yml
@@ -86,6 +86,26 @@ cloudlets:
   physicalname: tmus-cloud-1
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 16
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: AcmeAppCo

--- a/setup-env/e2e-tests/data/show10.yml
+++ b/setup-env/e2e-tests/data/show10.yml
@@ -474,6 +474,188 @@ cloudlets:
   physicalname: tmus-cloud-8
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: gcp
+    name: gcp-cloud-10
+  state: CloudletStateReady
+  notifyid: 49
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 41
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-3
+  state: CloudletStateReady
+  notifyid: 42
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-4
+  state: CloudletStateReady
+  notifyid: 43
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-5
+  state: CloudletStateReady
+  notifyid: 44
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-6
+  state: CloudletStateReady
+  notifyid: 45
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-7
+  state: CloudletStateReady
+  notifyid: 46
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: azure
+    name: azure-cloud-9
+  state: CloudletStateReady
+  notifyid: 48
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 40
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-8
+  state: CloudletStateReady
+  notifyid: 47
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: Samsung

--- a/setup-env/e2e-tests/data/show2.yml
+++ b/setup-env/e2e-tests/data/show2.yml
@@ -94,6 +94,44 @@ cloudlets:
   physicalname: tmus-cloud-1
   containerversion: 2019-10-24
 
+cloudletinfos:
+- key:
+    organization: tmus
+    name: tmus-cloud-1
+  state: CloudletStateReady
+  notifyid: 37
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+- key:
+    organization: tmus
+    name: tmus-cloud-2
+  state: CloudletStateReady
+  notifyid: 38
+  controller: Jon-Mex@127.0.0.1:55001
+  osmaxram: 500
+  osmaxvcores: 50
+  osmaxvolgb: 5000
+  flavors:
+  - name: x1.small
+    vcpus: 10
+    ram: 101024
+    disk: 500
+  status:
+    tasknumber: 3
+    taskname: Gathering Cloudlet Info
+  containerversion: "2019-10-24"
+
 apps:
 - key:
     organization: MobiledgeX

--- a/setup-env/e2e-tests/testfiles/ctrl_restart.yml
+++ b/setup-env/e2e-tests/testfiles/ctrl_restart.yml
@@ -36,7 +36,7 @@ tests:
     yaml1: "{{outputdir}}/show-commands.yml"
     yaml2: "{{datadir}}/appdata_show.yml"
     filetype: appdata
-  
+
 - name: delete and show provisioning, verify it is empty
   actions: [ctrlapi-delete,ctrlapi-show]
   apifile: "{{datadir}}/appdata.yml"

--- a/setup-env/test-mex/test-mex.go
+++ b/setup-env/test-mex/test-mex.go
@@ -113,6 +113,7 @@ func main() {
 	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
+	util.SetLogFormat()
 
 	config := e2eapi.TestConfig{}
 	spec := setupmex.TestSpec{}
@@ -166,14 +167,15 @@ func main() {
 	if spec.CompareYaml.Yaml1 != "" && spec.CompareYaml.Yaml2 != "" {
 		retryOk := true
 		pass := false
-		for ii := 0; ii < 5 && retryOk; ii++ {
+		maxTries := 5
+		for ii := 0; ii < maxTries && retryOk; ii++ {
 			pass = util.CompareYamlFiles(spec.CompareYaml.Yaml1,
 				spec.CompareYaml.Yaml2, spec.CompareYaml.FileType)
-			if pass || len(retryActions) == 0 {
+			if pass || len(retryActions) == 0 || ii == maxTries-1 {
 				break
 			}
 			// retry (typically retry show command)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 			msg := fmt.Sprintf("re-running actions %v count %d due to compare yaml failure", retryActions, ii)
 			util.PrintStepBanner(msg)
 			for _, a := range retryActions {

--- a/setup-env/util/util.go
+++ b/setup-env/util/util.go
@@ -313,6 +313,10 @@ func connectOnlineController(delay time.Duration) *grpc.ClientConn {
 	return nil
 }
 
+func SetLogFormat() {
+	log.SetFlags(log.Flags() | log.Ltime | log.Lmicroseconds)
+}
+
 func PrintStartBanner(label string) {
 	log.Printf("\n\n   *** %s\n", label)
 }
@@ -464,9 +468,7 @@ func CompareYamlFiles(firstYamlFile string, secondYamlFile string, fileType stri
 		err2 = ReadYamlFile(secondYamlFile, &a2)
 		a1.Sort()
 		a2.Sort()
-		// "show" used to not include CloudletInfos, so remove them.
-		a1.CloudletInfos = nil
-		a2.CloudletInfos = nil
+
 		y1 = a1
 		y2 = a2
 


### PR DESCRIPTION
This fixes an intermittent failure in the ctrl_restart test. The problem was after the controller is restarted, we go ahead and delete all the data. But, there is a race condition. The CRM needs to reconnect to the controller and set the CloudletInfo state to Ready before all the AppInsts/ClusterInsts associated with it can be deleted.

We already have a retry on the show comparison for these types of cases, but currently the CloudletInfos are being ignored because we don't clean them up on Cloudlet delete, so they carry over between tests. So I've added some code to delete the CloudletInfo when the CRM is deleted as long as the CloudletInfo.State is Offline (meaning CRM disconnected). This avoids any race conditions where CRM is still alive and sending a CloudletInfo to the controller (Crm should never send a CloudletInfo with state Offline). Most of the changes here are to add the expected CloudletInfo state to the "show" yaml files.

I also fixed an issue where ShowDebug was missing the last reply because we trigger the waiting thread before sending the reply.

Also there are a few other issues I've seen but have been unable to reproduce reliably, notably a failure in TestJwk where the vault setup script fails due to "pki path already in use".