### PR TITLE
fix e2e test regression

### DIFF
--- a/setup-env/e2e-tests/data/crm_info.yml
+++ b/setup-env/e2e-tests/data/crm_info.yml
@@ -121,7 +121,6 @@ cloudletinfos:
     name: tmus-cloud-1
   state: CloudletStateReady
   notifyid: 37
-  controller: Jon-Mex@127.0.0.1:55001
   osmaxram: 500
   osmaxvcores: 50
   osmaxvolgb: 5000
@@ -139,7 +138,6 @@ cloudletinfos:
     name: tmus-cloud-2
   state: CloudletStateReady
   notifyid: 38
-  controller: Jon-Mex@127.0.0.1:55001
   osmaxram: 500
   osmaxvcores: 50
   osmaxvolgb: 5000

--- a/setup-env/util/util.go
+++ b/setup-env/util/util.go
@@ -475,13 +475,19 @@ func CompareYamlFiles(firstYamlFile string, secondYamlFile string, fileType stri
 		a1.Sort()
 		a2.Sort()
 
-		y1 = a1
-		y2 = a2
-
 		copts = append(copts, cmpopts.IgnoreTypes(time.Time{}, dmeproto.Timestamp{}))
 		if fileType == "appdata" {
 			copts = append(copts, edgeproto.IgnoreTaggedFields("nocmp")...)
 		}
+		if fileType == "appdata-showcmp" {
+			// need to clear controller field of CloudletInfo
+			// because it depends on local hostname.
+			clearCloudletInfoNocmp(&a1)
+			clearCloudletInfoNocmp(&a2)
+		}
+
+		y1 = a1
+		y2 = a2
 	} else if fileType == "appdata-output" {
 		var a1 testutil.AllDataOut
 		var a2 testutil.AllDataOut
@@ -648,6 +654,13 @@ func clearInfluxTime(results []influxclient.Result) {
 				}
 			}
 		}
+	}
+}
+
+func clearCloudletInfoNocmp(data *edgeproto.AllData) {
+	for ii, _ := range data.CloudletInfos {
+		data.CloudletInfos[ii].Controller = ""
+		data.CloudletInfos[ii].NotifyId = 0
 	}
 }
 


### PR DESCRIPTION
I broke e2e tests with the inclusion of CloudletInfo for the "appdata-showcmp" case. It didn't trigger on my tests because it's a hostname check.

Fix is to remove the hostname when comparing the "nocmp" fields.