### PR TITLE
EDGECLOUD-2635 fix removal of ports ref on AppInst delete

### DIFF
--- a/controller/alert_api_test.go
+++ b/controller/alert_api_test.go
@@ -46,4 +46,5 @@ func testinit() {
 	vaultConfig, _ = vault.BestConfig("")
 	services.events = influxq.NewInfluxQ("events", "user", "pass")
 	cleanupCloudletInfoTimeout = 100 * time.Millisecond
+	RequireAppInstPortConsistency = true
 }

--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -56,6 +56,8 @@ func TestAppInstApi(t *testing.T) {
 	// the fake crm returns a failure. If it doesn't, the next test to
 	// create all the app insts will fail.
 	responder.SetSimulateAppCreateFailure(true)
+	// clean up on failure may find ports inconsistent
+	RequireAppInstPortConsistency = false
 	for _, obj := range testutil.AppInstData {
 		if testutil.IsAutoClusterAutoDeleteApp(&obj.Key) {
 			continue
@@ -71,6 +73,7 @@ func TestAppInstApi(t *testing.T) {
 		}
 	}
 	responder.SetSimulateAppCreateFailure(false)
+	RequireAppInstPortConsistency = true
 	require.Equal(t, 0, len(appInstApi.cache.Objs))
 	require.Equal(t, clusterInstCnt, len(clusterInstApi.cache.Objs))
 


### PR DESCRIPTION
Fixes removal of AppInst port refs on AppInst delete. Previously we were deleting ports refs in various cases we shouldn't have - dedicated clusterinsts, VM AppInsts, appinsts with internal ports only. This matches what we do during create.

To test I added an option to require expected refs to be there on delete. This isn't always true (due to failures on create), so this option is only enabled for unit testing.