### PR TITLE
added vm lb app for unit tests

### DIFF
--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -189,7 +189,7 @@ func TestAppInstApi(t *testing.T) {
 	for _, data := range appInstApi.cache.Objs {
 		obj := data.Obj
 		app_name := util.K8SSanitize(obj.Key.AppKey.Name)
-		if app_name == "helmapp" {
+		if app_name == "helmapp" || app_name == "vmlb" {
 			continue
 		}
 		for _, port := range obj.MappedPorts {

--- a/notify/notify_tree_test.go
+++ b/notify/notify_tree_test.go
@@ -95,9 +95,9 @@ func TestNotifyTree(t *testing.T) {
 	// crms at all levels get all flavors
 	// mid level gets the appInsts and clusterInsts for all below it.
 	// low level only gets the ones for itself.
-	checkClientCache(t, low21, 3, 3, 5, 1)
+	checkClientCache(t, low21, 3, 3, 6, 1)
 	checkClientCache(t, low22, 3, 2, 3, 1)
-	checkClientCache(t, mid2, 3, 5, 8, 2)
+	checkClientCache(t, mid2, 3, 5, 9, 2)
 	checkCache(t, mid1, FreeReservableClusterInstType, 1)
 
 	// Add info objs to low nodes
@@ -168,9 +168,9 @@ func TestNotifyTree(t *testing.T) {
 	checkCache(t, mid2, AlertType, 1)
 
 	low21.startClient()
-	checkClientCache(t, low21, 3, 3, 5, 1)
+	checkClientCache(t, low21, 3, 3, 6, 1)
 	checkClientCache(t, low22, 3, 2, 3, 1)
-	checkClientCache(t, mid2, 3, 5, 8, 2)
+	checkClientCache(t, mid2, 3, 5, 9, 2)
 	checkCache(t, mid1, FreeReservableClusterInstType, 1)
 	mid2.handler.WaitForCloudletInfo(2)
 

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -209,6 +209,19 @@ var AppData = []edgeproto.App{
 			AutoProvPolicyData[3].Key.Name,
 		},
 	},
+	edgeproto.App{
+		Key: edgeproto.AppKey{
+			Organization: DevData[0],
+			Name:         "vm lb",
+			Version:      "1.0.2",
+		},
+		Deployment:    "vm",
+		ImageType:     edgeproto.ImageType_IMAGE_TYPE_QCOW,
+		ImagePath:     "http://somerepo/image/path/myreality/0.0.1#md5:7e9cfcb763e83573a4b9d9315f56cc5f",
+		AccessPorts:   "tcp:10003",
+		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
+		DefaultFlavor: FlavorData[0].Key,
+	},
 }
 var OperatorData = []string{
 	"AT&T Inc.",
@@ -534,6 +547,17 @@ var AppInstData = []edgeproto.AppInst{
 		},
 		CloudletLoc: CloudletData[1].Location,
 	},
+	edgeproto.AppInst{ // 11
+		Key: edgeproto.AppInstKey{
+			AppKey: AppData[12].Key, //vm app with lb
+			ClusterInstKey: edgeproto.ClusterInstKey{
+				ClusterKey:   edgeproto.ClusterKey{Name: "DefaultVMCluster"},
+				CloudletKey:  CloudletData[0].Key,
+				Organization: DevData[0],
+			},
+		},
+		CloudletLoc: CloudletData[1].Location,
+	},
 }
 
 var AppInstInfoData = []edgeproto.AppInstInfo{
@@ -629,6 +653,12 @@ var AppInstRefsData = []edgeproto.AppInstRefs{
 	edgeproto.AppInstRefs{
 		Key:   AppData[11].Key,
 		Insts: map[string]uint32{},
+	},
+	edgeproto.AppInstRefs{
+		Key: AppData[12].Key,
+		Insts: map[string]uint32{
+			AppInstData[11].Key.GetKeyString(): 1,
+		},
 	},
 }
 


### PR DESCRIPTION
Added a vm app with a load balancer for testing vm healthchecks on shepherd. This was done to cover unit-tests for https://github.com/mobiledgex/edge-cloud-infra/pull/1038