### PR TITLE
EDGECLOUD-2693  Crm helm chart upgrade ignores version annotations

### DIFF
--- a/cloud-resource-manager/k8smgmt/helm.go
+++ b/cloud-resource-manager/k8smgmt/helm.go
@@ -176,13 +176,17 @@ func CreateHelmAppInst(ctx context.Context, client ssh.Client, names *KubeNames,
 
 func UpdateHelmAppInst(ctx context.Context, client ssh.Client, names *KubeNames, app *edgeproto.App, appInst *edgeproto.AppInst) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "update kubernetes helm app", "app", app, "kubeNames", names)
+	helmArgs, err := getHelmInstallOptsString(app.Annotations)
+	if err != nil {
+		return err
+	}
 	configs := append(app.Configs, appInst.Configs...)
 	helmOpts, err := getHelmOpts(ctx, client, names.AppName, configs)
 	if err != nil {
 		return err
 	}
-	log.SpanLog(ctx, log.DebugLevelInfra, "Helm options", "helmOpts", helmOpts)
-	cmd := fmt.Sprintf("%s helm upgrade %s %s %s", names.KconfEnv, helmOpts, names.HelmAppName, names.AppImage)
+	log.SpanLog(ctx, log.DebugLevelInfra, "Helm options", "helmOpts", helmOpts, "helmArgs", helmArgs)
+	cmd := fmt.Sprintf("%s helm upgrade %s %s %s %s", names.KconfEnv, helmArgs, helmOpts, names.HelmAppName, names.AppImage)
 	out, err := client.Output(cmd)
 	if err != nil {
 		return fmt.Errorf("error updating helm chart, %s, %s, %v", cmd, out, err)


### PR DESCRIPTION
EDGECLOUD-2693

- Since annotations were not part of the `helm upgrade` helm pulled the latest prometheus chart
- Add annotations for helm upgrade to keep the version as part of the helm upgrade
- Tested this with edgebox and on hamburg cloudlet - Prometheus upgrade succeeds after restarting cluster-svc