### PR TITLE
EDGECLOUD-3535 return 400 for single AppInst update failure

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -899,7 +899,7 @@ func (s *AppInstApi) RefreshAppInst(in *edgeproto.AppInst, cb edgeproto.AppInstA
 		} else {
 			numFailed++
 			if singleAppInst {
-				cb.Send(&edgeproto.Result{Message: fmt.Sprintf("Failed: %s", result.errString)})
+				return fmt.Errorf("%s", result.errString)
 			} else {
 				cb.Send(&edgeproto.Result{Message: fmt.Sprintf("Failed for cluster (%s/%s), cloudlet (%s/%s): %s", k.ClusterInstKey.ClusterKey.Name, k.ClusterInstKey.Organization, k.ClusterInstKey.CloudletKey.Name, k.ClusterInstKey.CloudletKey.Organization, result.errString)})
 			}


### PR DESCRIPTION
This makes it so trying to update a single AppInst when the Cloudlet is in maintenance (or other similar errors) returns a 400 error from the MC API.

The problem is the way streaming over HTTP works, once you want to stream back anything, you must return 200 (StatusOK). After that if an error is hit, it becomes just part of the data stream and cannot affect the result status.

So I've changed it in this case, but for streaming APIs it's not guaranteed that hitting an error will always return a non-200 status. Because it depends on if other data has been sent back before the error is hit.