### PR TITLE
EDGECLOUD-3380 UpdateCloudletPool incorrectly deleting it

### DIFF
--- a/controller/cloudletpool_api.go
+++ b/controller/cloudletpool_api.go
@@ -70,7 +70,7 @@ func (s *CloudletPoolApi) UpdateCloudletPool(ctx context.Context, in *edgeproto.
 		if err := s.checkCloudletsExist(stm, &cur); err != nil {
 			return err
 		}
-		s.store.STMDel(stm, &in.Key)
+		s.store.STMPut(stm, &cur)
 		return nil
 	})
 	return &edgeproto.Result{}, err

--- a/controller/cloudletpool_api_test.go
+++ b/controller/cloudletpool_api_test.go
@@ -73,8 +73,12 @@ func TestCloudletPoolApi(t *testing.T) {
 	require.True(t, found, "get pool %v", poolKey)
 	require.Equal(t, 1, len(pool.Cloudlets))
 
-	// add member to pool for next test
-	_, err = cloudletPoolApi.AddCloudletPoolMember(ctx, &member)
+	// use update to set members for next test
+	poolUpdate := testutil.CloudletPoolData[0]
+	poolUpdate.Cloudlets = append(poolUpdate.Cloudlets, member.CloudletName)
+	poolUpdate.Fields = []string{edgeproto.CloudletPoolFieldCloudlets}
+	require.Equal(t, 2, len(poolUpdate.Cloudlets))
+	_, err = cloudletPoolApi.UpdateCloudletPool(ctx, &poolUpdate)
 	require.Nil(t, err)
 	found = cloudletPoolApi.cache.Get(&poolKey, &pool)
 	require.True(t, found, "get pool %v", poolKey)


### PR DESCRIPTION
Fix copy-paste error where UpdateCloudletPool was deleting it instead. Also added unit test to verify UpdateCloudletPool is working correctly.