### PR TITLE
TLS certs kill envoy

### DIFF
--- a/cloud-resource-manager/proxy/envoy.go
+++ b/cloud-resource-manager/proxy/envoy.go
@@ -70,8 +70,12 @@ func CreateEnvoyProxy(ctx context.Context, client ssh.Client, name, listenIP, ba
 		// For dind, we use the network which the dind cluster is on.
 		cmdArgs = append(cmdArgs, "--network", opts.DockerNetwork)
 	}
+	certsDir, _, _, err := GetCertsDirAndFiles(ctx, client)
+	if err != nil {
+		return fmt.Errorf("Unable to get certsDir - %v", "err")
+	}
 	cmdArgs = append(cmdArgs, []string{
-		"-v", CertsDir + ":/etc/envoy/certs",
+		"-v", certsDir + ":/etc/envoy/certs",
 		"-v", accesslogFile + ":/var/log/access.log",
 		"-v", eyamlName + ":/etc/envoy/envoy.yaml",
 		"docker.mobiledgex.net/mobiledgex/mobiledgex_public/envoy-with-curl"}...)


### PR DESCRIPTION
EDGECLOUD-2794

When running with --commercialCerts, the envoy tls cert code tries to put the certs into /etc/ssl/certs.  This is a root-owned directory, so it was decided at some point to write the files in there using sudo.  That doesn't work because when envoy starts (under ubuntu), it tries to map that directory and then goes into a restart loop.

For running without --commercialCerts, they get put into /tmp.  This avoids the permissions problem but also isn't ideal either because on a reboot they will disappear.

Solution is to ubuntu home user's dir for the certs.  There is not a need to use /etc/ssl/certs for either production or non prod. 