### PR TITLE
EDGECLOUD-2551 audit ShowLogs

### DIFF
--- a/d-match-engine/dme-proto/app-client.pb.go
+++ b/d-match-engine/dme-proto/app-client.pb.go
@@ -6143,6 +6143,13 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 	return data, nil
 }
 
+var ShowMethodNames = map[string]struct{}{}
+
+func IsShow(cmd string) bool {
+	_, found := ShowMethodNames[cmd]
+	return found
+}
+
 func (m *Tag) Size() (n int) {
 	var l int
 	_ = l

--- a/edgeproto/alert.pb.go
+++ b/edgeproto/alert.pb.go
@@ -1027,6 +1027,41 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 	return data, nil
 }
 
+var ShowMethodNames = map[string]struct{}{
+	"ShowAlert":              struct{}{},
+	"ShowSettings":           struct{}{},
+	"ShowFlavor":             struct{}{},
+	"ShowOperatorCode":       struct{}{},
+	"ShowResTagTable":        struct{}{},
+	"ShowCloudlet":           struct{}{},
+	"ShowCloudletInfo":       struct{}{},
+	"ShowCloudletMetrics":    struct{}{},
+	"ShowCloudletPool":       struct{}{},
+	"ShowCloudletPoolMember": struct{}{},
+	"ShowPoolsForCloudlet":   struct{}{},
+	"ShowCloudletsForPool":   struct{}{},
+	"ShowAutoScalePolicy":    struct{}{},
+	"ShowApp":                struct{}{},
+	"ShowClusterInst":        struct{}{},
+	"ShowClusterInstInfo":    struct{}{},
+	"ShowAutoProvPolicy":     struct{}{},
+	"ShowPrivacyPolicy":      struct{}{},
+	"ShowAppInst":            struct{}{},
+	"ShowAppInstInfo":        struct{}{},
+	"ShowAppInstMetrics":     struct{}{},
+	"ShowController":         struct{}{},
+	"ShowNode":               struct{}{},
+	"ShowDevice":             struct{}{},
+	"ShowDeviceReport":       struct{}{},
+	"ShowCloudletRefs":       struct{}{},
+	"ShowClusterRefs":        struct{}{},
+}
+
+func IsShow(cmd string) bool {
+	_, found := ShowMethodNames[cmd]
+	return found
+}
+
 func (m *Alert) Size() (n int) {
 	var l int
 	_ = l

--- a/gensupport/support.go
+++ b/gensupport/support.go
@@ -541,7 +541,7 @@ func ServerStreaming(method *descriptor.MethodDescriptorProto) bool {
 }
 
 func IsShow(method *descriptor.MethodDescriptorProto) bool {
-	if proto.GetBoolExtension(method.Options, protogen.E_NonStandardShow, false) {
+	if GetNonStandardShow(method) {
 		return false
 	}
 	return GetCamelCasePrefix(*method.Name) == "Show"
@@ -549,6 +549,10 @@ func IsShow(method *descriptor.MethodDescriptorProto) bool {
 
 func GetEnumBackend(enumVal *descriptor.EnumValueDescriptorProto) bool {
 	return proto.GetBoolExtension(enumVal.Options, protogen.E_EnumBackend, false)
+}
+
+func GetNonStandardShow(method *descriptor.MethodDescriptorProto) bool {
+	return proto.GetBoolExtension(method.Options, protogen.E_NonStandardShow, false)
 }
 
 type MethodInfo struct {

--- a/log/debug.pb.go
+++ b/log/debug.pb.go
@@ -257,6 +257,13 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 	return data, nil
 }
 
+var ShowMethodNames = map[string]struct{}{}
+
+func IsShow(cmd string) bool {
+	_, found := ShowMethodNames[cmd]
+	return found
+}
+
 func init() { proto.RegisterFile("debug.proto", fileDescriptorDebug) }
 
 var fileDescriptorDebug = []byte{

--- a/testgen/sample.pb.go
+++ b/testgen/sample.pb.go
@@ -3059,6 +3059,13 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 	return data, nil
 }
 
+var ShowMethodNames = map[string]struct{}{}
+
+func IsShow(cmd string) bool {
+	_, found := ShowMethodNames[cmd]
+	return found
+}
+
 func (m *NestedMessage) Size() (n int) {
 	var l int
 	_ = l


### PR DESCRIPTION
The "ShowLogs" command was not being audited (logged to Jaeger) because it was being treated as a "Show" command due to it's name. We do not log show commands because they're typically not interesting and fill up the logs.

The "ShowLogs" command was already marked as a "non-standard-show" in the proto file def, so this just makes explicit which commands are "show" commands. See alert.pb.go. The auditlog check in MC uses this function instead of tagging of the name.