### PR TITLE
EDGECLOUD-3647: RunCommand/ShowLogs not working for Docker LB

### DIFF
--- a/controller/exec_api.go
+++ b/controller/exec_api.go
@@ -28,7 +28,7 @@ const (
 	// For K8s/Docker based Apps
 	ShortTimeout = edgeproto.Duration(6 * time.Second)
 	// For VM based Apps
-	LongTimeout = edgeproto.Duration(20 * time.Second)
+	LongTimeout = edgeproto.Duration(60 * time.Second)
 )
 
 var execApi = ExecApi{}


### PR DESCRIPTION
* Increased timeout as at times Openstack commands take lot of time.
* In case of Docker LB, CRM needs to fetch two IPs -> (1) RootLB's (2) Docker VM's. And to fetch ip details it makes 3 Openstack API calls. So in total 6.
* For example, here's output from Berlin cloudlet:
```
OpenStack Command Done  {"parmstr": "server show -f json autoclusterandycmd.automationberlincloudlet.tdg.mobiledgex.net", "elapsed time": "4.160064155s"}
OpenStack Command Done  {"parmstr": "port list --server autoclusterandycmd.automationberlincloudlet.tdg.mobiledgex.net -f json", "elapsed time": "3.74564244s"}
OpenStack Command Done  {"parmstr": "subnet list --network mex-k8s-net-1 -f json", "elapsed time": "3.713614037s"}
OpenStack Command Done  {"parmstr": "server show -f json mex-docker-vm-automationberlincloudlet-autoclusterandycmd-mobiledgex", "elapsed time": "5.337946698s"}
OpenStack Command Done  {"parmstr": "port list --server mex-docker-vm-automationberlincloudlet-autoclusterandycmd-mobiledgex -f json", "elapsed time": "7.223800318s"}
OpenStack Command Done  {"parmstr": "subnet list --network mex-k8s-net-1 -f json", "elapsed time": "3.526770007s"}
```
* Above accounts for total time of ~27secs ! Hence i have increased the timeout in case Openstack command takes lot of time