### PR TITLE
EDGECLOUD-2430 fix cli input for aliased map var

### DIFF
--- a/cli/input.go
+++ b/cli/input.go
@@ -77,6 +77,7 @@ func (s *Input) ParseArgs(args []string, obj interface{}) (map[string]interface{
 		}
 		var argVal interface{}
 		argKey, argVal := kv[0], kv[1]
+		argKey = resolveAlias(argKey, aliases)
 		specialArgType := ""
 		if s.SpecialArgs != nil {
 			if argType, found := (*s.SpecialArgs)[argKey]; found {
@@ -91,10 +92,9 @@ func (s *Input) ParseArgs(args []string, obj interface{}) (map[string]interface{
 				}
 			}
 		}
-		key := resolveAlias(argKey, aliases)
-		delete(required, key)
-		setKeyVal(dat, key, argVal, specialArgType)
-		if key == s.PasswordArg {
+		delete(required, argKey)
+		setKeyVal(dat, argKey, argVal, specialArgType)
+		if argKey == s.PasswordArg {
 			passwordFound = true
 		}
 	}
@@ -451,7 +451,8 @@ func replaceMapVals(src map[string]interface{}, dst map[string]interface{}) {
 // MarshalArgs generates a name=val arg list from the object.
 // Arg names that should be ignore can be specified. Names are the
 // same format as arg names, lowercase of field names, joined by '.'
-func MarshalArgs(obj interface{}, ignore []string) ([]string, error) {
+// Aliases are of the form alias=hiername.
+func MarshalArgs(obj interface{}, ignore []string, aliases []string) ([]string, error) {
 	args := []string{}
 	if obj == nil {
 		return args, nil
@@ -471,18 +472,28 @@ func MarshalArgs(obj interface{}, ignore []string) ([]string, error) {
 			ignoremap[str] = struct{}{}
 		}
 	}
+	spargs := GetSpecialArgs(obj)
 
-	return MapToArgs([]string{}, dat, ignoremap), nil
+	aliasm := make(map[string]string)
+	for _, alias := range aliases {
+		ar := strings.SplitN(alias, "=", 2)
+		if len(ar) != 2 {
+			continue
+		}
+		aliasm[ar[1]] = ar[0]
+	}
+
+	return MapToArgs([]string{}, dat, ignoremap, spargs, aliasm), nil
 }
 
-func MapToArgs(prefix []string, dat map[string]interface{}, ignore map[string]struct{}) []string {
+func MapToArgs(prefix []string, dat map[string]interface{}, ignore map[string]struct{}, specialArgs map[string]string, aliases map[string]string) []string {
 	args := []string{}
 	for k, v := range dat {
 		if v == nil {
 			continue
 		}
 		if sub, ok := v.(map[string]interface{}); ok {
-			subargs := MapToArgs(append(prefix, k), sub, ignore)
+			subargs := MapToArgs(append(prefix, k), sub, ignore, specialArgs, aliases)
 			args = append(args, subargs...)
 			continue
 		}
@@ -496,21 +507,69 @@ func MapToArgs(prefix []string, dat map[string]interface{}, ignore map[string]st
 				submap := map[string]interface{}{
 					key: subv,
 				}
-				subargs := MapToArgs(prefix, submap, ignore)
+				subargs := MapToArgs(prefix, submap, ignore, specialArgs, aliases)
 				args = append(args, subargs...)
 			}
 			continue
 		}
 		keys := append(prefix, k)
-		if _, ok := ignore[strings.Join(keys, ".")]; ok {
+		name := strings.Join(keys, ".")
+		if _, ok := ignore[name]; ok {
 			continue
 		}
+		parentName := strings.Join(prefix, ".")
+		sparg, _ := specialArgs[parentName]
+		if sparg == "StringToString" {
+			name = parentName
+		}
+		if alias, ok := aliases[name]; ok {
+			name = alias
+		}
+
 		val := fmt.Sprintf("%v", v)
 		if strings.ContainsAny(val, " \t\r\n") {
 			val = strconv.Quote(val)
 		}
-		arg := fmt.Sprintf("%s=%s", strings.Join(keys, "."), val)
+		var arg string
+		if sparg == "StringToString" {
+			arg = fmt.Sprintf("%s=%s=%s", name, k, val)
+		} else {
+			arg = fmt.Sprintf("%s=%s", name, val)
+		}
 		args = append(args, arg)
 	}
 	return args
+}
+
+func GetSpecialArgs(obj interface{}) map[string]string {
+	m := make(map[string]string)
+	getSpecialArgs(m, []string{}, reflect.TypeOf(obj))
+	return m
+}
+
+func getSpecialArgs(special map[string]string, parents []string, t reflect.Type) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() == reflect.Struct {
+		for ii := 0; ii < t.NumField(); ii++ {
+			sf := t.Field(ii)
+			getSpecialArgs(special, append(parents, sf.Name), sf.Type)
+		}
+	}
+	if len(parents) == 0 {
+		// basic type but not in a struct
+		return
+	}
+	sptype := ""
+	if t.Kind() == reflect.Map && t == reflect.MapOf(reflect.TypeOf(""), reflect.TypeOf("")) {
+		sptype = "StringToString"
+	}
+	if t.Kind() == reflect.Slice && t == reflect.SliceOf(reflect.TypeOf("")) {
+		sptype = "StringArray"
+	}
+	if sptype != "" {
+		key := strings.Join(parents, ".")
+		special[strings.ToLower(key)] = sptype
+	}
 }

--- a/cli/input_test.go
+++ b/cli/input_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/mobiledgex/edge-cloud/cli"
@@ -17,36 +18,82 @@ type TestObj struct {
 	Inner1     InnerObj
 	Inner2     *InnerObj
 	unexported string
-	Arr        []string          // unsupported
-	Mmm        map[string]string // unsupported
+	Arr        []string
+	Mmm        map[string]string
+	ObjArr     []InnerObj
 }
 
 type InnerObj struct {
 	Name string
 	Val  int
+	Mmm  map[string]string
 }
 
 func TestParseArgs(t *testing.T) {
 	var args []string
-	input := &cli.Input{}
+
+	spargs := cli.GetSpecialArgs(TestObj{})
+	expectSpArgs := map[string]string{
+		"mmm":        "StringToString",
+		"arr":        "StringArray",
+		"inner1.mmm": "StringToString",
+		"inner2.mmm": "StringToString",
+	}
+	require.Equal(t, expectSpArgs, spargs, "GetSpecialArgs")
+
+	input := &cli.Input{
+		SpecialArgs: &spargs,
+	}
 
 	ex := TestObj{
 		Inner1: InnerObj{
 			Name: "name1",
 			Val:  1,
+			Mmm: map[string]string{
+				"xkey": "xx",
+			},
 		},
 		Inner2: &InnerObj{
 			Name: "name2",
 			Val:  2,
 		},
+		Arr: []string{"foo", "bar", "baz"},
+		Mmm: map[string]string{
+			"key1":         "val1",
+			"key.with.dot": "val.with.dot",
+			"keye":         "val=with=equals",
+			// key with equals not supported
+			//"key=with=equals": "val=with=equals",
+		},
+		ObjArr: []InnerObj{
+			InnerObj{
+				Name: "arrin1",
+				Val:  3,
+			},
+			InnerObj{
+				Name: "arrin2",
+				Val:  4,
+			},
+		},
 	}
-	args = []string{"inner1.name=name1", "inner1.val=1", "inner2.name=name2", "inner2.val=2"}
-	testParseArgs(t, input, args, &ex, &TestObj{}, &TestObj{})
 
-	// fails because of unsupported arrays/maps
-	args = []string{"inner1.name=name1", "inner1.val=1", "inner2.name=name2", "inner2.val=2", "unexported=err", "arr=bad-array", "mmm=badmap"}
-	_, err := input.ParseArgs(args, &TestObj{})
-	assert.NotNil(t, err)
+	args = []string{"inner1.name=name1", "inner1.val=1", "inner2.name=name2", "inner2.val=2", "inner1.mmm=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4"}
+	testConversion(t, input, &ex, &TestObj{}, &TestObj{}, args)
+
+	// test with alias args
+	inputAliased := &cli.Input{
+		SpecialArgs: &spargs,
+		AliasArgs: []string{
+			"name1=inner1.name",
+			"name2=inner2.name",
+			"val1=inner1.val",
+			"val2=inner2.val",
+			"mmm1=inner1.mmm",
+			"mmm2=inner2.mmm",
+		},
+	}
+	args = []string{"name1=name1", "val1=1", "name2=name2", "val2=2", "mmm1=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4"}
+	testConversion(t, inputAliased, &ex, &TestObj{}, &TestObj{}, args)
 
 	rf := edgeproto.Flavor{
 		Key: edgeproto.FlavorKey{
@@ -62,7 +109,7 @@ func TestParseArgs(t *testing.T) {
 
 	// required args
 	input.RequiredArgs = []string{"regionx"}
-	_, err = input.ParseArgs(args, &edgeproto.Flavor{})
+	_, err := input.ParseArgs(args, &edgeproto.Flavor{})
 	require.NotNil(t, err)
 
 	input.RequiredArgs = []string{"key.name"}
@@ -117,42 +164,49 @@ func testParseArgs(t *testing.T, input *cli.Input, args []string, expected, buf1
 
 func TestConversion(t *testing.T) {
 	// test converting obj to args and then back to obj
-
-	for _, flavor := range testutil.FlavorData {
-		testConversion(t, &flavor, &edgeproto.Flavor{}, &edgeproto.Flavor{})
-	}
-	for _, app := range testutil.AppData {
-		testConversion(t, &app, &edgeproto.App{}, &edgeproto.App{})
-	}
-	for _, cloudlet := range testutil.CloudletData {
-		testConversion(t, &cloudlet, &edgeproto.Cloudlet{}, &edgeproto.Cloudlet{})
-	}
-	for _, cinst := range testutil.ClusterInstData {
-		testConversion(t, &cinst, &edgeproto.ClusterInst{}, &edgeproto.ClusterInst{})
-	}
-	for _, appinst := range testutil.AppInstData {
-		testConversion(t, &appinst, &edgeproto.AppInst{}, &edgeproto.AppInst{})
-	}
-	for _, pp := range testutil.PrivacyPolicyData {
-		testConversion(t, &pp, &edgeproto.PrivacyPolicy{}, &edgeproto.PrivacyPolicy{})
-	}
-	settings := edgeproto.GetDefaultSettings()
-	settings.Fields = []string{"16", "4", "9", "2.2"}
-	testConversion(t, settings, &edgeproto.Settings{}, &edgeproto.Settings{})
-	// CloudletInfo and CloudletRefs have arrays which aren't supported yet.
-}
-
-func testConversion(t *testing.T, obj interface{}, buf, buf2 interface{}) {
-	// marshal object to args
-	args, err := cli.MarshalArgs(obj, nil)
-	require.Nil(t, err, "marshal %v", obj)
-	input := cli.Input{
+	input := &cli.Input{
 		DecodeHook: edgeproto.DecodeHook,
 		SpecialArgs: &map[string]string{
 			"fields": "StringArray",
 		},
 	}
+	for _, flavor := range testutil.FlavorData {
+		testConversion(t, input, &flavor, &edgeproto.Flavor{}, &edgeproto.Flavor{}, nil)
+	}
+	for _, app := range testutil.AppData {
+		testConversion(t, input, &app, &edgeproto.App{}, &edgeproto.App{}, nil)
+	}
+	for _, cloudlet := range testutil.CloudletData {
+		testConversion(t, input, &cloudlet, &edgeproto.Cloudlet{}, &edgeproto.Cloudlet{}, nil)
+	}
+	for _, cinst := range testutil.ClusterInstData {
+		testConversion(t, input, &cinst, &edgeproto.ClusterInst{}, &edgeproto.ClusterInst{}, nil)
+	}
+	for _, appinst := range testutil.AppInstData {
+		testConversion(t, input, &appinst, &edgeproto.AppInst{}, &edgeproto.AppInst{}, nil)
+	}
+	for _, pp := range testutil.PrivacyPolicyData {
+		testConversion(t, input, &pp, &edgeproto.PrivacyPolicy{}, &edgeproto.PrivacyPolicy{}, nil)
+	}
+	settings := edgeproto.GetDefaultSettings()
+	settings.Fields = []string{"16", "4", "9", "2.2"}
+	testConversion(t, input, settings, &edgeproto.Settings{}, &edgeproto.Settings{}, nil)
+	// CloudletInfo and CloudletRefs have arrays which aren't supported yet.
+}
+
+func testConversion(t *testing.T, input *cli.Input, obj interface{}, buf, buf2 interface{}, expectedArgs []string) {
+	// marshal object to args
+	args, err := cli.MarshalArgs(obj, nil, input.AliasArgs)
+	require.Nil(t, err, "marshal %v", obj)
+
 	fmt.Printf("args: %v\n", args)
+	if expectedArgs != nil {
+		sortargs := make([]string, len(args))
+		copy(sortargs, args)
+		sort.Strings(expectedArgs)
+		sort.Strings(sortargs)
+		require.Equal(t, expectedArgs, sortargs)
+	}
 
 	// parse args into buf, generate args map - should match original
 	dat, err := input.ParseArgs(args, buf)

--- a/edgectl/wrapper/wrapper.go
+++ b/edgectl/wrapper/wrapper.go
@@ -27,7 +27,7 @@ func RunEdgectlObjs(args []string, in, out interface{}, ops ...RunOp) error {
 	opts := runOptions{}
 	opts.apply(ops)
 
-	objArgs, err := cli.MarshalArgs(in, opts.ignore)
+	objArgs, err := cli.MarshalArgs(in, opts.ignore, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixed an issue where the cli arg for a string-string map was not working if an alias was used. The problem in input.go:ParseArgs() was the alias was being resolved after the special arg lookup, causing the special arg lookup to fail.

In addition to fixing the above, I've added more unit tests. In order for the unit tests to work, I've modified the MarshalArgs func (which converts an object to cli args) to recognize the special args fields, and also be able to convert aliases.