### PR TITLE
fix crash in CreateCloudlet

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -267,6 +267,7 @@ func getCaches(ctx context.Context, vmPool *edgeproto.VMPool) *pf.Caches {
 	caches := pf.Caches{
 		SettingsCache: &settingsApi.cache,
 		FlavorCache:   &flavorApi.cache,
+		CloudletCache: &cloudletApi.cache,
 	}
 	if vmPool != nil && vmPool.Key.Name != "" {
 		var vmPoolMux sync.Mutex


### PR DESCRIPTION
EDGECLOUD-3306

Code to retrieve ResTables within CreateCloudlet causes a crash because CloudletCache is not initialized.

