### PR TITLE
EDGECLOUD-3396 autoprov immediate deployment AppInst not marked correctly

### DIFF
--- a/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
@@ -482,7 +482,7 @@ appinstances:
   cloudletloc:
     latitude: 35
     longitude: -95
-  liveness: LivenessDynamic
+  liveness: LivenessAutoprov
   mappedports:
   - proto: LProtoTcp
     internalport: 81


### PR DESCRIPTION
This bug applies only to AppInsts created for immediate deployment, i.e. DeployClientCount = 1 in the policy. These AppInsts are created by the Controller, rather than the AutoProv service. So this bug does not affect AppInsts created for DeployClientCount > 1, or for AppInst HA.

The root cause of this bug was the grpc metadata was being added to the ctx after the ctx was already copied to the stream object, thus the api call (which pulls the ctx from the stream object) never got the metadata. Without the metadata, we weren't checking the AppInst properly, and we weren't marking it with LivenessAutoprov. Since it wasn't marked with LivenessAutoprov, Shepherd didn't set up the necessary alerts for auto-undeployment.

The fix sets up the metadata correctly and verifies it in the e2e test expected data. Another problem was the debug level was metrics, which is not on by default, so these logs never showed up in Jaeger, making it hard to debug. I've changed them to DebugLevelApi instead.

I've also changed to using a keyworker to avoid spawning multiple go threads in parallel doing the same thing. This also avoids spamming span logs now that I've changed them to DebugLevelApi.