### PR TITLE
EDGECLOUD-3452: Autocluster cleanup fails if creation of app Inst fails

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -555,11 +555,11 @@ func (s *ClusterInstApi) deleteClusterInstInternal(cctx *CallContext, in *edgepr
 	}
 	// If it is autoClusterInst and creation had failed, then deletion should proceed
 	// even though clusterinst is in use by Application Instance
-	//if !(cctx.Undo && strings.HasPrefix(in.Key.ClusterKey.Name, ClusterAutoPrefix)) {
-	if appInstApi.UsesClusterInst(&in.Key) {
-		return errors.New("ClusterInst in use by Application Instance")
+	if !(cctx.Undo && strings.HasPrefix(in.Key.ClusterKey.Name, ClusterAutoPrefix)) {
+		if appInstApi.UsesClusterInst(&in.Key) {
+			return errors.New("ClusterInst in use by Application Instance")
+		}
 	}
-	//}
 	cctx.SetOverride(&in.CrmOverride)
 	ctx := cb.Context()
 


### PR DESCRIPTION
I accidentally commented this check long back :D Have fixed it now.