### PR TITLE
edgecloud-3849 support for multiple udp ports in a single appinst

### DIFF
--- a/cloud-resource-manager/proxy/envoy.go
+++ b/cloud-resource-manager/proxy/envoy.go
@@ -240,7 +240,7 @@ static_resources:
       {{- end}}
   {{- end}}
   {{- range .UDPSpec}}
-  - name: listener_0
+  - name: udp_listener_{{.ListenPort}}
     address:
       socket_address:
         protocol: UDP


### PR DESCRIPTION
The listener name for udp listeners in envoy wasn't unique so only the first one listed would actually work, thus only one udp port could be used at a time per appinst. Renamed the listeners based on the udp port number they listen to. 