### PR TITLE
consistent cluster name length limitation

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -314,6 +314,9 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 				return fmt.Errorf("Privacy Policy not supported on %s", platName)
 			}
 		}
+		if len(in.Key.ClusterKey.Name) > cloudcommon.MaxClusterNameLength {
+			return fmt.Errorf("Cluster name limited to %d characters", cloudcommon.MaxClusterNameLength)
+		}
 		if cloudlet.PlatformType == edgeproto.PlatformType_PLATFORM_TYPE_AZURE || cloudlet.PlatformType == edgeproto.PlatformType_PLATFORM_TYPE_GCP {
 			if in.Deployment != cloudcommon.DeploymentTypeKubernetes {
 				return errors.New("Only kubernetes clusters can be deployed in Azure or GCP")
@@ -321,9 +324,7 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 			if in.NumNodes == 0 {
 				return errors.New("NumNodes cannot be 0 for Azure or GCP")
 			}
-			if len(in.Key.ClusterKey.Name) > cloudcommon.MaxClusterNameLength {
-				return fmt.Errorf("Cluster name limited to %d characters for GCP and Azure", cloudcommon.MaxClusterNameLength)
-			}
+
 		}
 		if in.AutoScalePolicy != "" {
 			policy := edgeproto.AutoScalePolicy{}


### PR DESCRIPTION
EDGECLOUD-3125

Currently Azure and GCP cluster names are limited to 40 characters because of an Azure limitation.  OpenStack can handler a longer length but it the limitations seem somewhat variable; Frankfurt's behavior is different than other cloudlets for example.

We could try to find the exact lowest common denominator for each environment, but it's a little complicated because the heat stack names are function of cloudlet name plus cluster names.   Consistency across platforms is also desirable as we should be infra agnostic and at some point we may want to replicate one cloudlet's clusters on another.  

There are no clusters anywhere in production with names > 33 characters so a limit of 40 seems OK.  I also confirmed this with Wonho.


