### PR TITLE
EDGECLOUD-2845: CreateApp unsupported protocol error message not correct

### DIFF
--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -636,7 +636,7 @@ func GetLProto(s string) (dme.LProto, error) {
 	case "udp":
 		return dme.LProto_L_PROTO_UDP, nil
 	}
-	return 0, fmt.Errorf("%s is not a supported Protocol", s)
+	return 0, fmt.Errorf("Unsupported protocol: %s", s)
 }
 
 func LProtoStr(proto dme.LProto) (string, error) {

--- a/util/ports.go
+++ b/util/ports.go
@@ -70,8 +70,13 @@ func ParsePorts(accessPorts string) ([]PortSpec, error) {
 			endport = 0
 		}
 
+		proto := strings.ToLower(pp[0])
+		if proto != "tcp" && proto != "udp" {
+			return nil, fmt.Errorf("Unsupported protocol: %s", pp[0])
+		}
+
 		portSpec := PortSpec{
-			Proto:   strings.ToLower(pp[0]),
+			Proto:   proto,
 			Port:    strconv.FormatInt(baseport, 10),
 			EndPort: strconv.FormatInt(endport, 10),
 		}


### PR DESCRIPTION
Change error message for unsupported protocol. Put the protocol at the end, so that it is not capitalized when going through audit.go

Also added an unsupported protocol check in ParsePorts before the user inputted string is converted to lower case. This way the error message reflects what the user typed.

For example: if someone CreateApp with "tC:2016", the error message returned will be "Unsupported protocol: tC" instead of "Unsupported protocol: tc". 