### PR TITLE
EC-2415: add --gpus all when needed for docker run

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -405,6 +405,10 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		in.ExternalVolumeSize = vmspec.ExternalVolumeSize
 		log.SpanLog(ctx, log.DebugLevelApi, "Selected AppInst Node Flavor", "vmspec", vmspec.FlavorName)
 
+		if resTagTableApi.UsesGpu(ctx, stm, *vmspec.FlavorInfo, cloudlet) {
+			in.OptRes = "gpu"
+		}
+
 		in.Revision = app.Revision
 		appDeploymentType = app.Deployment
 		if in.AutoClusterIpAccess == edgeproto.IpAccess_IP_ACCESS_SHARED && app.AccessType == edgeproto.AccessType_ACCESS_TYPE_DIRECT {

--- a/controller/cloudlet_api_test.go
+++ b/controller/cloudlet_api_test.go
@@ -802,6 +802,8 @@ func testGpuResourceMapping(t *testing.T, ctx context.Context, cl *edgeproto.Clo
 		spec, vmerr = resTagTableApi.GetVMSpec(ctx, stm, flavorVgpuNvidiaMatch, *cl, cli)
 		require.Nil(t, vmerr, "GetVmSpec")
 		require.Equal(t, "flavor.large-nvidia", spec.FlavorName)
+		uses := resTagTableApi.UsesGpu(ctx, stm, *spec.FlavorInfo, *cl)
+		require.Equal(t, true, uses)
 
 		// Now try 2 optional resources requested by one flavor, first non-nominal, no res tag table for nas tags
 		spec, vmerr = resTagTableApi.GetVMSpec(ctx, stm, testflavor2, *cl, cli)

--- a/controller/restagtable_api.go
+++ b/controller/restagtable_api.go
@@ -221,6 +221,16 @@ func (s *ResTagTableApi) osFlavorResources(ctx context.Context, stm concurrency.
 	return resources, rescnt
 }
 
+func (s *ResTagTableApi) UsesGpu(ctx context.Context, stm concurrency.STM, flavor edgeproto.FlavorInfo, cl edgeproto.Cloudlet) bool {
+	resources, rescnt := s.osFlavorResources(ctx, stm, flavor, cl)
+	if rescnt > 0 {
+		if _, ok := resources["gpu"]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // Check the match for any given request 'req' for resource 'resname' in OS flavor 'flavor'.
 func (s *ResTagTableApi) match(ctx context.Context, stm concurrency.STM, resname string, req string, flavor edgeproto.FlavorInfo, cl edgeproto.Cloudlet) (bool, error) {
 
@@ -430,6 +440,7 @@ func (s *ResTagTableApi) GetVMSpec(ctx context.Context, stm concurrency.STM, nod
 		vmspec.FlavorName = flavor.Name
 		vmspec.AvailabilityZone = az
 		vmspec.ImageName = img
+		vmspec.FlavorInfo = flavor
 		log.SpanLog(ctx, log.DebugLevelApi, "Found closest flavor", "flavor", flavor, "vmspec", vmspec)
 
 		return &vmspec, nil

--- a/edgeproto/appinst.proto
+++ b/edgeproto/appinst.proto
@@ -127,6 +127,8 @@ message AppInst {
   string availability_zone = 33 [(protogen.hidetag) = "nocmp", (protogen.backend) = true];
   // OS node flavor to use
   string vm_flavor = 34 [(protogen.hidetag) = "nocmp", (protogen.backend) = true];
+  // Optional Resources required by OS flavor if any
+  string opt_res = 35 [(protogen.hidetag) = "nocmp", (protogen.backend) = true];
   option (protogen.generate_matches) = true;
   option (protogen.generate_cud) = true;
   option (protogen.generate_cud_test) = true;

--- a/edgeproto/restagtable.proto
+++ b/edgeproto/restagtable.proto
@@ -38,7 +38,7 @@ message ResTagTable {
   option (protogen.generate_cache) = true;
   option (protogen.notify_cache) = true;
   option (protogen.notify_message) = true;
-  option (protogen.alias) = "res=Key.Name,organzation=Key.Organization";
+  option (protogen.alias) = "res=Key.Name,organization=Key.Organization";
   option (protogen.also_required) = "Tags";
   option (protogen.uses_org) = "key=Organization";
 }

--- a/vmspec/vmspec_matcher.go
+++ b/vmspec/vmspec_matcher.go
@@ -16,6 +16,7 @@ type VMCreationSpec struct {
 	ImageName          string
 	PrivacyPolicy      *edgeproto.PrivacyPolicy
 	MasterNodeFlavor   string
+	FlavorInfo         *edgeproto.FlavorInfo
 }
 
 // GetVMSpec returns the VMCreationAttributes including flavor name and the size of the external volume which is required, if any


### PR DESCRIPTION
When creating AppInst for a docker deployment, make dockerapp.go::CreateAppInst check if the appInst's OS flavor requires a gpu, and if so, add --gpus all to the docker run cmd. 
What changed?modified:   edgeproto/appinst.proto            // add optional resource string opt_res
        modified:   vmspec/vmspec_matcher.go          // add entrie FlavorInfo object to vmspec
        modified:   controller/restagtable_api.go    // Add UsesGpu()
        modified:   controller/cloudlet_api_test.go // test new UsesGpu()
        modified:   controller/appinst_api.go      // test if OS Flavor UsesGpu set appInst if so
        modified:   cloud-resource-manager/dockermgmt/dockerapp.go // check appInst.OptRes
        modified:   edgeproto/restagtable.proto // fix typo in alias organzation=>organization
