### PR TITLE
EDGECLOUD-3623 stop using hard-coded cert for internal pki

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/crm_server_test.go
+++ b/cloud-resource-manager/cmd/crmserver/crm_server_test.go
@@ -146,7 +146,7 @@ func startMain(t *testing.T) (chan struct{}, error) {
 func TestCRM(t *testing.T) {
 	var err error
 	log.SetDebugLevel(log.DebugLevelApi | log.DebugLevelNotify | log.DebugLevelInfra)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
@@ -247,12 +247,9 @@ func TestCRM(t *testing.T) {
 }
 
 func TestNotifyOrder(t *testing.T) {
-	log.InitTracer("")
-	defer log.FinishTracer()
-	ctx := log.StartTestSpan(context.Background())
-
-	err := nodeMgr.Init(ctx, node.NodeTypeCRM, node.NoEventTlsClientIssuer)
+	_, _, err := nodeMgr.Init(node.NodeTypeCRM, node.NoTlsClientIssuer)
 	require.Nil(t, err)
+	defer nodeMgr.Finish()
 	controllerData = crmutil.NewControllerData(nil, &nodeMgr)
 	mgr := notify.ServerMgr{}
 	initSrvNotify(&mgr)

--- a/cloud-resource-manager/k8smgmt/manifest_test.go
+++ b/cloud-resource-manager/k8smgmt/manifest_test.go
@@ -26,7 +26,7 @@ var envVars = `- name: SOME_ENV1
 
 func TestEnvVars(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
@@ -318,7 +318,7 @@ var imagePaths = map[string]string{
 
 func TestImagePullSecrets(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/cloudcommon/deployment_test.go
+++ b/cloudcommon/deployment_test.go
@@ -19,7 +19,7 @@ var deploymentMF = "some deployment manifest"
 
 func TestDeployment(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/cloudcommon/manifest_zip_test/dockermanifest_test.go
+++ b/cloudcommon/manifest_zip_test/dockermanifest_test.go
@@ -70,7 +70,7 @@ var imagePaths = map[string]struct{}{
 
 func TestRemoteZipManifests(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/cloudcommon/node/events_test.go
+++ b/cloudcommon/node/events_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -14,9 +13,6 @@ import (
 
 func TestEvents(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelEvents)
-	log.InitTracer("")
-	defer log.FinishTracer()
-	ctx := log.StartTestSpan(context.Background())
 
 	// elasticsearch docker takes a while to start up (~20s),
 	// so make sure to include all unit-testing against it here.
@@ -28,7 +24,7 @@ func TestEvents(t *testing.T) {
 
 	// events rely on nodeMgr
 	nodeMgr := NodeMgr{}
-	err = nodeMgr.Init(ctx, NodeTypeController, "", WithRegion("unit-test"),
+	ctx, _, err := nodeMgr.Init(NodeTypeController, "", WithRegion("unit-test"),
 		WithESUrls("http://localhost:9200"))
 	require.Nil(t, err)
 

--- a/cloudcommon/node/pki.go
+++ b/cloudcommon/node/pki.go
@@ -99,6 +99,13 @@ func (s *NodeMgr) initInternalPki(ctx context.Context) error {
 	return nil
 }
 
+// Must be called after Jaeger is initialized because it creates new spans.
+func (s *internalPki) start() {
+	if s.UseVaultCerts {
+		go s.refreshCerts()
+	}
+}
+
 // Load certs specified on command line.
 func (s *internalPki) loadCerts(tlsCertFile string) error {
 	dir := path.Dir(tlsCertFile)

--- a/cloudcommon/node/pki_issuer.go
+++ b/cloudcommon/node/pki_issuer.go
@@ -10,7 +10,7 @@ const (
 	CertIssuerGlobal           = "pki-global"
 	CertIssuerRegional         = "pki-regional"
 	CertIssuerRegionalCloudlet = "pki-regional-cloudlet"
-	NoEventTlsClientIssuer     = ""
+	NoTlsClientIssuer          = ""
 )
 
 // To avoid services from one region to be able to talk to services from

--- a/cloudcommon/node/pki_test.go
+++ b/cloudcommon/node/pki_test.go
@@ -20,7 +20,7 @@ import (
 // dependencies on process package.
 
 func TestInternalPki(t *testing.T) {
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	// Set up local Vault process.
@@ -354,8 +354,9 @@ func testGetTlsConfig(t *testing.T, ctx context.Context, vroles *process.VaultRo
 	vc := getVaultConfig(cfg.VaultNodeType, cfg.VaultRegion, vroles)
 	mgr := node.NodeMgr{}
 	mgr.InternalPki.UseVaultCerts = true
-	mgr.Init(ctx, cfg.NodeType, node.NoEventTlsClientIssuer, node.WithRegion(cfg.Region), node.WithVaultConfig(vc))
-	_, err := mgr.InternalPki.GetServerTlsConfig(ctx,
+	_, _, err := mgr.Init(cfg.NodeType, node.NoTlsClientIssuer, node.WithRegion(cfg.Region), node.WithVaultConfig(vc))
+	require.Nil(t, err)
+	_, err = mgr.InternalPki.GetServerTlsConfig(ctx,
 		mgr.CommonName(),
 		cfg.LocalIssuer,
 		cfg.RemoteCAs)
@@ -392,7 +393,7 @@ func testExchange(t *testing.T, ctx context.Context, vroles *process.VaultRoles,
 	serverNode.InternalPki.UseVaultCAs = cs.Server.UseVaultCAs
 	serverNode.InternalPki.UseVaultCerts = cs.Server.UseVaultCerts
 	serverNode.InternalDomain = "mobiledgex.net"
-	err := serverNode.Init(ctx, cs.Server.Type, "",
+	_, _, err := serverNode.Init(cs.Server.Type, node.NoTlsClientIssuer,
 		node.WithRegion(cs.Server.Region),
 		node.WithVaultConfig(serverVault))
 	require.Nil(t, err)
@@ -411,7 +412,7 @@ func testExchange(t *testing.T, ctx context.Context, vroles *process.VaultRoles,
 	clientNode.InternalPki.UseVaultCAs = cs.Client.UseVaultCAs
 	clientNode.InternalPki.UseVaultCerts = cs.Client.UseVaultCerts
 	clientNode.InternalDomain = "mobiledgex.net"
-	err = clientNode.Init(ctx, cs.Client.Type, "",
+	_, _, err = clientNode.Init(cs.Client.Type, node.NoTlsClientIssuer,
 		node.WithRegion(cs.Client.Region),
 		node.WithVaultConfig(clientVault))
 	require.Nil(t, err)

--- a/cloudcommon/node/publicnode.go
+++ b/cloudcommon/node/publicnode.go
@@ -1,0 +1,32 @@
+package node
+
+import (
+	"context"
+	"crypto/tls"
+	"os"
+)
+
+// Third party services that we deploy all have their own letsencrypt-public
+// issued certificate, with a CA pool that includes the vault internal public CAs.
+// This allows mTLS where the public node uses a public cert and our internal
+// services use an internal vault pki cert.
+// Examples of such services are Jaeger, ElasticSearch, etc.
+
+func (s *NodeMgr) GetPublicClientTlsConfig(ctx context.Context) (*tls.Config, error) {
+	if s.tlsClientIssuer == "" {
+		return nil, nil
+	}
+	tlsOpts := []TlsOp{
+		WithPublicCAPool(),
+	}
+	if e2e := os.Getenv("E2ETEST_TLS"); e2e != "" {
+		// skip verifying cert if e2e-tests, because cert
+		// will be self-signed
+		tlsOpts = append(tlsOpts, WithTlsSkipVerify(true))
+	}
+	return s.InternalPki.GetClientTlsConfig(ctx,
+		s.CommonName(),
+		s.tlsClientIssuer,
+		[]MatchCA{},
+		tlsOpts...)
+}

--- a/cluster-svc/cluster-svc-main.go
+++ b/cluster-svc/cluster-svc-main.go
@@ -615,18 +615,14 @@ func validateAppRevision(ctx context.Context, appkey *edgeproto.AppKey) error {
 
 func main() {
 	nodeMgr.InitFlags()
-	var err error
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer(nodeMgr.TlsCertFile)
-	defer log.FinishTracer()
-	span := log.StartSpan(log.DebugLevelInfo, "main")
-	ctx := log.ContextWithSpan(context.Background(), span)
 
-	err = nodeMgr.Init(ctx, node.NodeTypeClusterSvc, node.CertIssuerRegional, node.WithName(*hostname), node.WithRegion(*region))
+	ctx, span, err := nodeMgr.Init(node.NodeTypeClusterSvc, node.CertIssuerRegional, node.WithName(*hostname), node.WithRegion(*region))
 	if err != nil {
 		log.FatalLog("init node mgr failed", "err", err)
 	}
+	defer nodeMgr.Finish()
 
 	clusterSvcPlugin, err = pfutils.GetClusterSvc(ctx, *pluginRequired)
 	if err != nil {

--- a/controller/alert_api_test.go
+++ b/controller/alert_api_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAlertApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
@@ -40,7 +40,7 @@ func TestAlertApi(t *testing.T) {
 
 func TestAppInstDownAlert(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/controller/app_api_test.go
+++ b/controller/app_api_test.go
@@ -13,8 +13,6 @@ import (
 func TestAppApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
 	testinit()
-	log.InitTracer("")
-	defer log.FinishTracer()
 
 	dummy := dummyEtcd{}
 	dummy.Start()
@@ -25,6 +23,8 @@ func TestAppApi(t *testing.T) {
 	defer sync.Done()
 
 	// cannot create apps without developer
+	log.InitTracer(nil)
+	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	for _, obj := range testutil.AppData {
 		_, err := appApi.CreateApp(ctx, &obj)

--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAppInstApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()
@@ -287,8 +287,6 @@ func ClientAppInstCachedFieldsTest(t *testing.T, ctx context.Context, appApi edg
 
 func TestAutoClusterInst(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
-	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()
 

--- a/controller/appinstclient_api_test.go
+++ b/controller/appinstclient_api_test.go
@@ -35,7 +35,7 @@ func (x *ShowAppInstClient) Context() context.Context {
 
 func TestAppInstClientApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()

--- a/controller/autoprovpolicy_api_test.go
+++ b/controller/autoprovpolicy_api_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAutoProvPolicyApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()

--- a/controller/autoscalepolicy_api_test.go
+++ b/controller/autoscalepolicy_api_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAutoScalePolicyApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()

--- a/controller/cloudlet_api_test.go
+++ b/controller/cloudlet_api_test.go
@@ -30,7 +30,7 @@ const (
 
 func TestCloudletApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()

--- a/controller/cloudletinfo_api_test.go
+++ b/controller/cloudletinfo_api_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCloudletInfo(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()

--- a/controller/cloudletpool_api_test.go
+++ b/controller/cloudletpool_api_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCloudletPoolApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()

--- a/controller/clusterinst_api_test.go
+++ b/controller/clusterinst_api_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestClusterInstApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()

--- a/controller/device_api_test.go
+++ b/controller/device_api_test.go
@@ -15,7 +15,7 @@ import (
 func TestDeviceApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
 	testinit()
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/controller/flavor_api_test.go
+++ b/controller/flavor_api_test.go
@@ -3,18 +3,19 @@ package main
 import (
 	"context"
 
+	"testing"
+
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/testutil"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestFlavorApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
 	testinit()
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/controller/influxq_client/influxq_test.go
+++ b/controller/influxq_client/influxq_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestInfluxQ(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelMetrics)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 
 	addr := "127.0.0.1:8086"

--- a/controller/main_test.go
+++ b/controller/main_test.go
@@ -25,7 +25,7 @@ func getGrpcClient(t *testing.T) (*grpc.ClientConn, error) {
 
 func TestController(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelNotify | log.DebugLevelApi | log.DebugLevelUpgrade)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	flag.Parse() // set defaults
@@ -175,7 +175,7 @@ func TestDataGen(t *testing.T) {
 
 func TestEdgeCloudBug26(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	flag.Parse()

--- a/controller/operatorcode_api_test.go
+++ b/controller/operatorcode_api_test.go
@@ -12,7 +12,7 @@ import (
 func TestOperatorCodeApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
 	testinit()
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 
 	dummy := dummyEtcd{}

--- a/controller/privacypolicy_api_test.go
+++ b/controller/privacypolicy_api_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestPrivacyPolicyApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()

--- a/controller/restagtable_api_test.go
+++ b/controller/restagtable_api_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestResTagTableApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	objstore.InitRegion(1)

--- a/controller/settings_api_test.go
+++ b/controller/settings_api_test.go
@@ -2,17 +2,17 @@ package main
 
 import (
 	"context"
+	"testing"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestSettingsApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi)
 	testinit()
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/controller/upgrade_test.go
+++ b/controller/upgrade_test.go
@@ -141,7 +141,7 @@ func TestAllUpgradeFuncs(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelUpgrade | log.DebugLevelApi)
 	objStore := dummyEtcd{}
 	objstore.InitRegion(1)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	for ii, fn := range edgeproto.VersionHash_UpgradeFuncs {

--- a/controller/vmpool_api_test.go
+++ b/controller/vmpool_api_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestVMPoolApi(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	testinit()

--- a/d-match-engine/dme-common/autoprov_dmestats_test.go
+++ b/d-match-engine/dme-common/autoprov_dmestats_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAutoProvStats(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelDmereq | log.DebugLevelMetrics)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/d-match-engine/dme-server/dme-location_test.go
+++ b/d-match-engine/dme-server/dme-location_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestVerifyLoc(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelDmereq)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	span := log.SpanFromContext(ctx)

--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -398,16 +398,13 @@ func main() {
 	nodeMgr.InitFlags()
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer(nodeMgr.TlsCertFile)
-	defer log.FinishTracer()
-	span := log.StartSpan(log.DebugLevelInfo, "main")
-	ctx := log.ContextWithSpan(context.Background(), span)
 
 	cloudcommon.ParseMyCloudletKey(false, cloudletKeyStr, &myCloudletKey)
-	err := nodeMgr.Init(ctx, node.NodeTypeDME, node.CertIssuerRegionalCloudlet, node.WithName(*scaleID), node.WithCloudletKey(&myCloudletKey), node.WithRegion(*region))
+	ctx, span, err := nodeMgr.Init(node.NodeTypeDME, node.CertIssuerRegionalCloudlet, node.WithName(*scaleID), node.WithCloudletKey(&myCloudletKey), node.WithRegion(*region))
 	if err != nil {
 		log.FatalLog("Failed init node", "err", err)
 	}
+	defer nodeMgr.Finish()
 	operatorApiGw, err = initOperator(ctx, *carrier)
 	if err != nil {
 		span.Finish()

--- a/d-match-engine/dme-server/dme-notify_test.go
+++ b/d-match-engine/dme-server/dme-notify_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestNotify(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	dmecommon.SetupMatchEngine()

--- a/d-match-engine/dme-server/match-engine_test.go
+++ b/d-match-engine/dme-server/match-engine_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAddRemove(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelDmereq)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	span := log.SpanFromContext(ctx)

--- a/edgeturn/server.go
+++ b/edgeturn/server.go
@@ -91,20 +91,16 @@ func main() {
 	nodeMgr.InitFlags()
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer(nodeMgr.TlsCertFile)
-	defer log.FinishTracer()
 
 	sigChan = make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
 
-	span := log.StartSpan(log.DebugLevelInfo, "main")
-	ctx := log.ContextWithSpan(context.Background(), span)
-
-	err := nodeMgr.Init(ctx, node.NodeTypeEdgeTurn, node.CertIssuerRegional, node.WithRegion(*region))
+	ctx, span, err := nodeMgr.Init(node.NodeTypeEdgeTurn, node.CertIssuerRegional, node.WithRegion(*region))
 	if err != nil {
 		span.Finish()
 		log.FatalLog("Failed to init node", "err", err)
 	}
+	defer nodeMgr.Finish()
 
 	started := make(chan bool)
 	go func() {

--- a/edgeturn/server_test.go
+++ b/edgeturn/server_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestEdgeTurnServer(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelApi | log.DebugLevelInfo)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	flag.Parse() // set defaults
 

--- a/log/jaeger.go
+++ b/log/jaeger.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mobiledgex/edge-cloud/tls"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	jaeger "github.com/uber/jaeger-client-go"
@@ -30,7 +30,7 @@ var SpanServiceName string
 // InitTracer configures the Jaeger OpenTracing client to log traces.
 // Set JAEGER_ENDPOINT to http://<jaegerhost>:14268/api/traces to
 // specify the Jaeger server.
-func InitTracer(tlsCertFile string) {
+func InitTracer(tlsConfig *tls.Config) {
 	SpanServiceName = filepath.Base(os.Args[0])
 
 	jaegerEndpoint := os.Getenv("JAEGER_ENDPOINT")
@@ -43,11 +43,6 @@ func InitTracer(tlsCertFile string) {
 	}
 
 	// Set up client-side TLS
-	skipVerify := false
-	tlsConfig, err := tls.GetTLSClientConfig(ur.Host, tlsCertFile, "", skipVerify)
-	if err != nil {
-		panic(fmt.Sprintf("ERROR: failed to init TLS client config for cert %s, %v", tlsCertFile, err))
-	}
 	if tlsConfig == nil {
 		ur.Scheme = "http"
 	} else {

--- a/log/spanlog.go
+++ b/log/spanlog.go
@@ -15,7 +15,8 @@ import (
 // Wrap Span so we can override Finish()
 type Span struct {
 	*jaeger.Span
-	suppress bool // ignore log for show commands etc
+	suppress  bool // ignore log for show commands etc
+	noTracing bool // special span that only logs to disk
 }
 
 var IgnoreLvl uint64 = 99999
@@ -60,6 +61,16 @@ func StartSpan(lvl uint64, operationName string, opts ...opentracing.StartSpanOp
 	if jspan.SpanContext().IsSampled() && !span.suppress {
 		ec := zapcore.NewEntryCaller(runtime.Caller(1))
 		spanlogger.Info(getSpanMsg(span, ec.TrimmedPath(), "start "+operationName))
+	}
+	return span
+}
+
+// This span only logs to disk, and does not actually do any tracing.
+// It is primarily for use during init for logging to disk before Jaeger
+// is initialized, or for unit tests.
+func NoTracingSpan() opentracing.Span {
+	span := &Span{
+		noTracing: true,
 	}
 	return span
 }
@@ -112,12 +123,18 @@ func SpanLog(ctx context.Context, lvl uint64, msg string, keysAndValues ...inter
 	if !ok {
 		panic("non-edge-cloud Span not supported")
 	}
-	if !span.SpanContext().IsSampled() {
+	if !span.noTracing && !span.SpanContext().IsSampled() {
 		return
 	}
 
-	ec := zapcore.NewEntryCaller(runtime.Caller(1))
+	ec := zapcore.NewEntryCaller(runtime.Caller(2))
 	lineno := ec.TrimmedPath()
+	if span.noTracing {
+		// just log to disk
+		zfields := getFields(keysAndValues)
+		spanlogger.Info(getSpanMsg(nil, lineno, msg), zfields...)
+		return
+	}
 	fields := []trlog.Field{
 		trlog.String("msg", msg),
 		trlog.String("lineno", lineno),
@@ -156,7 +173,7 @@ func getFields(args []interface{}) []zap.Field {
 	return fields
 }
 
-// Convenience function for test routines
+// Convenience function for test routines. Does not require InitTracer().
 func StartTestSpan(ctx context.Context) context.Context {
 	span := StartSpan(DebugLevelInfo, "test")
 	// ignore span.Finish()
@@ -164,7 +181,7 @@ func StartTestSpan(ctx context.Context) context.Context {
 }
 
 func (s *Span) Finish() {
-	if s.suppress {
+	if s.suppress || s.noTracing {
 		return
 	}
 	s.Span.Finish()

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestNotifyBasic(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/notify/notify_tree_test.go
+++ b/notify/notify_tree_test.go
@@ -29,7 +29,7 @@ const (
 // a balanced binary tree.
 func TestNotifyTree(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/notifyroot/notifyroot.go
+++ b/notifyroot/notifyroot.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -24,15 +23,12 @@ func main() {
 	nodeMgr.InitFlags()
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer(nodeMgr.TlsCertFile)
-	defer log.FinishTracer()
-	span := log.StartSpan(log.DebugLevelInfo, "main")
-	ctx := log.ContextWithSpan(context.Background(), span)
 
-	err := nodeMgr.Init(ctx, node.NodeTypeNotifyRoot, node.CertIssuerGlobal)
+	ctx, span, err := nodeMgr.Init(node.NodeTypeNotifyRoot, node.CertIssuerGlobal)
 	if err != nil {
 		log.FatalLog("Failed to init node", "err", err)
 	}
+	defer nodeMgr.Finish()
 
 	notifyServer := &notify.ServerMgr{}
 	nodeMgr.RegisterServer(notifyServer)

--- a/setup-env/test-mex/test-mex.go
+++ b/setup-env/test-mex/test-mex.go
@@ -110,7 +110,7 @@ func validateArgs(config *e2eapi.TestConfig, spec *setupmex.TestSpec) {
 
 func main() {
 	flag.Parse()
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	util.SetLogFormat()

--- a/util/tasks/keyworkers_test.go
+++ b/util/tasks/keyworkers_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestKeyWorkers(t *testing.T) {
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 


### PR DESCRIPTION
These changes to remove any dependencies on the hard-coded id_rsa_mex cert from our services. The main remaining code change needed to was to transition Jaeger from the hard-coded cert to a vault internal pki cert.

There was a circular dependency issue though, because Jaeger needs to init after Vault to get the right tls config, but Vault relies on the logging provided by Jaeger. To fix:
1. I've moved logging init inside of nodeMgr init.
2. A special span that only logs to disk is created for the code that needs to run before Jaeger is initialized (vault pki init).
3. After that, we transition to a normal span created inside nodeMgr.Init(). This span is then passed back to the caller (which is always main) to be used as the main span.

Note that there are no changes to edge-cloud e2e tests. Edge-cloud e2e tests maintains testing of file-based cert for internal encryption. The infra e2e-tests rely solely upon vault internal pki. So the two tests cover the two possible ways of doing it.