### PR TITLE
EDGECLOUD-3682 fix pki cert refresh

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -996,6 +996,10 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 
 	var app edgeproto.App
 
+	s.setDefaultVMClusterKey(ctx, &in.Key)
+	if err := in.Key.AppKey.ValidateKey(); err != nil {
+		return err
+	}
 	// get appinst info for flavor
 	appInstInfo := edgeproto.AppInst{}
 	if !appInstApi.cache.Get(&in.Key, &appInstInfo) {
@@ -1013,10 +1017,6 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 	if in.Key.ClusterInstKey.Organization == "" {
 		in.Key.ClusterInstKey.Organization = in.Key.AppKey.Organization
 		cb.Send(&edgeproto.Result{Message: "Setting ClusterInst developer to match App developer"})
-	}
-	s.setDefaultVMClusterKey(ctx, &in.Key)
-	if err := in.Key.AppKey.ValidateKey(); err != nil {
-		return err
 	}
 
 	// check if we are deleting an autocluster instance we need to set the key correctly.

--- a/setup-env/e2e-tests/data/influx_events_data.yml
+++ b/setup-env/e2e-tests/data/influx_events_data.yml
@@ -9,10 +9,14 @@
     - cloudletorg
     - cluster
     - clusterorg
+    - deployment
     - disk
     - event
     - flavor
-    - nodeCount
+    - flavor_1
+    - ipaccess
+    - nodecount
+    - org
     - other
     - ram
     - status
@@ -26,8 +30,12 @@
       - tmus
       - SmallCluster
       - AcmeAppCo
+      - kubernetes
       - null
       - CREATED
+      - null
+      - null
+      - null
       - null
       - null
       - null
@@ -42,8 +50,12 @@
       - tmus
       - SmallCluster
       - AcmeAppCo
+      - kubernetes
       - null
       - DELETED
+      - null
+      - null
+      - null
       - null
       - null
       - null
@@ -58,8 +70,12 @@
       - tmus
       - SmallCluster
       - AcmeAppCo
+      - kubernetes
       - null
       - CREATED
+      - null
+      - null
+      - null
       - null
       - null
       - null
@@ -74,8 +90,12 @@
       - tmus
       - SmallCluster
       - AcmeAppCo
+      - kubernetes
       - null
       - DELETED
+      - null
+      - null
+      - null
       - null
       - null
       - null
@@ -94,10 +114,14 @@
     - cloudletorg
     - cluster
     - clusterorg
+    - deployment
     - disk
     - event
     - flavor
-    - nodeCount
+    - flavor_1
+    - ipaccess
+    - nodecount
+    - org
     - other
     - ram
     - status
@@ -112,7 +136,11 @@
       - null
       - null
       - null
+      - null
       - CREATED
+      - null
+      - null
+      - null
       - null
       - null
       - null
@@ -128,7 +156,11 @@
       - null
       - null
       - null
+      - null
       - DELETED
+      - null
+      - null
+      - null
       - null
       - null
       - null
@@ -147,10 +179,14 @@
     - cloudletorg
     - cluster
     - clusterorg
+    - deployment
     - disk
     - event
     - flavor
-    - nodeCount
+    - flavor_1
+    - ipaccess
+    - nodecount
+    - org
     - other
     - ram
     - status
@@ -164,10 +200,14 @@
       - tmus
       - SmallCluster
       - AcmeAppCo
+      - null
       - 2
       - CREATED
+      - null
       - x1.small
+      - IP_ACCESS_SHARED
       - 3
+      - AcmeAppCo
       - map[]
       - 2048
       - UP
@@ -180,10 +220,14 @@
       - tmus
       - SmallCluster
       - AcmeAppCo
+      - null
       - 2
       - DELETED
+      - null
       - x1.small
+      - IP_ACCESS_SHARED
       - 3
+      - AcmeAppCo
       - map[]
       - 2048
       - DOWN


### PR DESCRIPTION
Fixes pki refresh bug. The code to do the refresh was never getting run because of improperly set up select statement. I had kind of set it up like a switch statement but select doesn't work the same way (also select doesn't support fallthrough). The select statement should be a blocking path only, the refresh code runs after the select statement is exited.

To test, e2e-tests will run with a refresh rate of 10s. I verified from the log files that refresh was actually running, and e2e-tests pass (after fixes), so refreshed certs must be ok.

Also includes fixes for unrelated e2e-test regressions.