### PR TITLE
UpdateApp manifest

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -431,7 +431,7 @@ func (s *AppApi) UpdateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 		} else if in.AccessPorts != "" {
 			// force regeneration of manifest
 			if cur.DeploymentGenerator == "" {
-				// no generator means we previously provide a manifest.  Force them to do so again when changing ports so
+				// No generator means the user previously provided a manifest.  Force them to do so again when changing ports so
 				// that they do not accidentally lose their provided manifest details
 				return fmt.Errorf("manifest which was previously specified must be provided again when changing access ports")
 			}


### PR DESCRIPTION
Another tweak to UpdateApp validation:  when we update AccessPorts, we have to re-generate the manifest.  A concern was raised that if a developer had previously specified a manifest, but neglected to do so on update, their original manifest would be overridden.  

This change is to force the developer to specify the manifest on Update, if it was previously specified on Create.  We check the DeploymentGenerator to make this determination (an empty DeploymentGenerator means a manifest was specified rather than having been auto-generated)