### PR TITLE
EDGECLOUD-2862 CreateCloudlet and UpgradeCloudlet fail with "No module named queue"

### DIFF
--- a/docker/Dockerfile.edge-cloud
+++ b/docker/Dockerfile.edge-cloud
@@ -51,7 +51,7 @@ RUN make doc
 RUN make external-doc
 RUN make -C d-match-engine/dme-proto external-swagger
 
-FROM registry.mobiledgex.net:5000/mobiledgex/edge-cloud-base-image:v1.2-32-ga55839b
+FROM registry.mobiledgex.net:5000/mobiledgex/edge-cloud-base-image:v1.2-33-gbe0664e3
 
 # Will be overridden during build from the command line
 ARG BUILD_TAG=latest


### PR DESCRIPTION
Pull in base image with fix for EDGECLOUD-2862