### PR TITLE
updateapp validations for docker, and ignore manifest check for non-k8s

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -429,12 +429,15 @@ func (s *AppApi) UpdateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 			// reset the deployment generator
 			cur.DeploymentGenerator = ""
 		} else if in.AccessPorts != "" {
-			// force regeneration of manifest
-			if cur.DeploymentGenerator == "" {
+			if cur.DeploymentGenerator == "" && cur.Deployment == cloudcommon.DeploymentTypeKubernetes {
 				// No generator means the user previously provided a manifest.  Force them to do so again when changing ports so
 				// that they do not accidentally lose their provided manifest details
-				return fmt.Errorf("manifest which was previously specified must be provided again when changing access ports")
+				return fmt.Errorf("kubernetes manifest which was previously specified must be provided again when changing access ports")
+			} else if cur.Deployment == cloudcommon.DeploymentTypeDocker {
+				// there's no way to tell if we generated this manifest or it was provided, so disallow this change
+				return fmt.Errorf("Changing access ports on docker apps not allowed unless manifest is specified")
 			}
+			// force regeneration of manifest
 			cur.DeploymentManifest = ""
 		}
 		cur.CopyInFields(in)


### PR DESCRIPTION
UpdateApp tweaks part 37 (roughly)

- My previous check for k8s manifest being required broke an e2e helm test, so restricting this change to k8s only as that is where the deployment generator is used
- Add an additional check to disallow changing access ports on docker because there's no way to tell if the manifest was auto generated or not.  