### PR TITLE
delete ClusterInst configDir issue

### DIFF
--- a/cloud-resource-manager/k8smgmt/cluster.go
+++ b/cloud-resource-manager/k8smgmt/cluster.go
@@ -23,7 +23,6 @@ func DeleteNodes(ctx context.Context, client ssh.Client, kconfName string, nodes
 }
 
 func CleanupClusterConfig(ctx context.Context, client ssh.Client, clusterInst *edgeproto.ClusterInst) error {
-
 	names, err := GetKubeNames(clusterInst, &edgeproto.App{}, &edgeproto.AppInst{})
 	if err != nil {
 		return err


### PR DESCRIPTION
EDGECLOUD-3663

DeleteClusterInst fails in Azure when there were no AppInsts created.   The reason is that CleanupClusterConfig tries to delete the config dir, but this dir is not created until there are AppInsts.  This is currently only seen in the Azure (probably GCP, AWS also) but that may be just because the OpenStack clusters always have at least a prometheus app as the code is common.

Fix is to use the platform DeleteDir function which will not error on a dir that does not exist, nor one with files in it (could possibly also happen in some error case)