### PR TITLE
EDGECLOUD-3141  Metrics for VM appinst are not being collected because of ujson package

### DIFF
--- a/docker/Dockerfile.edge-cloud
+++ b/docker/Dockerfile.edge-cloud
@@ -51,7 +51,7 @@ RUN make doc
 RUN make external-doc
 RUN make -C d-match-engine/dme-proto external-swagger
 
-FROM registry.mobiledgex.net:5000/mobiledgex/edge-cloud-base-image:v1.2-42-g214c2177
+FROM registry.mobiledgex.net:5000/mobiledgex/edge-cloud-base-image:v1.2.1-rc1-1-g4c90b58a
 
 # Will be overridden during build from the command line
 ARG BUILD_TAG=latest


### PR DESCRIPTION
Bump edge-cloud base image version to match with edge-cloud-infra changes