### PR TITLE
EDGECLOUD-3294 Update ClusterInst validate autoscale policy

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -532,7 +532,7 @@ func validateClusterInstUpdates(ctx context.Context, stm concurrency.STM, in *ed
 		return errors.New("Cloudlet under maintenance, please try again later")
 	}
 	if in.PrivacyPolicy != "" {
-		if cloudlet.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_OPENSTACK && cloudlet.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_FAKE {
+		if cloudlet.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_OPENSTACK && cloudlet.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_VSPHERE && cloudlet.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_FAKE {
 			platName := edgeproto.PlatformType_name[int32(cloudlet.PlatformType)]
 			return fmt.Errorf("Privacy Policy not supported on %s", platName)
 		}


### PR DESCRIPTION
I refactored some of the checks from CreateClusterInst into a common func so that both Create and Update can validate a bunch of common stuff in both Create and Update. The bug refers to failing to validate the AutoScalePolicy but there's a bunch of other stuff that should also be validated.