### PR TITLE
EDGECLOUD-3189 Fix Kuberentes AppInst Refresh

### DIFF
--- a/cloud-resource-manager/k8smgmt/kubenames.go
+++ b/cloud-resource-manager/k8smgmt/kubenames.go
@@ -14,6 +14,8 @@ import (
 
 type KubeNames struct {
 	AppName           string
+	AppVersion        string
+	AppOrg            string
 	HelmAppName       string
 	AppURI            string
 	AppImage          string
@@ -66,6 +68,8 @@ func GetKubeNames(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appIns
 	kubeNames.ClusterName = NormalizeName(clusterInst.Key.ClusterKey.Name + clusterInst.Key.Organization)
 	kubeNames.K8sNodeNameSuffix = GetK8sNodeNameSuffix(&clusterInst.Key)
 	kubeNames.AppName = NormalizeName(app.Key.Name)
+	kubeNames.AppVersion = NormalizeName(app.Key.Version)
+	kubeNames.AppOrg = NormalizeName(app.Key.Organization)
 	// Helm app name has to conform to DNS naming standards
 	kubeNames.HelmAppName = util.DNSSanitize(app.Key.Name + "v" + app.Key.Version)
 	kubeNames.AppURI = appInst.Uri


### PR DESCRIPTION
Refresh failed when changing an App between scalewithcluster=false to scalewithcluster=true. The reason is the with scalewithcluster=true, we generate a k8s deployment manifest that uses the "Deployment" object. With scalewithcluster=false, we generate a k8s deployment manifest that uses the "DaemonSet" object.

Refresh tries to apply the new configuration using "kubectl apply". This applies the changes in the new file, but does not know anything about what is in the old file. Because the DaemonSet is a new object, the old Deployment still gets left behind.

This is a general problem with changing kubernetes manifests, and would also affect user-supplied k8s manifests if they changed them by removing old objects, based on the way we were doing the refresh.

Kubernetes has 2 configuration models that use yaml manifests (see https://kubernetes.io/docs/concepts/overview/working-with-objects/object-management/). In the Imperative Object model, you should only use "create" or "delete" with yaml files. To update, you really need to run a "delete" with the old file before running a "create" with the new file. In the Declarative Object model, create and update are both handled by "apply", and delete uses "delete", but they act upon a directory, not a single file. All yaml configuration must be in that config dir.

Our code was mixing these two models, which kubernetes says yields undefined behavior, and so we ended up with this bug.

To fix, I have changed our code to use the Declarative Object model. This requires that manifest files for an AppInst (of which we only support one) are kept in a single directory. We can only use "apply" and "delete" on the directory. With the "--prune --all" option, "apply" can remove old objects that were once part of that directory's config, but are no longer present. This allows us to remove the old Deployment when changing over to a DaemonSet. Kubernetes figures out for us what needs to be removed. The old code would put all yaml files in the home dir on the rootLB, so the new code makes sub directories for each AppInst instead.

This change is backwards compatible, but the bug remains for existing AppInsts because they were originally created with "create" instead of "apply", and so cannot be pruned properly.