### PR TITLE
Platform FindClient with no token

### DIFF
--- a/d-match-engine/dme-server/dme-stats.go
+++ b/d-match-engine/dme-server/dme-stats.go
@@ -266,7 +266,7 @@ func (s *DmeStats) UnaryStatsInterceptor(ctx context.Context, req interface{}, i
 		token := req.(*dme.PlatformFindCloudletRequest).ClientToken
 		// cannot collect any stats without a token
 		if token != "" {
-			tokdata, tokerr := dmecommon.GetClientDataFromToken(req.(*dme.PlatformFindCloudletRequest).ClientToken)
+			tokdata, tokerr := dmecommon.GetClientDataFromToken(token)
 			if tokerr != nil {
 				return resp, tokerr
 			}


### PR DESCRIPTION
EDGECLOUD-2570

If the client token is not provided for PlatformFindCloudlet, an unclear error is given.  This is because the stats interceptor tries to parse the empty token, so the error handling within the PlatformFindCloudlet code is bypassed.