### PR TITLE
fix crash when PlatformFindCloudlet is done with a developer cookie

### DIFF
--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -113,7 +113,7 @@ func (s *server) PlatformFindCloudlet(ctx context.Context, req *dme.PlatformFind
 	}
 	if !cloudcommon.IsPlatformApp(ckey.OrgName, ckey.AppName) {
 		log.SpanLog(ctx, log.DebugLevelDmereq, "PlatformFindCloudlet API Not allowed for developer app", "org", ckey.OrgName, "name", ckey.AppName)
-		return nil, grpc.Errorf(codes.PermissionDenied, "API Not allowed for developer: %s app: %s", ckey.OrgName, ckey.AppName)
+		return reply, grpc.Errorf(codes.PermissionDenied, "API Not allowed for developer: %s app: %s", ckey.OrgName, ckey.AppName)
 	}
 	if req.ClientToken == "" {
 		log.SpanLog(ctx, log.DebugLevelDmereq, "Invalid PlatformFindCloudlet request", "Error", "Missing ClientToken")


### PR DESCRIPTION
EDGECLOUD-2640

A crash occurs out of the dme stats interceptor when PlatformFindCloudlet is done with a developer app cookie because the stats intercept looks at the dme response even if there is an error code.  Fix is to return the empty reply instead of nil in that error case.