### PR TITLE
RSA keysize from 128 to 512

### DIFF
--- a/cloud-resource-manager/proxy/certifications.go
+++ b/cloud-resource-manager/proxy/certifications.go
@@ -188,7 +188,6 @@ func getSelfSignedCerts(ctx context.Context, tlsCert *access.TLSCert, commonName
 		}
 		args = fmt.Sprintf(selfSignedCmdWithSAN, commonNames[0], strings.Join(altNames, "\n"))
 	}
-	fmt.Printf("args: %s\n", args)
 	cmd := exec.Command("bash", "-c", args)
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
openssl doesn't allow keys to be less than 384 bits, so changed it from 128 to 512. It is still essentially instant so it shouldn't really have an impact on e2e tests and other things that already take a while