### PR TITLE
EDGECLOUD-3540 autoprov deploy helm

### DIFF
--- a/cloudcommon/deployment.go
+++ b/cloudcommon/deployment.go
@@ -408,3 +408,11 @@ func DownloadFile(ctx context.Context, vaultConfig *vault.Config, fileUrlPath st
 
 	return nil
 }
+
+// Transform AppInst deployment type to ClusterInst deployment type
+func AppInstToClusterDeployment(deployment string) string {
+	if deployment == DeploymentTypeHelm {
+		deployment = DeploymentTypeKubernetes
+	}
+	return deployment
+}

--- a/d-match-engine/dme-common/match-engine.go
+++ b/d-match-engine/dme-common/match-engine.go
@@ -674,7 +674,7 @@ func (s *searchAppInst) searchPotential(ctx context.Context, policy *AutoProvPol
 		// make sure there's a free reservable ClusterInst
 		// on the cloudlet. if cinsts exists there is at
 		// least one free.
-		cinstKey := DmeAppTbl.FreeReservableClusterInsts.GetForCloudlet(&cl.Key, s.appDeployment)
+		cinstKey := DmeAppTbl.FreeReservableClusterInsts.GetForCloudlet(&cl.Key, s.appDeployment, cloudcommon.AppInstToClusterDeployment)
 		if cinstKey == nil {
 			continue
 		}

--- a/edgeproto/free_reservable_clusterinsts.go
+++ b/edgeproto/free_reservable_clusterinsts.go
@@ -69,7 +69,9 @@ func (s *FreeReservableClusterInstCache) Prune(ctx context.Context, validKeys ma
 
 func (s *FreeReservableClusterInstCache) Flush(ctx context.Context, notifyId int64) {}
 
-func (s *FreeReservableClusterInstCache) GetForCloudlet(key *CloudletKey, deployment string) *ClusterInstKey {
+func (s *FreeReservableClusterInstCache) GetForCloudlet(key *CloudletKey, deployment string, deploymentTransformFunc func(string) string) *ClusterInstKey {
+	// need a transform func to avoid import cycle
+	deployment = deploymentTransformFunc(deployment)
 	s.Mux.Lock()
 	defer s.Mux.Unlock()
 	cinsts, found := s.InstsByCloudlet[*key]


### PR DESCRIPTION
This change is need to be able to find a reservable ClusterInst for a helm AppInst. The FreeReservableClusterInstCache looks for a reservable cluster of the same deployment type, but type helm does not match kubernetes so we need to account for that. Unfortunately edgecloud cannot import cloudcommon (import cyle) so the caller passes in a deployment transform function instead.