### PR TITLE
EDGECLOUD-3728 crash on RunCommand error

### DIFF
--- a/cloud-resource-manager/crmutil/exec.go
+++ b/cloud-resource-manager/crmutil/exec.go
@@ -193,7 +193,7 @@ func (cd *ControllerData) ProcessExecReq(ctx context.Context, req *edgeproto.Exe
 	// turn connection.
 	defer func() {
 		if reterr != nil && replySent {
-			turnConn.Write([]byte(err.Error()))
+			turnConn.Write([]byte(reterr.Error()))
 		}
 	}()
 	if req.Console != nil {


### PR DESCRIPTION
Fix for crash found in regression testing. In my tests, I think the path I was testing always set "err", so I didn't hit it.