### PR TITLE
EDGECLOUD-3411: RemoveVMPoolMember with missing vm name should give consistent error message

### DIFF
--- a/controller/vmpool_api.go
+++ b/controller/vmpool_api.go
@@ -83,6 +83,9 @@ func (s *VMPoolApi) UpdateVMPool(ctx context.Context, in *edgeproto.VMPool) (*ed
 }
 
 func (s *VMPoolApi) DeleteVMPool(ctx context.Context, in *edgeproto.VMPool) (*edgeproto.Result, error) {
+	if err := in.Validate(nil); err != nil {
+		return &edgeproto.Result{}, err
+	}
 	// Validate if pool is in use by Cloudlet
 	if cloudletApi.UsesVMPool(&in.Key) {
 		return &edgeproto.Result{}, fmt.Errorf("VM pool in use by Cloudlet")
@@ -147,6 +150,10 @@ func (s *VMPoolApi) AddVMPoolMember(ctx context.Context, in *edgeproto.VMPoolMem
 }
 
 func (s *VMPoolApi) RemoveVMPoolMember(ctx context.Context, in *edgeproto.VMPoolMember) (*edgeproto.Result, error) {
+	if err := in.Validate(nil); err != nil {
+		return &edgeproto.Result{}, err
+	}
+
 	var err error
 
 	cctx := DefCallContext()

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -333,10 +333,8 @@ func (s *VMPool) Validate(fields map[string]struct{}) error {
 			}
 			internalIPMap[v.NetInfo.InternalIp] = struct{}{}
 		}
-		if _, found := fields[VMPoolFieldVmsState]; found {
-			if v.State != VMState_VM_FORCE_FREE {
-				return errors.New("Invalid VM state, only VmForceFree state is allowed")
-			}
+		if v.State != VMState_VM_FREE && v.State != VMState_VM_FORCE_FREE {
+			return errors.New("Invalid VM state, only VmForceFree state is allowed")
 		}
 	}
 	return nil


### PR DESCRIPTION
* Add validation for Delete/RemoveVMPool*, to have consistent error output
* Field VmState is not set as only set repeated struct's field. Hence, no way to figure out if a field is set or not. Hence remove field check.