### PR TITLE
PrivacyPolicy update fix

### DIFF
--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -535,7 +535,7 @@ func (s *PrivacyPolicy) Validate(fields map[string]struct{}) error {
 			if o.PortRangeMax > maxPort {
 				return fmt.Errorf("Invalid max port range: %d", o.PortRangeMax)
 			}
-			if o.PortRangeMin > o.PortRangeMax && o.PortRangeMax != 0 {
+			if o.PortRangeMin > o.PortRangeMax {
 				return fmt.Errorf("Min port range: %d cannot be higher than max: %d", o.PortRangeMin, o.PortRangeMax)
 			}
 		}


### PR DESCRIPTION
EDGECLOUD-1949

When updating PrivacyPolicy, set the maxport == minport if maxport is not specified.  This is the same behavior as Create.
