### PR TITLE
EGECLOUD-2847 Prevent vmspec.GetVMSpec from returning gpu flavor

### DIFF
--- a/vmspec/vmspec_matcher.go
+++ b/vmspec/vmspec_matcher.go
@@ -3,6 +3,7 @@ package vmspec
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
@@ -40,6 +41,10 @@ func GetVMSpec(flavorList []*edgeproto.FlavorInfo, nodeflavor edgeproto.Flavor) 
 		return flavorList[i].Disk < flavorList[j].Disk
 	})
 	for _, flavor := range flavorList {
+
+		if strings.Contains(flavor.Name, "gpu") {
+			continue
+		}
 
 		if flavor.Vcpus < nodeflavor.Vcpus {
 			continue


### PR DESCRIPTION
Until we arrive at a complete solution where we converge on only one set of flavor mapping code, make the original vmspec.GetVMSpec ignore OS flavors with "gpu" in its name.