### PR TITLE
Dme crash fix in e2e-tests 

### DIFF
--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -452,18 +452,19 @@ func main() {
 	notifyClient.RegisterSend(sendAutoProvCounts)
 	nodeMgr.RegisterClient(notifyClient)
 
-	interval := time.Duration(*statsInterval) * time.Second
-	stats := NewDmeStats(interval, *statsShards, sendMetric.Update)
-	stats.Start()
-	defer stats.Stop()
-
-	notifyClient.Start()
-	defer notifyClient.Stop()
-
+	// Start autProvStats before we recieve Settings Update
 	dmecommon.Settings = *edgeproto.GetDefaultSettings()
 	autoProvStats := dmecommon.InitAutoProvStats(dmecommon.Settings.AutoDeployIntervalSec, 0, *statsShards, &nodeMgr.MyNode.Key, sendAutoProvCounts.Update)
 	autoProvStats.Start()
 	defer autoProvStats.Stop()
+
+	notifyClient.Start()
+	defer notifyClient.Stop()
+
+	interval := time.Duration(*statsInterval) * time.Second
+	stats := NewDmeStats(interval, *statsShards, sendMetric.Update)
+	stats.Start()
+	defer stats.Stop()
 
 	InitAppInstClients()
 


### PR DESCRIPTION
Start stats thread before notify thread, as settings update triggers update to autoprov stats.