### PR TITLE
fix error checking on e2e when there is more than one action

### DIFF
--- a/setup-env/test-mex/test-mex.go
+++ b/setup-env/test-mex/test-mex.go
@@ -155,7 +155,7 @@ func main() {
 		for _, a := range spec.Actions {
 			util.PrintStepBanner("running action: " + a + retry.Tries())
 			actionretry := false
-			tryErrs = setupmex.RunAction(ctx, a, outputDir, &spec, mods, config.Vars, &actionretry)
+			tryErrs = append(tryErrs, setupmex.RunAction(ctx, a, outputDir, &spec, mods, config.Vars, &actionretry)...)
 			ranTest = true
 			if actionretry {
 				retry.ActionEnable()


### PR DESCRIPTION
If there are multiple actions within a given e2e-test (e.g. "actions: [ctrlapi-delete,ctrlapi-show]") and the first action returns an error but the second does not, the first error is silently ignored.
