### PR TITLE
EDGECLOUD-3167 UpdateClusterInst with AutoScalePolicy set NumNodes

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -487,7 +487,7 @@ func (s *ClusterInstApi) updateClusterInstInternal(cctx *CallContext, in *edgepr
 			// nothing changed
 			return nil
 		}
-		if err := validateClusterInstUpdates(ctx, stm, in); err != nil {
+		if err := validateClusterInstUpdates(ctx, stm, &inbuf); err != nil {
 			return err
 		}
 		if !ignoreCRM(cctx) {

--- a/controller/clusterinst_api_test.go
+++ b/controller/clusterinst_api_test.go
@@ -92,6 +92,26 @@ func TestClusterInstApi(t *testing.T) {
 	require.Nil(t, err, "delete overrides create error")
 	checkClusterInstState(t, ctx, commonApi, &obj, edgeproto.TrackedState_NOT_PRESENT)
 
+	// test update of autoscale policy
+	obj = testutil.ClusterInstData[0]
+	obj.Key.Organization = testutil.AutoScalePolicyData[1].Key.Organization
+	err = clusterInstApi.CreateClusterInst(&obj, testutil.NewCudStreamoutClusterInst(ctx))
+	require.Nil(t, err, "create ClusterInst")
+	check := edgeproto.ClusterInst{}
+	found := clusterInstApi.cache.Get(&obj.Key, &check)
+	require.True(t, found)
+	require.Equal(t, 2, int(check.NumNodes))
+
+	obj.AutoScalePolicy = testutil.AutoScalePolicyData[1].Key.Name
+	obj.Fields = []string{edgeproto.ClusterInstFieldAutoScalePolicy}
+	err = clusterInstApi.UpdateClusterInst(&obj, testutil.NewCudStreamoutClusterInst(ctx))
+	require.Nil(t, err)
+	check = edgeproto.ClusterInst{}
+	found = clusterInstApi.cache.Get(&obj.Key, &check)
+	require.True(t, found)
+	require.Equal(t, testutil.AutoScalePolicyData[1].Key.Name, check.AutoScalePolicy)
+	require.Equal(t, 4, int(check.NumNodes))
+
 	// override CRM error
 	responder.SetSimulateClusterCreateFailure(true)
 	responder.SetSimulateClusterDeleteFailure(true)


### PR DESCRIPTION
NumNodes was not getting set properly from AutoScalePolicy limits because it was operating on the wrong struct. Unit test to verify.