### PR TITLE
bypass check for privacy policy cluster for vmapp

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -461,7 +461,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		if in.PrivacyPolicy == "" {
 			in.PrivacyPolicy = app.DefaultPrivacyPolicy
 		} else {
-			if !autocluster {
+			if !autocluster && cloudcommon.IsClusterInstReqd(&app) {
 				return fmt.Errorf("Cannot specify Privacy Policy for an AppInst on an existing cluster")
 			}
 		}


### PR DESCRIPTION
EDGECLOUD-3060 

The check I put in recently for disallowing Privacy Policy within AppInst should not be applied to VM based apps.