### PR TITLE
EDGECLOUD-3295 disallow all AppInst/ClusterInst APIs if cloudlet in maintenance

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -328,11 +328,6 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		in.Liveness = edgeproto.Liveness_LIVENESS_DYNAMIC
 	}
 	cctx.SetOverride(&in.CrmOverride)
-	if !ignoreCRM(cctx) {
-		if err := cloudletInfoApi.checkCloudletReady(&in.Key.ClusterInstKey.CloudletKey); err != nil {
-			return err
-		}
-	}
 
 	var autocluster bool
 	tenant := isTenantAppInst(&in.Key)
@@ -368,8 +363,8 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		if !cloudletApi.store.STMGet(stm, &in.Key.ClusterInstKey.CloudletKey, &cloudlet) {
 			return errors.New("Specified Cloudlet not found")
 		}
-		if cloudlet.MaintenanceState != edgeproto.MaintenanceState_NORMAL_OPERATION {
-			return errors.New("Cloudlet under maintenance, please try again later")
+		if err := checkCloudletReady(cctx, stm, &in.Key.ClusterInstKey.CloudletKey); err != nil {
+			return err
 		}
 
 		cikey := &in.Key.ClusterInstKey
@@ -778,8 +773,6 @@ func (s *AppInstApi) refreshAppInstInternal(cctx *CallContext, key edgeproto.App
 		return false, err
 	}
 
-	cloudletErr := cloudletInfoApi.checkCloudletReady(&key.ClusterInstKey.CloudletKey)
-
 	var app edgeproto.App
 
 	err := s.sync.ApplySTMWait(ctx, func(stm concurrency.STM) error {
@@ -807,6 +800,7 @@ func (s *AppInstApi) refreshAppInstInternal(cctx *CallContext, key edgeproto.App
 			crmUpdateRequired = false
 		} else {
 			// check cloudlet state before updating
+			cloudletErr := checkCloudletReady(cctx, stm, &key.ClusterInstKey.CloudletKey)
 			if crmUpdateRequired && cloudletErr != nil {
 				return cloudletErr
 			}
@@ -1049,12 +1043,6 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		return err
 	}
 
-	if !ignoreCRM(cctx) {
-		if err := cloudletInfoApi.checkCloudletReady(&in.Key.ClusterInstKey.CloudletKey); err != nil {
-			return err
-		}
-	}
-
 	// check if we are deleting an autocluster instance we need to set the key correctly.
 	if strings.HasPrefix(in.Key.ClusterInstKey.ClusterKey.Name, ClusterAutoPrefix) && in.Key.ClusterInstKey.Organization == "" {
 		in.Key.ClusterInstKey.Organization = in.Key.AppKey.Organization
@@ -1077,14 +1065,15 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		if err := in.Key.ClusterInstKey.ValidateKey(); err != nil {
 			return err
 		}
-
 		if !cctx.Undo && in.State != edgeproto.TrackedState_READY && in.State != edgeproto.TrackedState_CREATE_ERROR && in.State != edgeproto.TrackedState_DELETE_ERROR && in.State != edgeproto.TrackedState_UPDATE_ERROR && !ignoreTransient(cctx, in.State) {
 			log.SpanLog(ctx, log.DebugLevelApi, "AppInst busy, cannot delete", "state", in.State)
 			return errors.New("AppInst busy, cannot delete")
 		}
+		if err := checkCloudletReady(cctx, stm, &in.Key.ClusterInstKey.CloudletKey); err != nil {
+			return err
+		}
 
 		var cloudlet edgeproto.Cloudlet
-
 		if !cloudletApi.store.STMGet(stm, &in.Key.ClusterInstKey.CloudletKey, &cloudlet) {
 			return fmt.Errorf("For AppInst, %v", in.Key.ClusterInstKey.CloudletKey.NotFoundError())
 		}


### PR DESCRIPTION
This adds a check for Cloudlet maintenance to the checkCloudletReady func, which is used by all AppInst/ClusterInst create/update/delete funcs to fail to the API if the cloudlet is not ready. I've also changed the checkCloudletReady func to be called within an STM context, to avoid race conditions between checking the Cloudlet state and applying the API change.