### PR TITLE
use separate vm for docker lb

### DIFF
--- a/cloud-resource-manager/dockermgmt/dockerapp.go
+++ b/cloud-resource-manager/dockermgmt/dockerapp.go
@@ -246,32 +246,24 @@ func CreateAppInstLocal(client ssh.Client, app *edgeproto.App, appInst *edgeprot
 	return nil
 }
 
-func CreateAppInst(ctx context.Context, vaultConfig *vault.Config, client ssh.Client, app *edgeproto.App, appInst *edgeproto.AppInst, networkMode DockerNetworkingMode) error {
+func CreateAppInst(ctx context.Context, vaultConfig *vault.Config, client ssh.Client, app *edgeproto.App, appInst *edgeproto.AppInst) error {
 	image := app.ImagePath
 	nameLabelVal := util.DNSSanitize(app.Key.Name)
 	versionLabelVal := util.DNSSanitize(app.Key.Version)
-	name := GetContainerName(&app.Key)
 	base_cmd := "docker run "
 	if appInst.OptRes == "gpu" {
 		base_cmd += "--gpus all"
 	}
 
 	if app.DeploymentManifest == "" {
-
 		cmd := fmt.Sprintf("%s -d -l %s=%s -l %s=%s --restart=unless-stopped --network=host --name=%s %s %s", base_cmd,
 			cloudcommon.MexAppNameLabel, nameLabelVal, cloudcommon.MexAppVersionLabel,
 			versionLabelVal, GetContainerName(&app.Key), image, app.Command)
-		if networkMode == DockerBridgeMode {
-			cmd = fmt.Sprintf("%s -d -l edge-cloud -l %s=%s -l %s=%s --restart=unless-stopped --name=%s %s %s %s", base_cmd,
-				cloudcommon.MexAppNameLabel, nameLabelVal, cloudcommon.MexAppVersionLabel, versionLabelVal, name,
-				strings.Join(GetDockerPortString(appInst.MappedPorts, UsePublicPortInContainer, dme.LProto_L_PROTO_UNKNOWN, cloudcommon.IPAddrDockerHost), " "), image, app.Command)
-		}
 		log.SpanLog(ctx, log.DebugLevelInfra, "running docker run ", "cmd", cmd)
 		out, err := client.Output(cmd)
 		if err != nil {
 			return fmt.Errorf("error running docker run, %s, %v", out, err)
 		}
-
 		log.SpanLog(ctx, log.DebugLevelInfra, "done docker run ")
 	} else {
 		if strings.HasSuffix(app.DeploymentManifest, ".zip") {
@@ -343,14 +335,14 @@ func DeleteAppInst(ctx context.Context, vaultConfig *vault.Config, client ssh.Cl
 	return nil
 }
 
-func UpdateAppInst(ctx context.Context, vaultConfig *vault.Config, client ssh.Client, app *edgeproto.App, appInst *edgeproto.AppInst, dockerMode DockerNetworkingMode) error {
+func UpdateAppInst(ctx context.Context, vaultConfig *vault.Config, client ssh.Client, app *edgeproto.App, appInst *edgeproto.AppInst) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "UpdateAppInst", "appkey", app.Key, "ImagePath", app.ImagePath)
 
 	err := DeleteAppInst(ctx, vaultConfig, client, app, appInst)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfo, "DeleteAppInst failed, proceeding with create", "appkey", app.Key, "err", err)
 	}
-	return CreateAppInst(ctx, vaultConfig, client, app, appInst, dockerMode)
+	return CreateAppInst(ctx, vaultConfig, client, app, appInst)
 }
 
 func appendContainerIdsFromDockerComposeImages(client ssh.Client, dockerComposeFile string, rt *edgeproto.AppInstRuntime) error {

--- a/cloudcommon/deployment.go
+++ b/cloudcommon/deployment.go
@@ -98,14 +98,6 @@ func GetMappedAccessType(accessType edgeproto.AccessType, deployment, deployment
 		if deployment == DeploymentTypeVM {
 			return edgeproto.AccessType_ACCESS_TYPE_DIRECT, nil
 		}
-		if deployment == DeploymentTypeDocker {
-			dtype := GetDockerDeployType(deploymentManifest)
-			if dtype != "docker" {
-				// Because of the complexity with managing port mappings with
-				// docker-compose manifests do not default to LB
-				return accessType, nil
-			}
-		}
 		// all others default to LB
 		return edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER, nil
 	}

--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -62,7 +62,6 @@ var VMAppInstUsage = "VMappinst-usage"
 
 var IPAddrAllInterfaces = "0.0.0.0"
 var IPAddrLocalHost = "127.0.0.1"
-var IPAddrDockerHost = "172.17.0.1"
 var RemoteServerNone = ""
 
 type InstanceEvent string

--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -304,15 +304,6 @@ func (s *AppApi) CreateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 		in.AccessType = newAccessType
 	}
 
-	if in.Deployment == cloudcommon.DeploymentTypeDocker && in.AccessType == edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER {
-		dtype := cloudcommon.GetDockerDeployType(in.DeploymentManifest)
-		if dtype != "docker" {
-			// docker-compose manifests introduce a lot of complexity for LB solution because the port mappings will have
-			// to change, and there may be multiple containers which communicate together over the host network.
-			return &edgeproto.Result{}, fmt.Errorf("ACCESS_TYPE_LOAD_BALANCER not supported for docker deployment type: %s", dtype)
-		}
-	}
-
 	if in.Deployment == cloudcommon.DeploymentTypeDocker || in.Deployment == cloudcommon.DeploymentTypeVM {
 		if strings.Contains(strings.ToLower(in.AccessPorts), "http") {
 			return &edgeproto.Result{}, fmt.Errorf("Deployment Type and HTTP access ports are incompatible")


### PR DESCRIPTION
EDGECLOUD-2878

Docker-compose deployment have never supported using a LB because docker load balancers have run on the same VM as docker itself to conserve VMs used.  Because docker then has to run in bridge mode, we need to know the specific port mappings used, and these are contained in the docker-compose file itself, which is hard to deal with.  Docker-compose apps also often communicate across contains via the host network which makes bridge mode a problem. 

To resolve this, we will use a separate VM now for the LB for docker deployments if the access type specifies an LB.  This allows removal of the restriction that docker-compose apps could not run thru the LB.  Host networking mode is now used exclusively.

There is also an infra portion for this.