### PR TITLE
Privacy Policy validation fixes

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -460,6 +460,10 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		}
 		if in.PrivacyPolicy == "" {
 			in.PrivacyPolicy = app.DefaultPrivacyPolicy
+		} else {
+			if !autocluster {
+				return fmt.Errorf("Cannot specify Privacy Policy for an AppInst on an existing cluster")
+			}
 		}
 		if in.PrivacyPolicy != "" {
 			policy := edgeproto.PrivacyPolicy{}

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -456,6 +456,9 @@ func (s *PrivacyPolicy) Validate(fields map[string]struct{}) error {
 			if o.PortRangeMin < minPort || o.PortRangeMin > maxPort {
 				return fmt.Errorf("Invalid min port range: %d", o.PortRangeMin)
 			}
+			if o.PortRangeMax > maxPort {
+				return fmt.Errorf("Invalid max port range: %d", o.PortRangeMax)
+			}
 			if o.PortRangeMin > o.PortRangeMax {
 				return fmt.Errorf("Min port range: %d cannot be higher than max: %d", o.PortRangeMin, o.PortRangeMax)
 			}


### PR DESCRIPTION
Validation enhancement for PrivacyPolicy:

EDGECLOUD-1955
Disallow AppInst to specify PrivacyPolicy except in auto cluster case

EDGECLOUD-1891
Validate Max Port range for  PrivacyPolicy