### PR TITLE
EDGECLOUD-3645: Better error message for invalid AccessPorts input

### DIFF
--- a/util/ports.go
+++ b/util/ports.go
@@ -30,7 +30,7 @@ func ParsePorts(accessPorts string) ([]PortSpec, error) {
 		annotations := make(map[string]string)
 		for _, kv := range pp[2:] {
 			if kv == "" {
-				return nil, fmt.Errorf("invalid AccessPorts format '%s'", pstr)
+				return nil, fmt.Errorf("invalid AccessPorts annotation %s for port %s, expected format is either key or key=val", kv, pp[1])
 			}
 			keyval := strings.Split(kv, "=")
 			if len(keyval) == 1 {


### PR DESCRIPTION
Added check for empty annotation in parseAppPorts