### PR TITLE
fix upgrade

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -61,7 +61,8 @@ func main() {
 	flag.Parse()
 
 	if strings.Contains(*debugLevels, "mexos") {
-		log.FatalLog("mexos log level is obsolete, please use infra")
+		log.WarnLog("mexos log level is obsolete, please use infra")
+		*debugLevels = strings.ReplaceAll(*debugLevels, "mexos", "infra")
 	}
 	log.SetDebugLevelStrs(*debugLevels)
 	log.InitTracer(nodeMgr.TlsCertFile)


### PR DESCRIPTION
Cloudlet upgrade broke as part of refactor due to the logging change I made from "mexos" to "infra".   I had intentionally caused a fatal error when you tried to start crmserver with the old mexos debug level because I wanted to make sure the new infra started getting used.  

This caused a problem however with upgrade because it is the old crm code that starts the new crm process, and the old code references mexos.   This won't be a long term problem but will affect ugrades in the field and in QA.  Fix is to make this a non fatal error and then substitute infra for mexos.