### PR TITLE
tweak for deployment validation checking on update

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -433,9 +433,11 @@ func (s *AppApi) UpdateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 		if err != nil {
 			return err
 		}
-		err = cloudcommon.IsValidDeploymentManifest(cur.Deployment, cur.Command, cur.DeploymentManifest, ports)
-		if err != nil {
-			return fmt.Errorf("Invalid deployment manifest, %v", err)
+		if in.DeploymentManifest != "" {
+			err = cloudcommon.IsValidDeploymentManifest(cur.Deployment, cur.Command, in.DeploymentManifest, ports)
+			if err != nil {
+				return fmt.Errorf("Invalid deployment manifest, %v", err)
+			}
 		}
 		if cur.Deployment == cloudcommon.DeploymentTypeKubernetes {
 			_, err := k8smgmt.GetAppEnvVars(ctx, &cur, vaultConfig, &k8smgmt.TestReplacementVars)


### PR DESCRIPTION
EDGECLOUD-3576

My earlier fix to check for a valid deployment manifest on Update broke the case in which the user wants to update the access ports, because on update, the access ports have been earlier modified to include the public port, so the string matching for ports does not work and you get an error "port XXXX defined in AccessPorts but missing from kubernetes manifest"

Fix is to only validate the manifest on update when it is actually passed in and not generated