### PR TITLE
improve proxy cleanup

### DIFF
--- a/cloud-resource-manager/proxy/envoy.go
+++ b/cloud-resource-manager/proxy/envoy.go
@@ -221,8 +221,12 @@ func DeleteEnvoyProxy(ctx context.Context, client ssh.Client, name string) error
 	out, err = client.Output("rm -rf " + envoyDir)
 	log.SpanLog(ctx, log.DebugLevelMexos, "delete envoy dir", "name", name, "dir", envoyDir, "out", out, "err", err)
 
-	out, err = client.Output("docker rm " + "envoy" + name)
+	out, err = client.Output("docker rm -f " + "envoy" + name)
 	log.SpanLog(ctx, log.DebugLevelMexos, "rm envoy result", "out", out, "err", err)
+	if err != nil && !strings.Contains(string(out), "No such container") {
+		// delete the envoy proxy anyway
+		return fmt.Errorf("can't remove envoy container %s, %s, %v", name, out, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
EDGECLOUD-2579

When the app creation fails due to an envoy port conflict, the envoy container is created but never starts.  

Subsequently, the delete envoy does not complete because it cannot stop the container which is not running.

Fix is to keep running through all the delete steps even if one fails.    
