### PR TITLE
EDGECLOUD-2273: able to create an app without the org name

### DIFF
--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -154,6 +154,9 @@ func (key *AppKey) ValidateKey() error {
 	if !util.ValidName(key.Version) {
 		return errors.New("Invalid app version string")
 	}
+	if !util.ValidName(key.Organization) {
+		return errors.New("Invalid organization name")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Previously ValidateKey called a function to validate the developer name. Added ValidName check for organization name now.