### PR TITLE
EDGECLOUD-3754 elasticsearch events index deployment tag

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -42,7 +42,6 @@ var cloudletVMImagePath = flag.String("cloudletVMImagePath", "", "Image path whe
 var commercialCerts = flag.Bool("commercialCerts", false, "Get TLS certs from LetsEncrypt. If false CRM will generate its own self-signed certs")
 var appDNSRoot = flag.String("appDNSRoot", "mobiledgex.net", "App domain name root")
 var chefServerPath = flag.String("chefServerPath", "", "Chef server path")
-var deploymentTag = flag.String("deploymentTag", "", "Tag to indicate type of deployment setup. Ex: production, staging, etc")
 var upgrade = flag.Bool("upgrade", false, "Flag to initiate upgrade run as part of crm bringup")
 
 // myCloudletInfo is the information for the cloudlet in which the CRM is instantiated.
@@ -306,7 +305,7 @@ func initPlatform(ctx context.Context, cloudlet *edgeproto.Cloudlet, cloudletInf
 		NodeMgr:             &nodeMgr,
 		AppDNSRoot:          *appDNSRoot,
 		ChefServerPath:      *chefServerPath,
-		DeploymentTag:       *deploymentTag,
+		DeploymentTag:       nodeMgr.DeploymentTag,
 		Upgrade:             *upgrade,
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "init platform", "location(cloudlet.key.name)", loc, "operator", oper, "Platform type", platform.GetType())

--- a/cloudcommon/node/nodemgr.go
+++ b/cloudcommon/node/nodemgr.go
@@ -39,6 +39,7 @@ type NodeMgr struct {
 	ESClient        *elasticsearch.Client
 	tlsClientIssuer string
 	commonName      string
+	DeploymentTag   string
 }
 
 // Most of the time there will only be one NodeMgr per process, and these
@@ -55,6 +56,7 @@ func (s *NodeMgr) InitFlags() {
 	flag.BoolVar(&s.InternalPki.UseVaultCerts, "useVaultCerts", false, "Use Vault Certs for internal mTLS; implies useVaultCAs")
 	flag.StringVar(&s.InternalDomain, "internalDomain", "mobiledgex.net", "domain name for internal PKI")
 	flag.StringVar(&s.commonName, "commonName", "", "common name to use for vault internal pki issued certificates")
+	flag.StringVar(&s.DeploymentTag, "deploymentTag", "", "Tag to indicate type of deployment setup. Ex: production, staging, etc")
 }
 
 func (s *NodeMgr) Init(nodeType, tlsClientIssuer string, ops ...NodeOp) (context.Context, opentracing.Span, error) {

--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -165,7 +165,7 @@ func getPlatformConfig(ctx context.Context, cloudlet *edgeproto.Cloudlet) (*edge
 	pfConfig.Span = log.SpanToString(ctx)
 	pfConfig.ChefServerPath = *chefServerPath
 	pfConfig.ChefClientInterval = settingsApi.Get().ChefClientInterval
-	pfConfig.DeploymentTag = *deploymentTag
+	pfConfig.DeploymentTag = nodeMgr.DeploymentTag
 
 	return &pfConfig, nil
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -63,7 +63,6 @@ var testMode = flag.Bool("testMode", false, "Run controller in test mode")
 var commercialCerts = flag.Bool("commercialCerts", false, "Have CRM grab certs from LetsEncrypt. If false then CRM will generate its onwn self-signed cert")
 var checkpointInterval = flag.String("checkpointInterval", "MONTH", "Interval at which to checkpoint cluster usage")
 var appDNSRoot = flag.String("appDNSRoot", "mobiledgex.net", "App domain name root")
-var deploymentTag = flag.String("deploymentTag", "", "Tag to indicate type of deployment setup. Ex: production, staging, etc")
 
 var ControllerId = ""
 var InfluxDBName = cloudcommon.DeveloperMetricsDbName

--- a/d-match-engine/dme-proto/app-client.pb.go
+++ b/d-match-engine/dme-proto/app-client.pb.go
@@ -117,7 +117,7 @@ func (x FindCloudletReply_FindStatus) String() string {
 }
 
 func (FindCloudletReply_FindStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{4, 0}
+	return fileDescriptor_bb90079a337be67f, []int{5, 0}
 }
 
 // Status of the reply
@@ -146,7 +146,7 @@ func (x VerifyLocationReply_TowerStatus) String() string {
 }
 
 func (VerifyLocationReply_TowerStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{6, 0}
+	return fileDescriptor_bb90079a337be67f, []int{7, 0}
 }
 
 type VerifyLocationReply_GPSLocationStatus int32
@@ -189,7 +189,7 @@ func (x VerifyLocationReply_GPSLocationStatus) String() string {
 }
 
 func (VerifyLocationReply_GPSLocationStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{6, 1}
+	return fileDescriptor_bb90079a337be67f, []int{7, 1}
 }
 
 // Status of the reply
@@ -219,7 +219,7 @@ func (x GetLocationReply_LocStatus) String() string {
 }
 
 func (GetLocationReply_LocStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{8, 0}
+	return fileDescriptor_bb90079a337be67f, []int{9, 0}
 }
 
 // Status of the reply
@@ -248,7 +248,7 @@ func (x AppInstListReply_AIStatus) String() string {
 }
 
 func (AppInstListReply_AIStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{12, 0}
+	return fileDescriptor_bb90079a337be67f, []int{13, 0}
 }
 
 // Status of the reply
@@ -277,7 +277,7 @@ func (x FqdnListReply_FLStatus) String() string {
 }
 
 func (FqdnListReply_FLStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{15, 0}
+	return fileDescriptor_bb90079a337be67f, []int{16, 0}
 }
 
 type AppOfficialFqdnReply_AOFStatus int32
@@ -305,7 +305,7 @@ func (x AppOfficialFqdnReply_AOFStatus) String() string {
 }
 
 func (AppOfficialFqdnReply_AOFStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{17, 0}
+	return fileDescriptor_bb90079a337be67f, []int{18, 0}
 }
 
 // Use Secure communication or Open with the group
@@ -334,8 +334,51 @@ func (x DynamicLocGroupRequest_DlgCommType) String() string {
 }
 
 func (DynamicLocGroupRequest_DlgCommType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{18, 0}
+	return fileDescriptor_bb90079a337be67f, []int{19, 0}
 }
+
+type Tag struct {
+	// type of data
+	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	// data value
+	Data                 string   `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *Tag) Reset()         { *m = Tag{} }
+func (m *Tag) String() string { return proto.CompactTextString(m) }
+func (*Tag) ProtoMessage()    {}
+func (*Tag) Descriptor() ([]byte, []int) {
+	return fileDescriptor_bb90079a337be67f, []int{0}
+}
+func (m *Tag) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Tag) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Tag.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Tag) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Tag.Merge(m, src)
+}
+func (m *Tag) XXX_Size() int {
+	return m.Size()
+}
+func (m *Tag) XXX_DiscardUnknown() {
+	xxx_messageInfo_Tag.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Tag proto.InternalMessageInfo
 
 type RegisterClientRequest struct {
 	//
@@ -389,17 +432,17 @@ type RegisterClientRequest struct {
 	// Tags
 	//
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *RegisterClientRequest) Reset()         { *m = RegisterClientRequest{} }
 func (m *RegisterClientRequest) String() string { return proto.CompactTextString(m) }
 func (*RegisterClientRequest) ProtoMessage()    {}
 func (*RegisterClientRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{0}
+	return fileDescriptor_bb90079a337be67f, []int{1}
 }
 func (m *RegisterClientRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -467,17 +510,17 @@ type RegisterClientReply struct {
 	// Vendor specific data
 	//
 	// _(optional)_ Array of Tags.
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *RegisterClientReply) Reset()         { *m = RegisterClientReply{} }
 func (m *RegisterClientReply) String() string { return proto.CompactTextString(m) }
 func (*RegisterClientReply) ProtoMessage()    {}
 func (*RegisterClientReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{1}
+	return fileDescriptor_bb90079a337be67f, []int{2}
 }
 func (m *RegisterClientReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -537,17 +580,17 @@ type FindCloudletRequest struct {
 	// Tags
 	//
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *FindCloudletRequest) Reset()         { *m = FindCloudletRequest{} }
 func (m *FindCloudletRequest) String() string { return proto.CompactTextString(m) }
 func (*FindCloudletRequest) ProtoMessage()    {}
 func (*FindCloudletRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{2}
+	return fileDescriptor_bb90079a337be67f, []int{3}
 }
 func (m *FindCloudletRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -602,17 +645,17 @@ type PlatformFindCloudletRequest struct {
 	// Tags
 	//
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *PlatformFindCloudletRequest) Reset()         { *m = PlatformFindCloudletRequest{} }
 func (m *PlatformFindCloudletRequest) String() string { return proto.CompactTextString(m) }
 func (*PlatformFindCloudletRequest) ProtoMessage()    {}
 func (*PlatformFindCloudletRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{3}
+	return fileDescriptor_bb90079a337be67f, []int{4}
 }
 func (m *PlatformFindCloudletRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -656,17 +699,17 @@ type FindCloudletReply struct {
 	// Location of the cloudlet
 	CloudletLocation *Loc `protobuf:"bytes,5,opt,name=cloudlet_location,json=cloudletLocation,proto3" json:"cloudlet_location,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *FindCloudletReply) Reset()         { *m = FindCloudletReply{} }
 func (m *FindCloudletReply) String() string { return proto.CompactTextString(m) }
 func (*FindCloudletReply) ProtoMessage()    {}
 func (*FindCloudletReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{4}
+	return fileDescriptor_bb90079a337be67f, []int{5}
 }
 func (m *FindCloudletReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -730,17 +773,17 @@ type VerifyLocationRequest struct {
 	// Tags
 	//
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *VerifyLocationRequest) Reset()         { *m = VerifyLocationRequest{} }
 func (m *VerifyLocationRequest) String() string { return proto.CompactTextString(m) }
 func (*VerifyLocationRequest) ProtoMessage()    {}
 func (*VerifyLocationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{5}
+	return fileDescriptor_bb90079a337be67f, []int{6}
 }
 func (m *VerifyLocationRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -782,17 +825,17 @@ type VerifyLocationReply struct {
 	// means no verification was performed
 	GpsLocationAccuracyKm float64 `protobuf:"fixed64,4,opt,name=gps_location_accuracy_km,json=gpsLocationAccuracyKm,proto3" json:"gps_location_accuracy_km,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *VerifyLocationReply) Reset()         { *m = VerifyLocationReply{} }
 func (m *VerifyLocationReply) String() string { return proto.CompactTextString(m) }
 func (*VerifyLocationReply) ProtoMessage()    {}
 func (*VerifyLocationReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{6}
+	return fileDescriptor_bb90079a337be67f, []int{7}
 }
 func (m *VerifyLocationReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -834,17 +877,17 @@ type GetLocationRequest struct {
 	// _(optional)_ Cell id where the client is
 	CellId uint32 `protobuf:"varint,4,opt,name=cell_id,json=cellId,proto3" json:"cell_id,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *GetLocationRequest) Reset()         { *m = GetLocationRequest{} }
 func (m *GetLocationRequest) String() string { return proto.CompactTextString(m) }
 func (*GetLocationRequest) ProtoMessage()    {}
 func (*GetLocationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{7}
+	return fileDescriptor_bb90079a337be67f, []int{8}
 }
 func (m *GetLocationRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -887,17 +930,17 @@ type GetLocationReply struct {
 	// The GPS location of the user
 	NetworkLocation *Loc `protobuf:"bytes,5,opt,name=network_location,json=networkLocation,proto3" json:"network_location,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *GetLocationReply) Reset()         { *m = GetLocationReply{} }
 func (m *GetLocationReply) String() string { return proto.CompactTextString(m) }
 func (*GetLocationReply) ProtoMessage()    {}
 func (*GetLocationReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{8}
+	return fileDescriptor_bb90079a337be67f, []int{9}
 }
 func (m *GetLocationReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -947,17 +990,17 @@ type AppInstListRequest struct {
 	// _(optional)_ Limit the number of results, defaults to 3
 	Limit uint32 `protobuf:"varint,6,opt,name=limit,proto3" json:"limit,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *AppInstListRequest) Reset()         { *m = AppInstListRequest{} }
 func (m *AppInstListRequest) String() string { return proto.CompactTextString(m) }
 func (*AppInstListRequest) ProtoMessage()    {}
 func (*AppInstListRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{9}
+	return fileDescriptor_bb90079a337be67f, []int{10}
 }
 func (m *AppInstListRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1006,7 +1049,7 @@ func (m *Appinstance) Reset()         { *m = Appinstance{} }
 func (m *Appinstance) String() string { return proto.CompactTextString(m) }
 func (*Appinstance) ProtoMessage()    {}
 func (*Appinstance) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{10}
+	return fileDescriptor_bb90079a337be67f, []int{11}
 }
 func (m *Appinstance) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1055,7 +1098,7 @@ func (m *CloudletLocation) Reset()         { *m = CloudletLocation{} }
 func (m *CloudletLocation) String() string { return proto.CompactTextString(m) }
 func (*CloudletLocation) ProtoMessage()    {}
 func (*CloudletLocation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{11}
+	return fileDescriptor_bb90079a337be67f, []int{12}
 }
 func (m *CloudletLocation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1093,17 +1136,17 @@ type AppInstListReply struct {
 	Status    AppInstListReply_AIStatus `protobuf:"varint,2,opt,name=status,proto3,enum=distributed_match_engine.AppInstListReply_AIStatus" json:"status,omitempty"`
 	Cloudlets []*CloudletLocation       `protobuf:"bytes,3,rep,name=cloudlets,proto3" json:"cloudlets,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *AppInstListReply) Reset()         { *m = AppInstListReply{} }
 func (m *AppInstListReply) String() string { return proto.CompactTextString(m) }
 func (*AppInstListReply) ProtoMessage()    {}
 func (*AppInstListReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{12}
+	return fileDescriptor_bb90079a337be67f, []int{13}
 }
 func (m *AppInstListReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1143,17 +1186,17 @@ type FqdnListRequest struct {
 	// _(optional)_ Cell id where the client is
 	CellId uint32 `protobuf:"varint,3,opt,name=cell_id,json=cellId,proto3" json:"cell_id,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *FqdnListRequest) Reset()         { *m = FqdnListRequest{} }
 func (m *FqdnListRequest) String() string { return proto.CompactTextString(m) }
 func (*FqdnListRequest) ProtoMessage()    {}
 func (*FqdnListRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{13}
+	return fileDescriptor_bb90079a337be67f, []int{14}
 }
 func (m *FqdnListRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1202,7 +1245,7 @@ func (m *AppFqdn) Reset()         { *m = AppFqdn{} }
 func (m *AppFqdn) String() string { return proto.CompactTextString(m) }
 func (*AppFqdn) ProtoMessage()    {}
 func (*AppFqdn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{14}
+	return fileDescriptor_bb90079a337be67f, []int{15}
 }
 func (m *AppFqdn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1240,17 +1283,17 @@ type FqdnListReply struct {
 	AppFqdns []*AppFqdn             `protobuf:"bytes,3,rep,name=app_fqdns,json=appFqdns,proto3" json:"app_fqdns,omitempty"`
 	Status   FqdnListReply_FLStatus `protobuf:"varint,4,opt,name=status,proto3,enum=distributed_match_engine.FqdnListReply_FLStatus" json:"status,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *FqdnListReply) Reset()         { *m = FqdnListReply{} }
 func (m *FqdnListReply) String() string { return proto.CompactTextString(m) }
 func (*FqdnListReply) ProtoMessage()    {}
 func (*FqdnListReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{15}
+	return fileDescriptor_bb90079a337be67f, []int{16}
 }
 func (m *FqdnListReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1290,17 +1333,17 @@ type AppOfficialFqdnRequest struct {
 	// The GPS location of the user
 	GpsLocation *Loc `protobuf:"bytes,3,opt,name=gps_location,json=gpsLocation,proto3" json:"gps_location,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *AppOfficialFqdnRequest) Reset()         { *m = AppOfficialFqdnRequest{} }
 func (m *AppOfficialFqdnRequest) String() string { return proto.CompactTextString(m) }
 func (*AppOfficialFqdnRequest) ProtoMessage()    {}
 func (*AppOfficialFqdnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{16}
+	return fileDescriptor_bb90079a337be67f, []int{17}
 }
 func (m *AppOfficialFqdnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1344,17 +1387,17 @@ type AppOfficialFqdnReply struct {
 	// List of Service Endpoints for AppInst
 	Ports []*AppPort `protobuf:"bytes,5,rep,name=ports,proto3" json:"ports,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *AppOfficialFqdnReply) Reset()         { *m = AppOfficialFqdnReply{} }
 func (m *AppOfficialFqdnReply) String() string { return proto.CompactTextString(m) }
 func (*AppOfficialFqdnReply) ProtoMessage()    {}
 func (*AppOfficialFqdnReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{17}
+	return fileDescriptor_bb90079a337be67f, []int{18}
 }
 func (m *AppOfficialFqdnReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1399,17 +1442,17 @@ type DynamicLocGroupRequest struct {
 	// _(optional)_ Cell id where the client is
 	CellId uint32 `protobuf:"varint,13,opt,name=cell_id,json=cellId,proto3" json:"cell_id,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *DynamicLocGroupRequest) Reset()         { *m = DynamicLocGroupRequest{} }
 func (m *DynamicLocGroupRequest) String() string { return proto.CompactTextString(m) }
 func (*DynamicLocGroupRequest) ProtoMessage()    {}
 func (*DynamicLocGroupRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{18}
+	return fileDescriptor_bb90079a337be67f, []int{19}
 }
 func (m *DynamicLocGroupRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1451,17 +1494,17 @@ type DynamicLocGroupReply struct {
 	// Group Cookie for Secure Group Communication
 	GroupCookie string `protobuf:"bytes,5,opt,name=group_cookie,json=groupCookie,proto3" json:"group_cookie,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *DynamicLocGroupReply) Reset()         { *m = DynamicLocGroupReply{} }
 func (m *DynamicLocGroupReply) String() string { return proto.CompactTextString(m) }
 func (*DynamicLocGroupReply) ProtoMessage()    {}
 func (*DynamicLocGroupReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{19}
+	return fileDescriptor_bb90079a337be67f, []int{20}
 }
 func (m *DynamicLocGroupReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1504,7 +1547,7 @@ func (m *QosPosition) Reset()         { *m = QosPosition{} }
 func (m *QosPosition) String() string { return proto.CompactTextString(m) }
 func (*QosPosition) ProtoMessage()    {}
 func (*QosPosition) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{20}
+	return fileDescriptor_bb90079a337be67f, []int{21}
 }
 func (m *QosPosition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1549,7 +1592,7 @@ func (m *BandSelection) Reset()         { *m = BandSelection{} }
 func (m *BandSelection) String() string { return proto.CompactTextString(m) }
 func (*BandSelection) ProtoMessage()    {}
 func (*BandSelection) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{21}
+	return fileDescriptor_bb90079a337be67f, []int{22}
 }
 func (m *BandSelection) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1596,17 +1639,17 @@ type QosPositionRequest struct {
 	// _(optional)_ Cell id where the client is
 	CellId uint32 `protobuf:"varint,6,opt,name=cell_id,json=cellId,proto3" json:"cell_id,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *QosPositionRequest) Reset()         { *m = QosPositionRequest{} }
 func (m *QosPositionRequest) String() string { return proto.CompactTextString(m) }
 func (*QosPositionRequest) ProtoMessage()    {}
 func (*QosPositionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{22}
+	return fileDescriptor_bb90079a337be67f, []int{23}
 }
 func (m *QosPositionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1659,7 +1702,7 @@ func (m *QosPositionKpiResult) Reset()         { *m = QosPositionKpiResult{} }
 func (m *QosPositionKpiResult) String() string { return proto.CompactTextString(m) }
 func (*QosPositionKpiResult) ProtoMessage()    {}
 func (*QosPositionKpiResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{23}
+	return fileDescriptor_bb90079a337be67f, []int{24}
 }
 func (m *QosPositionKpiResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1699,17 +1742,17 @@ type QosPositionKpiReply struct {
 	// kpi details
 	PositionResults []*QosPositionKpiResult `protobuf:"bytes,3,rep,name=position_results,json=positionResults,proto3" json:"position_results,omitempty"`
 	// _(optional)_ Vendor specific data
-	Tags                 map[string]string `protobuf:"bytes,100,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	Tags                 []*Tag   `protobuf:"bytes,99,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *QosPositionKpiReply) Reset()         { *m = QosPositionKpiReply{} }
 func (m *QosPositionKpiReply) String() string { return proto.CompactTextString(m) }
 func (*QosPositionKpiReply) ProtoMessage()    {}
 func (*QosPositionKpiReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bb90079a337be67f, []int{24}
+	return fileDescriptor_bb90079a337be67f, []int{25}
 }
 func (m *QosPositionKpiReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1749,216 +1792,188 @@ func init() {
 	proto.RegisterEnum("distributed_match_engine.FqdnListReply_FLStatus", FqdnListReply_FLStatus_name, FqdnListReply_FLStatus_value)
 	proto.RegisterEnum("distributed_match_engine.AppOfficialFqdnReply_AOFStatus", AppOfficialFqdnReply_AOFStatus_name, AppOfficialFqdnReply_AOFStatus_value)
 	proto.RegisterEnum("distributed_match_engine.DynamicLocGroupRequest_DlgCommType", DynamicLocGroupRequest_DlgCommType_name, DynamicLocGroupRequest_DlgCommType_value)
+	proto.RegisterType((*Tag)(nil), "distributed_match_engine.Tag")
 	proto.RegisterType((*RegisterClientRequest)(nil), "distributed_match_engine.RegisterClientRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.RegisterClientRequest.TagsEntry")
 	proto.RegisterType((*RegisterClientReply)(nil), "distributed_match_engine.RegisterClientReply")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.RegisterClientReply.TagsEntry")
 	proto.RegisterType((*FindCloudletRequest)(nil), "distributed_match_engine.FindCloudletRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.FindCloudletRequest.TagsEntry")
 	proto.RegisterType((*PlatformFindCloudletRequest)(nil), "distributed_match_engine.PlatformFindCloudletRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.PlatformFindCloudletRequest.TagsEntry")
 	proto.RegisterType((*FindCloudletReply)(nil), "distributed_match_engine.FindCloudletReply")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.FindCloudletReply.TagsEntry")
 	proto.RegisterType((*VerifyLocationRequest)(nil), "distributed_match_engine.VerifyLocationRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.VerifyLocationRequest.TagsEntry")
 	proto.RegisterType((*VerifyLocationReply)(nil), "distributed_match_engine.VerifyLocationReply")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.VerifyLocationReply.TagsEntry")
 	proto.RegisterType((*GetLocationRequest)(nil), "distributed_match_engine.GetLocationRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.GetLocationRequest.TagsEntry")
 	proto.RegisterType((*GetLocationReply)(nil), "distributed_match_engine.GetLocationReply")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.GetLocationReply.TagsEntry")
 	proto.RegisterType((*AppInstListRequest)(nil), "distributed_match_engine.AppInstListRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.AppInstListRequest.TagsEntry")
 	proto.RegisterType((*Appinstance)(nil), "distributed_match_engine.Appinstance")
 	proto.RegisterType((*CloudletLocation)(nil), "distributed_match_engine.CloudletLocation")
 	proto.RegisterType((*AppInstListReply)(nil), "distributed_match_engine.AppInstListReply")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.AppInstListReply.TagsEntry")
 	proto.RegisterType((*FqdnListRequest)(nil), "distributed_match_engine.FqdnListRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.FqdnListRequest.TagsEntry")
 	proto.RegisterType((*AppFqdn)(nil), "distributed_match_engine.AppFqdn")
 	proto.RegisterType((*FqdnListReply)(nil), "distributed_match_engine.FqdnListReply")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.FqdnListReply.TagsEntry")
 	proto.RegisterType((*AppOfficialFqdnRequest)(nil), "distributed_match_engine.AppOfficialFqdnRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.AppOfficialFqdnRequest.TagsEntry")
 	proto.RegisterType((*AppOfficialFqdnReply)(nil), "distributed_match_engine.AppOfficialFqdnReply")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.AppOfficialFqdnReply.TagsEntry")
 	proto.RegisterType((*DynamicLocGroupRequest)(nil), "distributed_match_engine.DynamicLocGroupRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.DynamicLocGroupRequest.TagsEntry")
 	proto.RegisterType((*DynamicLocGroupReply)(nil), "distributed_match_engine.DynamicLocGroupReply")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.DynamicLocGroupReply.TagsEntry")
 	proto.RegisterType((*QosPosition)(nil), "distributed_match_engine.QosPosition")
 	proto.RegisterType((*BandSelection)(nil), "distributed_match_engine.BandSelection")
 	proto.RegisterType((*QosPositionRequest)(nil), "distributed_match_engine.QosPositionRequest")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.QosPositionRequest.TagsEntry")
 	proto.RegisterType((*QosPositionKpiResult)(nil), "distributed_match_engine.QosPositionKpiResult")
 	proto.RegisterType((*QosPositionKpiReply)(nil), "distributed_match_engine.QosPositionKpiReply")
-	proto.RegisterMapType((map[string]string)(nil), "distributed_match_engine.QosPositionKpiReply.TagsEntry")
 }
 
 func init() { proto.RegisterFile("app-client.proto", fileDescriptor_bb90079a337be67f) }
 
 var fileDescriptor_bb90079a337be67f = []byte{
-	// 2545 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x5a, 0xcf, 0x6f, 0xdb, 0xc8,
-	0xf5, 0x5f, 0x52, 0x92, 0x6d, 0x3d, 0xd9, 0x32, 0x3d, 0xb6, 0xb3, 0x5a, 0x65, 0xed, 0xaf, 0x97,
-	0xbb, 0xc1, 0xe6, 0xeb, 0x36, 0x4e, 0xe2, 0x24, 0xcd, 0x6e, 0xba, 0xd9, 0xad, 0x56, 0x3f, 0x6c,
-	0x6e, 0x64, 0xc9, 0xa5, 0xe4, 0x04, 0x29, 0x0a, 0x10, 0x0c, 0x39, 0x66, 0x08, 0x53, 0x24, 0x43,
-	0x52, 0xde, 0xe8, 0x50, 0xa0, 0xe8, 0x1e, 0x8a, 0x3d, 0xb4, 0x45, 0xd1, 0x5e, 0x0a, 0x14, 0x68,
-	0xd1, 0xde, 0xda, 0x4b, 0x2f, 0x05, 0x7a, 0xec, 0xad, 0x39, 0x16, 0x2d, 0x7a, 0x6f, 0x83, 0x76,
-	0xfb, 0x37, 0xf4, 0x56, 0xcc, 0x90, 0x94, 0x49, 0x8a, 0x56, 0xa5, 0x8d, 0xb2, 0xc0, 0xde, 0x38,
-	0x6f, 0x7e, 0xbc, 0x37, 0x9f, 0xf7, 0x6b, 0xe6, 0x0d, 0x81, 0x93, 0x6d, 0xfb, 0x8a, 0x62, 0xe8,
-	0xd8, 0xf4, 0x76, 0x6c, 0xc7, 0xf2, 0x2c, 0x54, 0x52, 0x75, 0xd7, 0x73, 0xf4, 0x47, 0x7d, 0x0f,
-	0xab, 0x52, 0x4f, 0xf6, 0x94, 0xc7, 0x12, 0x36, 0x35, 0xdd, 0xc4, 0xe5, 0xd7, 0x35, 0xcb, 0xd2,
-	0x0c, 0x7c, 0x55, 0xb6, 0xf5, 0xab, 0xb2, 0x69, 0x5a, 0x9e, 0xec, 0xe9, 0x96, 0xe9, 0xfa, 0xf3,
-	0xca, 0x79, 0xc3, 0x52, 0x82, 0xcf, 0x65, 0xd9, 0xb6, 0x15, 0xab, 0xd7, 0xb3, 0x4c, 0x9f, 0xc0,
-	0xff, 0x32, 0x03, 0xeb, 0x22, 0xd6, 0x74, 0xd7, 0xc3, 0x4e, 0x95, 0x32, 0x13, 0xf1, 0x93, 0x3e,
-	0x76, 0x3d, 0xc4, 0x41, 0xe6, 0x14, 0x3b, 0x25, 0x66, 0x8b, 0xb9, 0xbc, 0x24, 0x92, 0x4f, 0xf4,
-	0x1a, 0x2c, 0x58, 0x8e, 0x26, 0x99, 0x72, 0x0f, 0x97, 0xd8, 0x2d, 0xe6, 0x72, 0x5e, 0x9c, 0xb7,
-	0x1c, 0xad, 0x25, 0xf7, 0x30, 0xe9, 0x92, 0x6d, 0xdb, 0xef, 0xca, 0xf8, 0x5d, 0xb2, 0x6d, 0x47,
-	0xbb, 0x4e, 0xb1, 0xe3, 0x96, 0xb2, 0xc3, 0xae, 0xfb, 0xd8, 0x71, 0xd1, 0x1b, 0xb0, 0xa8, 0xc8,
-	0x8e, 0xa3, 0x63, 0xc7, 0x9f, 0x99, 0xa3, 0xdd, 0x85, 0x80, 0x46, 0x67, 0x6f, 0x00, 0xc8, 0x7d,
-	0xef, 0xb1, 0xe4, 0x59, 0x27, 0xd8, 0x2c, 0xcd, 0xd1, 0x01, 0x79, 0x42, 0xe9, 0x12, 0x02, 0x7a,
-	0x15, 0xe6, 0x15, 0x6c, 0x18, 0x92, 0xae, 0x96, 0xe6, 0xa9, 0xa0, 0x73, 0xa4, 0x29, 0xa8, 0xe8,
-	0x2d, 0x28, 0xf6, 0x4d, 0xfd, 0x49, 0x1f, 0x4b, 0xba, 0x2a, 0x79, 0x03, 0x1b, 0x97, 0x16, 0xe8,
-	0xdc, 0x45, 0x9f, 0x2a, 0xa8, 0xdd, 0x81, 0x8d, 0xd1, 0x45, 0xc8, 0x0f, 0x47, 0x95, 0xf2, 0x74,
-	0xc0, 0x42, 0x38, 0x00, 0x1d, 0x40, 0xd6, 0x93, 0x35, 0xb7, 0xa4, 0x6e, 0x65, 0x2e, 0x17, 0x76,
-	0xdf, 0xdd, 0x39, 0x0f, 0xfd, 0x9d, 0x54, 0xfc, 0x76, 0xba, 0xb2, 0xe6, 0xd6, 0x4d, 0xcf, 0x19,
-	0x88, 0x74, 0x99, 0xf2, 0x6d, 0xc8, 0x0f, 0x49, 0x04, 0xdc, 0x13, 0x3c, 0xa0, 0xe0, 0xe6, 0x45,
-	0xf2, 0x89, 0xd6, 0x20, 0x77, 0x2a, 0x1b, 0xfd, 0x10, 0x59, 0xbf, 0x71, 0x87, 0x7d, 0x87, 0xe1,
-	0xbf, 0x9b, 0x81, 0xd5, 0x24, 0x0b, 0xdb, 0x18, 0xa4, 0x28, 0xe8, 0x2e, 0xcc, 0xb9, 0x9e, 0xec,
-	0xf5, 0x5d, 0xba, 0x48, 0x71, 0xf7, 0xd2, 0x38, 0x99, 0x6d, 0x63, 0xd0, 0xa1, 0x83, 0xc5, 0x60,
-	0x12, 0xba, 0x04, 0x45, 0x17, 0xbb, 0xae, 0x6e, 0x99, 0x92, 0x62, 0x59, 0x27, 0x7a, 0xa8, 0xca,
-	0xa5, 0x80, 0x5a, 0xa5, 0x44, 0x74, 0x19, 0x38, 0xaa, 0x0d, 0xc9, 0xc5, 0xce, 0x29, 0x76, 0xa4,
-	0xbe, 0xa3, 0x07, 0x8a, 0x2d, 0x52, 0x7a, 0x87, 0x92, 0x8f, 0x1c, 0x3d, 0x45, 0x09, 0xb9, 0xff,
-	0xa5, 0x84, 0xb9, 0x84, 0x12, 0xee, 0xc5, 0x94, 0x70, 0x7b, 0x72, 0x25, 0xd8, 0xc6, 0x60, 0x76,
-	0x2a, 0xf8, 0x0b, 0x0b, 0xab, 0x0d, 0xdd, 0x54, 0xab, 0x86, 0xd5, 0x57, 0x0d, 0x3c, 0xc6, 0x47,
-	0x46, 0x31, 0x64, 0xd3, 0x30, 0x4c, 0x5a, 0x7e, 0x66, 0xd4, 0xf2, 0xbf, 0x01, 0x8b, 0x9a, 0xed,
-	0x4a, 0x86, 0xa5, 0x50, 0x67, 0xa6, 0x10, 0x17, 0x76, 0x37, 0xce, 0x47, 0xa0, 0x69, 0x29, 0x62,
-	0x41, 0xb3, 0xdd, 0x66, 0x30, 0x23, 0xea, 0x1c, 0x0b, 0x31, 0xe7, 0x98, 0x18, 0xd4, 0x94, 0x3d,
-	0xcf, 0x0e, 0xd4, 0xdf, 0xb0, 0x70, 0xf1, 0xd0, 0x90, 0xbd, 0x63, 0xcb, 0xe9, 0x7d, 0xd1, 0xe0,
-	0x92, 0x21, 0xd4, 0x50, 0x82, 0xc0, 0x92, 0x0d, 0x86, 0x50, 0x9a, 0x1f, 0x5a, 0x3a, 0x31, 0x90,
-	0x3e, 0x38, 0x1f, 0xa4, 0x31, 0x7b, 0x98, 0x1d, 0x58, 0x7f, 0xcb, 0xc0, 0x4a, 0x9c, 0x41, 0x7a,
-	0x08, 0x68, 0x25, 0x42, 0xc0, 0xd7, 0x26, 0x55, 0x2e, 0xf1, 0x17, 0x42, 0x49, 0xc4, 0x04, 0x04,
-	0xd9, 0xe3, 0x27, 0xaa, 0x19, 0x60, 0x48, 0xbf, 0xd1, 0x6d, 0xc8, 0xd9, 0x96, 0xe3, 0x91, 0x70,
-	0x4e, 0xa0, 0x79, 0xe3, 0x7c, 0x16, 0x15, 0xdb, 0x3e, 0xb4, 0x1c, 0x4f, 0xf4, 0xc7, 0xa3, 0x8f,
-	0x60, 0x45, 0x09, 0x18, 0x9e, 0xd9, 0x75, 0x6e, 0x12, 0xbb, 0xe6, 0xc2, 0x79, 0x43, 0xe3, 0x16,
-	0x62, 0xea, 0xb9, 0x35, 0xcd, 0x36, 0x67, 0xa6, 0x94, 0x0a, 0xc0, 0x19, 0x64, 0x88, 0x83, 0xc5,
-	0x86, 0xd0, 0xaa, 0x49, 0x47, 0xad, 0x7b, 0xad, 0xf6, 0x83, 0x16, 0xf7, 0x0a, 0x2a, 0x02, 0x50,
-	0x4a, 0xa3, 0x7d, 0xd4, 0xaa, 0x71, 0x0c, 0x5a, 0x81, 0x25, 0xda, 0x6e, 0xb5, 0xbb, 0x3e, 0x89,
-	0x25, 0xc1, 0x7d, 0xfd, 0x3e, 0x76, 0xf4, 0xe3, 0x41, 0xb8, 0xb3, 0x2f, 0x47, 0x6c, 0xb9, 0x0c,
-	0xdc, 0x29, 0x15, 0x9b, 0x2c, 0x12, 0x38, 0x91, 0x1f, 0xdc, 0x8b, 0xa7, 0xe1, 0x76, 0x46, 0x52,
-	0xf4, 0x5c, 0x2c, 0x0a, 0x4d, 0x9c, 0x5f, 0x53, 0xf1, 0x99, 0x9d, 0x16, 0x3f, 0x9d, 0x83, 0xd5,
-	0x24, 0x8b, 0x74, 0xe7, 0xfa, 0x36, 0x2c, 0x7a, 0xd6, 0xc7, 0xd8, 0x91, 0x62, 0x2e, 0x36, 0x85,
-	0xe4, 0xd4, 0xfa, 0xc8, 0x0a, 0x81, 0x97, 0x15, 0xbc, 0xb3, 0x06, 0xb2, 0x60, 0x35, 0xaa, 0x94,
-	0x90, 0x49, 0x86, 0x32, 0xf9, 0x60, 0x3a, 0x26, 0x7b, 0x87, 0x9d, 0x90, 0x10, 0xb0, 0x5a, 0x89,
-	0x68, 0x2f, 0x60, 0x78, 0x1b, 0x4a, 0x31, 0x86, 0xb2, 0xa2, 0xf4, 0x1d, 0x59, 0x19, 0x48, 0x27,
-	0x3d, 0x6a, 0x11, 0x8c, 0xb8, 0x1e, 0x99, 0x54, 0x09, 0x7a, 0xef, 0xf5, 0x26, 0xcf, 0x1f, 0xa9,
-	0xfb, 0x9f, 0x95, 0xde, 0x1e, 0x43, 0x21, 0x82, 0x25, 0x71, 0xae, 0x6e, 0xfb, 0x41, 0x5d, 0x8c,
-	0xf8, 0xdf, 0x16, 0xbc, 0x5e, 0x6d, 0xb7, 0x5a, 0xf5, 0x6a, 0xb7, 0x5e, 0x93, 0xba, 0x6d, 0xa9,
-	0x73, 0x58, 0xaf, 0x0a, 0x0d, 0x81, 0x36, 0x1e, 0xd4, 0x45, 0x8e, 0x41, 0x6f, 0xc1, 0x56, 0xab,
-	0xdd, 0x95, 0xc6, 0x8e, 0x62, 0xf9, 0x7f, 0x33, 0xb0, 0x32, 0x82, 0x28, 0x5a, 0x86, 0x42, 0xb3,
-	0x5d, 0x8d, 0xb0, 0xe3, 0x60, 0x91, 0x10, 0xee, 0xd7, 0x45, 0x3a, 0x9d, 0x63, 0xd0, 0x06, 0xbc,
-	0x46, 0x28, 0x07, 0x42, 0xe7, 0xa0, 0xd2, 0xad, 0xee, 0x4b, 0x9d, 0xca, 0x41, 0x5d, 0xaa, 0xb6,
-	0x8f, 0x5a, 0x5d, 0xf1, 0x21, 0xc7, 0xa2, 0x4d, 0x28, 0xc7, 0xba, 0xdb, 0xdd, 0xfd, 0xba, 0x38,
-	0xec, 0xcf, 0x84, 0xd3, 0xc5, 0x76, 0xe5, 0x40, 0x68, 0xed, 0x85, 0x1d, 0x12, 0x1d, 0xcc, 0x65,
-	0xc9, 0xf6, 0x52, 0xbb, 0x83, 0xe5, 0xb8, 0x1c, 0x2a, 0xc3, 0x05, 0x32, 0xa2, 0x2e, 0x8a, 0x6d,
-	0x82, 0x4b, 0xe5, 0xa8, 0xbb, 0xdf, 0x16, 0x85, 0x6f, 0xd5, 0x6b, 0xdc, 0x1c, 0x5a, 0x85, 0xe5,
-	0xb3, 0x3e, 0xca, 0x99, 0x9b, 0xe7, 0x7f, 0xc8, 0x02, 0xda, 0x3b, 0x8b, 0xb2, 0x5f, 0x44, 0x2c,
-	0x8a, 0xc4, 0x87, 0x6c, 0x2c, 0x3e, 0x7c, 0x14, 0xb3, 0xb2, 0x31, 0x89, 0x6c, 0x54, 0xe0, 0xd9,
-	0x19, 0xd9, 0xef, 0x33, 0xc0, 0xc5, 0xd6, 0x4f, 0x8f, 0x0c, 0xcd, 0x44, 0xda, 0xbd, 0x39, 0xa1,
-	0xb4, 0xc4, 0x21, 0x9a, 0x96, 0x92, 0x48, 0xba, 0x13, 0xa0, 0xb6, 0x06, 0x39, 0x1a, 0x3b, 0x28,
-	0x66, 0x59, 0xd1, 0x6f, 0xa0, 0x7d, 0xe0, 0x4c, 0xec, 0x7d, 0x6c, 0x39, 0x27, 0x53, 0xe6, 0xd7,
-	0xe5, 0x60, 0xda, 0x30, 0xbe, 0xef, 0xc7, 0xc0, 0x9f, 0x66, 0x3b, 0x33, 0x83, 0xfe, 0xeb, 0x90,
-	0x1f, 0x42, 0x33, 0xea, 0x6c, 0x4b, 0x90, 0x27, 0x84, 0x30, 0xb5, 0x16, 0x01, 0x48, 0xb3, 0x56,
-	0x6f, 0x11, 0xcf, 0x63, 0xf9, 0xcf, 0x58, 0x40, 0x15, 0xdb, 0x16, 0x4c, 0xd7, 0x6b, 0xea, 0xee,
-	0x97, 0xef, 0xc0, 0x9e, 0x8b, 0xb9, 0xc2, 0x1a, 0xe4, 0x0c, 0xbd, 0xa7, 0x7b, 0x41, 0x06, 0xf5,
-	0x1b, 0x93, 0x3b, 0xc8, 0x28, 0x10, 0xb3, 0xd3, 0xd2, 0x6f, 0x19, 0x28, 0x54, 0x6c, 0x5b, 0x37,
-	0x5d, 0x4f, 0x36, 0x95, 0x78, 0x25, 0x80, 0x39, 0xbf, 0x12, 0xc0, 0xc6, 0x2b, 0x01, 0x33, 0x3d,
-	0x66, 0x46, 0xeb, 0x14, 0xb9, 0x58, 0x9d, 0x82, 0xff, 0x84, 0x05, 0xae, 0x9a, 0x3c, 0x4a, 0x26,
-	0x75, 0xcb, 0x8c, 0xea, 0xf6, 0x4d, 0x58, 0x1a, 0x9e, 0x5c, 0x23, 0xf5, 0x8f, 0xc5, 0x90, 0x98,
-	0x6a, 0x00, 0x99, 0xa9, 0x0d, 0xa0, 0x0c, 0x0b, 0x64, 0x30, 0x01, 0x32, 0xc8, 0xc0, 0xc3, 0x36,
-	0x12, 0x60, 0x51, 0x3e, 0xc3, 0xd9, 0x2d, 0xe5, 0x28, 0x2a, 0x97, 0xc6, 0xa2, 0x12, 0x8e, 0x16,
-	0x63, 0x53, 0xf9, 0xff, 0xb0, 0xc0, 0xc5, 0x6c, 0x22, 0x3d, 0xa8, 0xdd, 0x4b, 0x04, 0xb5, 0x1b,
-	0x13, 0x5a, 0x18, 0x89, 0x02, 0x15, 0x21, 0x11, 0xd3, 0xf6, 0x21, 0x1f, 0x82, 0x45, 0xce, 0x34,
-	0x44, 0xf6, 0xed, 0xf3, 0xd7, 0x4b, 0xea, 0x48, 0x3c, 0x9b, 0x3c, 0x79, 0x68, 0x1a, 0x11, 0x6a,
-	0x66, 0x46, 0xff, 0x2e, 0x2c, 0x84, 0x1b, 0x24, 0x59, 0xbf, 0x22, 0x48, 0x47, 0xad, 0x5a, 0xbd,
-	0x21, 0xb4, 0xea, 0x35, 0xff, 0xd8, 0x5f, 0x11, 0xa4, 0xce, 0x51, 0xb5, 0x5a, 0xef, 0x74, 0x38,
-	0x06, 0x15, 0x60, 0xbe, 0x22, 0x48, 0x8d, 0x8a, 0xd0, 0xe4, 0x58, 0xfe, 0x5f, 0x0c, 0x2c, 0x37,
-	0x9e, 0xa8, 0xe6, 0x4c, 0xa2, 0x52, 0x24, 0x60, 0x64, 0x62, 0x01, 0x63, 0x2f, 0x86, 0xd1, 0x18,
-	0xc5, 0x25, 0x44, 0x99, 0x1d, 0x44, 0xbf, 0x62, 0x60, 0xbe, 0x62, 0xdb, 0x64, 0xfd, 0xcf, 0x19,
-	0x13, 0xa2, 0x6e, 0x9c, 0x89, 0x97, 0x1b, 0xd7, 0x20, 0x47, 0x42, 0x84, 0x1f, 0x1a, 0xf2, 0xa2,
-	0xdf, 0x40, 0xd7, 0x60, 0x4d, 0x36, 0x55, 0xc7, 0xd2, 0x55, 0xc9, 0x96, 0x95, 0x13, 0x59, 0xc3,
-	0xd1, 0x18, 0x80, 0x82, 0xbe, 0x43, 0xbf, 0x8b, 0x86, 0x83, 0xcf, 0x58, 0x58, 0x3a, 0x43, 0x20,
-	0xdd, 0x0b, 0xde, 0x87, 0x3c, 0x91, 0xd0, 0xe7, 0x97, 0x99, 0x20, 0x14, 0x91, 0x05, 0x45, 0xb2,
-	0xab, 0x06, 0x95, 0x6a, 0x7f, 0xe8, 0x45, 0x59, 0xea, 0x45, 0xd7, 0x26, 0x51, 0x06, 0xbd, 0x8d,
-	0x37, 0x13, 0x2e, 0x54, 0x8f, 0x29, 0xf5, 0xfa, 0xa4, 0xeb, 0xcc, 0xd2, 0xea, 0x43, 0x99, 0xe8,
-	0x65, 0xb7, 0x99, 0xb4, 0xfa, 0x46, 0x33, 0x6e, 0xf5, 0x8d, 0x66, 0x68, 0xf5, 0x3f, 0x67, 0xe1,
-	0x42, 0xc5, 0xb6, 0xdb, 0xc7, 0xc7, 0xba, 0xa2, 0xcb, 0x06, 0x85, 0xe8, 0x45, 0x8d, 0xff, 0xc5,
-	0xc3, 0x6d, 0x2b, 0x06, 0xe8, 0x9d, 0xb1, 0x5a, 0x4d, 0x11, 0x7d, 0x76, 0xc8, 0x3e, 0xcb, 0xc0,
-	0xda, 0x08, 0x8f, 0x74, 0x73, 0xdc, 0x86, 0x15, 0x62, 0x8e, 0x56, 0x30, 0x94, 0xda, 0x65, 0xb0,
-	0xe0, 0xb2, 0x1c, 0x5f, 0x62, 0xa4, 0xca, 0x95, 0x19, 0xad, 0x72, 0x1d, 0x26, 0xac, 0xf3, 0x9d,
-	0x29, 0x40, 0xa0, 0x71, 0xbe, 0xdd, 0x48, 0x58, 0xe9, 0x30, 0x6d, 0xe7, 0xa6, 0x4c, 0xdb, 0xcd,
-	0x98, 0x36, 0xa6, 0x15, 0x64, 0x66, 0xba, 0xb8, 0x0b, 0xf9, 0xe1, 0xa6, 0xc8, 0xa5, 0xb2, 0xd2,
-	0x6e, 0xc4, 0xec, 0x7c, 0x19, 0x0a, 0x84, 0x74, 0x66, 0xe8, 0x8b, 0xb0, 0x40, 0x08, 0x81, 0xa5,
-	0xff, 0x31, 0x03, 0x17, 0x6a, 0x03, 0x53, 0xee, 0xe9, 0x4a, 0xd3, 0x52, 0xf6, 0x1c, 0xab, 0x6f,
-	0xbf, 0xb0, 0xa5, 0xaf, 0x42, 0xce, 0xd0, 0xc2, 0x20, 0x9f, 0x15, 0xb3, 0x86, 0x26, 0xa8, 0xe8,
-	0x21, 0xe4, 0x15, 0xab, 0xd7, 0xf3, 0xeb, 0xea, 0x05, 0xaa, 0xbc, 0xf7, 0xce, 0xc7, 0x2c, 0x5d,
-	0xa4, 0x9d, 0x9a, 0xa1, 0x55, 0xad, 0x5e, 0xaf, 0x3b, 0xb0, 0xb1, 0xb8, 0xa0, 0x04, 0x5f, 0xb4,
-	0x22, 0xef, 0x62, 0x47, 0x52, 0x65, 0x4f, 0x2e, 0x2d, 0x06, 0x15, 0x79, 0x17, 0x3b, 0x35, 0xd9,
-	0x93, 0xa3, 0x39, 0x67, 0x29, 0x96, 0x73, 0x26, 0xf6, 0xa6, 0x73, 0x64, 0x99, 0x99, 0x06, 0xdf,
-	0x87, 0x42, 0x64, 0x5f, 0x44, 0x87, 0xb5, 0xe6, 0x5e, 0x32, 0x56, 0x11, 0x52, 0xa7, 0x5e, 0x3d,
-	0x12, 0xeb, 0xbe, 0x0a, 0x49, 0xbb, 0x7d, 0x58, 0x6f, 0x71, 0x2c, 0xff, 0x3b, 0x16, 0xd6, 0x46,
-	0x64, 0x7c, 0x29, 0x2f, 0x2e, 0x1b, 0x00, 0xd8, 0x71, 0x2c, 0x47, 0x52, 0x2c, 0x15, 0x07, 0x29,
-	0x3c, 0x4f, 0x29, 0x55, 0x4b, 0xa5, 0x97, 0x0e, 0x8d, 0x70, 0x0f, 0x8d, 0x23, 0x78, 0x1f, 0xa3,
-	0xb4, 0xc0, 0x34, 0x26, 0x76, 0x9a, 0xb4, 0x0d, 0xcd, 0x0e, 0x72, 0x0b, 0x0a, 0xdf, 0xb4, 0xdc,
-	0x43, 0xcb, 0xd5, 0x69, 0x60, 0xdd, 0x04, 0xb0, 0x83, 0x6f, 0x5d, 0xa5, 0x2b, 0x64, 0xc4, 0x08,
-	0x65, 0x24, 0x74, 0xb3, 0xd3, 0x86, 0x6e, 0xfe, 0x04, 0x96, 0x3e, 0x94, 0x4d, 0xb5, 0x83, 0x0d,
-	0xac, 0x50, 0x96, 0xeb, 0x30, 0xe7, 0xc8, 0x9e, 0xb4, 0xab, 0x95, 0x18, 0xff, 0x4c, 0xe0, 0xc8,
-	0xde, 0xae, 0x16, 0x92, 0x6f, 0x68, 0x25, 0x76, 0x48, 0xbe, 0x31, 0x24, 0xdf, 0xd4, 0x68, 0x46,
-	0xf7, 0xc9, 0x37, 0x87, 0xe4, 0x5b, 0x5a, 0x78, 0xb0, 0x70, 0x64, 0xef, 0x96, 0xc6, 0xff, 0x3a,
-	0x03, 0x28, 0xb2, 0xbd, 0x17, 0xf6, 0xe7, 0x2a, 0xe4, 0x43, 0x30, 0xc2, 0x23, 0xc5, 0x18, 0xc3,
-	0x89, 0x72, 0x3e, 0x9b, 0x47, 0x8c, 0xc3, 0xf0, 0xb0, 0xa4, 0xc8, 0x1e, 0xd6, 0x2c, 0x67, 0x40,
-	0xe3, 0x77, 0x4e, 0x2c, 0x18, 0x1e, 0xae, 0x06, 0x24, 0xd4, 0x82, 0xe2, 0x23, 0xd9, 0x54, 0x25,
-	0x37, 0x44, 0x29, 0x28, 0x06, 0xbc, 0x7d, 0x3e, 0xb3, 0x18, 0xa8, 0xe2, 0xd2, 0xa3, 0x18, 0xc6,
-	0xe7, 0x96, 0x72, 0x27, 0xbe, 0x89, 0x8e, 0xa2, 0x38, 0x3b, 0x1b, 0xfc, 0x41, 0x16, 0xd6, 0x22,
-	0xeb, 0xdf, 0xb3, 0x75, 0x11, 0xbb, 0x7d, 0xc3, 0x7b, 0xf9, 0xd6, 0x88, 0xae, 0xc3, 0x9a, 0x6a,
-	0x90, 0x08, 0xe9, 0x3d, 0x76, 0xac, 0xbe, 0xf6, 0xd8, 0xee, 0x7b, 0x52, 0x4f, 0xf7, 0x13, 0x2e,
-	0x2b, 0xae, 0x26, 0xfb, 0x0e, 0xf4, 0xf4, 0x29, 0xf2, 0xa9, 0x46, 0xd5, 0x98, 0x32, 0xa5, 0x72,
-	0xaa, 0xa5, 0x73, 0x91, 0x9f, 0x52, 0xa5, 0xa6, 0x71, 0x91, 0x9f, 0x92, 0x29, 0xfd, 0x34, 0xc1,
-	0xe6, 0xfc, 0x29, 0xfd, 0x74, 0xc1, 0xfa, 0x69, 0x82, 0xcd, 0xa7, 0x4f, 0x09, 0x04, 0xeb, 0xa7,
-	0x09, 0xb6, 0x70, 0x0e, 0x17, 0xf9, 0x29, 0xfa, 0x3f, 0x28, 0x18, 0xb2, 0x87, 0x4d, 0x65, 0x40,
-	0xe5, 0xc9, 0xd3, 0x91, 0x10, 0x90, 0x88, 0x18, 0x91, 0x01, 0x84, 0x3b, 0xc4, 0x06, 0x10, 0xa6,
-	0xd1, 0x15, 0xe4, 0xa7, 0x34, 0x03, 0x46, 0x56, 0x90, 0x9f, 0xf2, 0x7f, 0x62, 0x61, 0x35, 0x69,
-	0x0f, 0x2f, 0x25, 0x8a, 0x3f, 0x04, 0x2e, 0xb4, 0x26, 0xc9, 0xa1, 0x26, 0x17, 0x7a, 0xf5, 0xce,
-	0x44, 0x9e, 0x30, 0xb4, 0x54, 0x71, 0xd9, 0x1e, 0x3a, 0x07, 0x5d, 0x66, 0xf2, 0x4a, 0x7b, 0xca,
-	0x46, 0x67, 0xe6, 0x59, 0xdb, 0x77, 0x61, 0x5e, 0xa8, 0x91, 0x5c, 0x4a, 0xcf, 0xfd, 0x42, 0x2d,
-	0x96, 0x4b, 0x17, 0x20, 0x2b, 0x1c, 0xd4, 0x05, 0x8e, 0x41, 0x00, 0x73, 0x07, 0x1d, 0xa1, 0x53,
-	0x6b, 0x71, 0x2c, 0xf9, 0x16, 0x0e, 0x2b, 0xb5, 0x9a, 0xc8, 0x65, 0xb6, 0xdf, 0x83, 0x42, 0x04,
-	0x36, 0xb2, 0x84, 0xd8, 0x49, 0xa6, 0x63, 0xb1, 0x13, 0xbf, 0x3a, 0x88, 0x9d, 0xe0, 0x40, 0xb5,
-	0xfb, 0x87, 0x02, 0x14, 0x0f, 0xc8, 0x56, 0xeb, 0x74, 0xa7, 0x15, 0x5b, 0x47, 0x3f, 0x62, 0xa0,
-	0x18, 0x7f, 0xef, 0x47, 0x57, 0xa7, 0xfc, 0x3d, 0xa3, 0x7c, 0x65, 0xaa, 0x5f, 0x09, 0xf8, 0x8d,
-	0xef, 0xfd, 0xf5, 0x9f, 0x3f, 0x61, 0x5f, 0xe5, 0xd1, 0xd5, 0xd3, 0xeb, 0x57, 0x9d, 0x60, 0x80,
-	0x7f, 0x90, 0xbe, 0xc3, 0x6c, 0xa3, 0xef, 0x33, 0xb0, 0x18, 0x7d, 0x68, 0x44, 0x57, 0xa6, 0x7a,
-	0x54, 0x2f, 0x7f, 0x65, 0x8a, 0xf7, 0x4b, 0xfe, 0x22, 0x95, 0x65, 0x9d, 0xe7, 0x88, 0x2c, 0xc7,
-	0xba, 0xa9, 0x86, 0xb5, 0x11, 0x22, 0xc9, 0x2f, 0x18, 0x58, 0x4b, 0x7b, 0x91, 0x46, 0xb7, 0x3e,
-	0xd7, 0x0b, 0xf6, 0x74, 0x92, 0xbd, 0x49, 0x25, 0xdb, 0xe0, 0x4b, 0x44, 0x32, 0x3b, 0x58, 0x35,
-	0x29, 0x21, 0xd1, 0x5e, 0xfc, 0x61, 0x68, 0x9c, 0xf6, 0x52, 0x1f, 0xff, 0xc6, 0x69, 0x2f, 0xe5,
-	0xcd, 0x29, 0xae, 0x3d, 0xff, 0x7d, 0x32, 0x8c, 0xf6, 0x44, 0xa2, 0x4f, 0x18, 0x28, 0x44, 0xea,
-	0xd8, 0xe8, 0xab, 0xd3, 0xbc, 0x35, 0x94, 0xb7, 0x27, 0x2f, 0x8e, 0xf3, 0x65, 0x2a, 0xc8, 0x1a,
-	0xbf, 0x4c, 0x04, 0xd1, 0xb0, 0x17, 0x95, 0xe2, 0xc7, 0x0c, 0x14, 0x2b, 0xaa, 0x7a, 0xe4, 0x62,
-	0xa7, 0x6b, 0xd1, 0x43, 0x1a, 0xba, 0x36, 0xed, 0x21, 0xba, 0xbc, 0x33, 0xdd, 0x09, 0x30, 0x8e,
-	0x8c, 0xac, 0xaa, 0x34, 0x52, 0x5b, 0xf4, 0x84, 0x49, 0x64, 0xfa, 0x94, 0x81, 0xe2, 0x1e, 0xf6,
-	0x22, 0x95, 0xb4, 0x71, 0xe0, 0x8c, 0xd6, 0x99, 0xc7, 0x81, 0x93, 0x2c, 0xcf, 0xc5, 0x65, 0xd1,
-	0xb0, 0x17, 0xd4, 0x2c, 0x0d, 0xdd, 0xa5, 0x76, 0xf3, 0x1d, 0xaa, 0xa4, 0xb0, 0xb6, 0x81, 0xfe,
-	0x7f, 0xe2, 0xa2, 0x56, 0xf9, 0xed, 0x09, 0x4b, 0x25, 0x23, 0xea, 0x21, 0x97, 0xeb, 0x90, 0xfd,
-	0xcf, 0x18, 0xfa, 0x34, 0x96, 0xb8, 0x7c, 0x8e, 0x53, 0x51, 0x7a, 0xd5, 0x60, 0x9c, 0x8a, 0xd2,
-	0x6e, 0xb6, 0xfc, 0x1b, 0x54, 0xa8, 0x8b, 0xfc, 0x85, 0x33, 0x58, 0xc2, 0xdb, 0x3f, 0x91, 0x8f,
-	0xc8, 0xf6, 0x53, 0x06, 0x56, 0xf6, 0xb0, 0x17, 0x4f, 0x02, 0xe3, 0x34, 0x35, 0x7a, 0x0e, 0x1b,
-	0xe7, 0x52, 0x29, 0xc9, 0x85, 0xdf, 0xa2, 0x52, 0x95, 0xf9, 0xf5, 0x40, 0xaa, 0x27, 0x96, 0x1b,
-	0x26, 0xaf, 0x13, 0x5b, 0xbf, 0xc3, 0x6c, 0x5f, 0x63, 0x3e, 0xe4, 0x9e, 0xfd, 0x63, 0xf3, 0x95,
-	0x67, 0xcf, 0x37, 0x99, 0x3f, 0x3f, 0xdf, 0x64, 0xfe, 0xfe, 0x7c, 0x93, 0x79, 0x34, 0x47, 0xff,
-	0x3a, 0xbc, 0xf1, 0xdf, 0x00, 0x00, 0x00, 0xff, 0xff, 0xef, 0xac, 0x4d, 0xc6, 0xdd, 0x28, 0x00,
-	0x00,
+	// 2393 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x5a, 0x4f, 0x6c, 0xe4, 0x56,
+	0x19, 0xaf, 0x3d, 0x33, 0x49, 0xe6, 0x9b, 0x64, 0xe2, 0xbc, 0x24, 0xdb, 0x69, 0xb6, 0x09, 0x5b,
+	0xb7, 0xab, 0x2e, 0x81, 0xcd, 0xfe, 0xa7, 0xb4, 0x74, 0x0b, 0xd3, 0xf9, 0x93, 0x98, 0x9d, 0xcc,
+	0x04, 0xcf, 0x64, 0x57, 0x8b, 0x90, 0xac, 0xb7, 0xf6, 0x8b, 0xd7, 0x8a, 0xc7, 0xf6, 0xda, 0x9e,
+	0x74, 0x73, 0xe0, 0x42, 0x91, 0x10, 0x07, 0x84, 0x10, 0x15, 0x52, 0x4f, 0x48, 0xdc, 0x50, 0xc5,
+	0x15, 0x71, 0xe0, 0x8c, 0x2a, 0x71, 0x00, 0xc4, 0x95, 0x03, 0xac, 0x40, 0x48, 0x9c, 0x7b, 0x07,
+	0xbd, 0x67, 0x7b, 0x62, 0x7b, 0x3c, 0x43, 0x32, 0xd9, 0xad, 0xd4, 0xdb, 0xbc, 0xef, 0xbd, 0xf7,
+	0x7d, 0xbf, 0xef, 0xff, 0x7b, 0xcf, 0x03, 0x02, 0x76, 0x9c, 0xab, 0xaa, 0x69, 0x10, 0xcb, 0xdf,
+	0x72, 0x5c, 0xdb, 0xb7, 0x51, 0x45, 0x33, 0x3c, 0xdf, 0x35, 0x1e, 0x0d, 0x7c, 0xa2, 0x29, 0x7d,
+	0xec, 0xab, 0x8f, 0x15, 0x62, 0xe9, 0x86, 0x45, 0xd6, 0x5e, 0xd5, 0x6d, 0x5b, 0x37, 0xc9, 0x35,
+	0xec, 0x18, 0xd7, 0xb0, 0x65, 0xd9, 0x3e, 0xf6, 0x0d, 0xdb, 0xf2, 0x82, 0x7d, 0x6b, 0x45, 0xd3,
+	0x56, 0xc3, 0x9f, 0x8b, 0xd8, 0x71, 0x54, 0xbb, 0xdf, 0xb7, 0xad, 0x80, 0x20, 0x5e, 0x85, 0x5c,
+	0x0f, 0xeb, 0x08, 0x41, 0xde, 0x3f, 0x76, 0x48, 0x85, 0xbb, 0xc4, 0x5d, 0x29, 0xca, 0xec, 0x37,
+	0xa5, 0x69, 0xd8, 0xc7, 0x15, 0x3e, 0xa0, 0xd1, 0xdf, 0xe2, 0x1f, 0x79, 0x58, 0x95, 0x89, 0x6e,
+	0x78, 0x3e, 0x71, 0x6b, 0x0c, 0x9b, 0x4c, 0x9e, 0x0c, 0x88, 0xe7, 0x23, 0x01, 0x72, 0x47, 0xc4,
+	0x65, 0x0c, 0x16, 0x64, 0xfa, 0x13, 0xbd, 0x02, 0x73, 0xb6, 0xab, 0x2b, 0x16, 0xee, 0x93, 0x90,
+	0xc7, 0xac, 0xed, 0xea, 0x6d, 0xdc, 0x27, 0x74, 0x0a, 0x3b, 0x4e, 0x30, 0x95, 0x0b, 0xa6, 0xb0,
+	0xe3, 0xc4, 0xa7, 0x8e, 0x88, 0xeb, 0x55, 0xf2, 0xc3, 0xa9, 0xfb, 0xc4, 0xf5, 0xd0, 0x6b, 0x30,
+	0xaf, 0x62, 0xd7, 0x35, 0x88, 0x1b, 0xec, 0x2c, 0xb0, 0xe9, 0x52, 0x48, 0x63, 0xbb, 0xd7, 0x01,
+	0xf0, 0xc0, 0x7f, 0xac, 0xf8, 0xf6, 0x21, 0xb1, 0x2a, 0x33, 0x6c, 0x41, 0x91, 0x52, 0x7a, 0x94,
+	0x80, 0x5e, 0x86, 0x59, 0x95, 0x98, 0xa6, 0x62, 0x68, 0x95, 0x59, 0x06, 0x74, 0x86, 0x0e, 0x25,
+	0x0d, 0xbd, 0x01, 0xe5, 0x81, 0x65, 0x3c, 0x19, 0x10, 0xc5, 0xd0, 0x14, 0x66, 0x89, 0x39, 0xb6,
+	0x77, 0x3e, 0xa0, 0x4a, 0x5a, 0x8f, 0x5a, 0xe4, 0x22, 0x14, 0x87, 0xab, 0x2a, 0x45, 0xb6, 0x60,
+	0x2e, 0x5a, 0x80, 0x6e, 0x40, 0xde, 0xc7, 0xba, 0x57, 0x51, 0x2f, 0xe5, 0xae, 0x94, 0x6e, 0xae,
+	0x6f, 0x8d, 0x73, 0xd6, 0x56, 0x0f, 0xeb, 0x32, 0x5b, 0x2a, 0xfe, 0x86, 0x87, 0xe5, 0xb4, 0x35,
+	0x1d, 0xf3, 0x38, 0xc3, 0x96, 0x77, 0x61, 0xc6, 0xf3, 0xb1, 0x3f, 0xf0, 0x98, 0x25, 0xcb, 0x37,
+	0x2f, 0x8f, 0x67, 0xcf, 0x58, 0x74, 0xd9, 0x62, 0x39, 0xdc, 0x84, 0x2e, 0x43, 0xd9, 0x23, 0x9e,
+	0x67, 0xd8, 0x96, 0xa2, 0xda, 0xf6, 0xa1, 0x11, 0x59, 0x7d, 0x21, 0xa4, 0xd6, 0x18, 0x11, 0x5d,
+	0x01, 0x81, 0x19, 0x4e, 0xf1, 0x88, 0x7b, 0x44, 0x5c, 0x65, 0xe0, 0x1a, 0xa1, 0x0f, 0xca, 0x8c,
+	0xde, 0x65, 0xe4, 0x7d, 0xd7, 0xc8, 0xb0, 0x57, 0xe1, 0xff, 0xd9, 0x6b, 0xe6, 0xfc, 0xf6, 0xfa,
+	0x2f, 0x07, 0xcb, 0x4d, 0xc3, 0xd2, 0x6a, 0xa6, 0x3d, 0xd0, 0x4c, 0x32, 0x21, 0xf6, 0x46, 0x15,
+	0xe6, 0xb3, 0x14, 0x4e, 0x47, 0x54, 0x6e, 0x34, 0xa2, 0xbe, 0x05, 0xf3, 0xba, 0xe3, 0x29, 0xa6,
+	0xad, 0xb2, 0x9c, 0x62, 0xf6, 0x98, 0x08, 0xb7, 0x65, 0xab, 0x72, 0x49, 0x77, 0xbc, 0x56, 0xb8,
+	0x23, 0x1e, 0x74, 0x73, 0x89, 0xa0, 0x9b, 0xc2, 0x02, 0x7f, 0xe2, 0xe0, 0xe2, 0x9e, 0x89, 0xfd,
+	0x03, 0xdb, 0xed, 0x7f, 0xde, 0x96, 0xa0, 0x4b, 0x58, 0x90, 0x86, 0xd9, 0x95, 0x0f, 0x97, 0x30,
+	0x5a, 0x90, 0x5f, 0x53, 0x68, 0xf4, 0xc3, 0x1c, 0x2c, 0x25, 0x35, 0xc9, 0xce, 0x80, 0x76, 0x2a,
+	0x03, 0xbe, 0x36, 0x9e, 0xf9, 0x08, 0x3b, 0x46, 0x49, 0xa5, 0x04, 0x82, 0xfc, 0xc1, 0x13, 0xcd,
+	0x0a, 0x15, 0x65, 0xbf, 0xd1, 0x5b, 0x50, 0x70, 0x6c, 0xd7, 0xa7, 0x85, 0x87, 0xe2, 0x7f, 0x6d,
+	0xbc, 0x88, 0xaa, 0xe3, 0xec, 0xd9, 0xae, 0x2f, 0x07, 0xeb, 0xd1, 0xb7, 0x61, 0x49, 0x0d, 0x05,
+	0x9e, 0x44, 0x4a, 0xe1, 0x34, 0x91, 0x22, 0x44, 0xfb, 0x86, 0xe1, 0x32, 0x85, 0x0d, 0xab, 0x00,
+	0x27, 0x1a, 0x22, 0x01, 0xe6, 0x9b, 0x52, 0xbb, 0xae, 0xec, 0xb7, 0xef, 0xb5, 0x3b, 0x0f, 0xda,
+	0xc2, 0x4b, 0xa8, 0x0c, 0xc0, 0x28, 0xcd, 0xce, 0x7e, 0xbb, 0x2e, 0x70, 0x68, 0x09, 0x16, 0xd8,
+	0xb8, 0xdd, 0xe9, 0x05, 0x24, 0x5e, 0xfc, 0x84, 0x87, 0xd5, 0xfb, 0xc4, 0x35, 0x0e, 0x8e, 0x23,
+	0x20, 0x5f, 0x8c, 0xe4, 0xba, 0x02, 0xc2, 0x11, 0x83, 0x4d, 0x99, 0x84, 0x81, 0x19, 0x94, 0xa2,
+	0xf2, 0x51, 0xa4, 0xce, 0x48, 0xed, 0x9f, 0x39, 0x6f, 0x1a, 0xfe, 0xb6, 0x00, 0xcb, 0x69, 0x6b,
+	0x65, 0x87, 0xed, 0xf7, 0x60, 0xde, 0xb7, 0x3f, 0x20, 0xae, 0x92, 0x08, 0xde, 0xb7, 0xc7, 0x0b,
+	0xc9, 0x60, 0xbb, 0xd5, 0xa3, 0x1c, 0xc2, 0xf8, 0x2d, 0xf9, 0x27, 0x03, 0x64, 0xc3, 0x72, 0xdc,
+	0x7e, 0x91, 0x90, 0x1c, 0x13, 0xf2, 0xcd, 0xb3, 0x09, 0xd9, 0xde, 0xeb, 0x46, 0x84, 0x50, 0xd4,
+	0x52, 0xcc, 0xd0, 0xa1, 0xc0, 0xb7, 0xa0, 0x92, 0x10, 0x88, 0x55, 0x75, 0xe0, 0x62, 0xf5, 0x58,
+	0x39, 0xec, 0x33, 0xe7, 0x71, 0xf2, 0x6a, 0x6c, 0x53, 0x35, 0x9c, 0xbd, 0xd7, 0x9f, 0xc6, 0xc8,
+	0x8f, 0xa1, 0x14, 0x53, 0x9c, 0x06, 0x6d, 0xaf, 0xf3, 0xa0, 0x21, 0xc7, 0xe2, 0xfa, 0x12, 0xbc,
+	0x5a, 0xeb, 0xb4, 0xdb, 0x8d, 0x5a, 0xaf, 0x51, 0x57, 0x7a, 0x1d, 0xa5, 0xbb, 0xd7, 0xa8, 0x49,
+	0x4d, 0x89, 0x0d, 0x1e, 0x34, 0x64, 0x81, 0x43, 0x6f, 0xc0, 0xa5, 0x76, 0xa7, 0xa7, 0x4c, 0x5c,
+	0xc5, 0x8b, 0xff, 0xe6, 0x60, 0x69, 0x44, 0x7d, 0xb4, 0x08, 0xa5, 0x56, 0xa7, 0x16, 0x13, 0x27,
+	0xc0, 0x3c, 0x25, 0xdc, 0x6f, 0xc8, 0x6c, 0xbb, 0xc0, 0xa1, 0x75, 0x78, 0x85, 0x52, 0x76, 0xa5,
+	0xee, 0x6e, 0xb5, 0x57, 0xdb, 0x51, 0xba, 0xd5, 0xdd, 0x86, 0x52, 0xeb, 0xec, 0xb7, 0x7b, 0xf2,
+	0x43, 0x81, 0x47, 0x1b, 0xb0, 0x96, 0x98, 0xee, 0xf4, 0x76, 0x1a, 0xf2, 0x70, 0x3e, 0x17, 0x6d,
+	0x97, 0x3b, 0xd5, 0x5d, 0xa9, 0xbd, 0x1d, 0x4d, 0x28, 0x6c, 0xb1, 0x90, 0xa7, 0xea, 0x65, 0x4e,
+	0x87, 0xec, 0x84, 0x02, 0x5a, 0x83, 0x0b, 0x74, 0x45, 0x43, 0x96, 0x3b, 0xd4, 0x2e, 0xd5, 0xfd,
+	0xde, 0x4e, 0x47, 0x96, 0xbe, 0xdb, 0xa8, 0x0b, 0x33, 0x68, 0x19, 0x16, 0x4f, 0xe6, 0x98, 0x64,
+	0x61, 0x56, 0xfc, 0x3d, 0x07, 0x68, 0xfb, 0xa4, 0xd8, 0x7c, 0x1e, 0x39, 0x1e, 0xcb, 0xbb, 0xfc,
+	0x79, 0xf3, 0xee, 0x5f, 0x3c, 0x08, 0x09, 0xf8, 0xd9, 0x49, 0xd7, 0x4a, 0xf5, 0x8a, 0xdb, 0xe3,
+	0x79, 0xa7, 0xb9, 0xd1, 0x0a, 0x93, 0xea, 0x14, 0xa7, 0xd0, 0x71, 0x05, 0x0a, 0x2c, 0x2d, 0x99,
+	0x86, 0x79, 0x39, 0x18, 0xa0, 0x1d, 0x10, 0x2c, 0xe2, 0x7f, 0x60, 0xbb, 0x87, 0x67, 0x6c, 0x0a,
+	0x8b, 0xe1, 0xb6, 0xf3, 0xf4, 0x84, 0x6f, 0x40, 0x71, 0xa8, 0xca, 0x68, 0x28, 0x2f, 0x40, 0x91,
+	0x12, 0xa2, 0x86, 0x50, 0x06, 0xa0, 0xc3, 0x7a, 0xa3, 0x4d, 0xe3, 0x9a, 0x17, 0x3f, 0xe2, 0x01,
+	0x55, 0x1d, 0x47, 0xb2, 0x3c, 0xbf, 0x65, 0x78, 0x5f, 0xbc, 0x73, 0x56, 0x21, 0x11, 0x68, 0x2b,
+	0x50, 0x30, 0x8d, 0xbe, 0xe1, 0x87, 0x75, 0x3f, 0x18, 0x4c, 0x63, 0xd3, 0x4f, 0x38, 0x28, 0x55,
+	0x1d, 0xc7, 0xb0, 0x3c, 0x1f, 0x5b, 0x6a, 0xf2, 0x1a, 0xc3, 0x8d, 0xbf, 0xc6, 0xf0, 0xc9, 0x6b,
+	0xcc, 0x73, 0x3d, 0x79, 0xc4, 0x2f, 0x59, 0x85, 0xc4, 0x25, 0x4b, 0xfc, 0x90, 0x07, 0xa1, 0x96,
+	0x3e, 0x5d, 0xa4, 0x3d, 0xc1, 0x8d, 0x7a, 0xe2, 0x75, 0x58, 0x18, 0x1e, 0x66, 0x62, 0x97, 0xb7,
+	0xf9, 0x88, 0x98, 0xe9, 0xae, 0xdc, 0x99, 0xdd, 0xb5, 0x06, 0x73, 0x74, 0x31, 0x35, 0x64, 0xd8,
+	0x3a, 0x86, 0x63, 0x24, 0xc1, 0x3c, 0x3e, 0xb1, 0xb3, 0x57, 0x29, 0x30, 0xab, 0x5c, 0x9e, 0x68,
+	0x95, 0x68, 0xb5, 0x9c, 0xd8, 0x2a, 0xfe, 0x9a, 0x07, 0x21, 0x11, 0xca, 0xd9, 0x25, 0xe3, 0x5e,
+	0xaa, 0x64, 0xdc, 0x9a, 0x28, 0x2b, 0xc1, 0x6d, 0xab, 0x2a, 0xa5, 0x2a, 0xc6, 0x0e, 0x14, 0x23,
+	0x63, 0xd1, 0x66, 0x4c, 0xb1, 0x6f, 0x8e, 0xe7, 0x97, 0xf6, 0x91, 0x7c, 0xb2, 0x79, 0x9a, 0x20,
+	0x7d, 0x1b, 0xe6, 0x22, 0x40, 0xb4, 0x63, 0x55, 0x25, 0x65, 0xbf, 0x5d, 0x6f, 0x34, 0xa5, 0x76,
+	0xa3, 0x1e, 0x1c, 0x05, 0xab, 0x92, 0xd2, 0xdd, 0xaf, 0xd5, 0x1a, 0xdd, 0xae, 0xc0, 0xa1, 0x12,
+	0xcc, 0x56, 0x25, 0xa5, 0x59, 0x95, 0x5a, 0x02, 0x2f, 0xfe, 0x82, 0x83, 0xc5, 0xe6, 0x13, 0xcd,
+	0x7a, 0x2e, 0x39, 0x1f, 0x4b, 0xc7, 0xdc, 0x79, 0xeb, 0xfe, 0xaf, 0x38, 0x98, 0xad, 0x3a, 0x0e,
+	0xc5, 0x36, 0x65, 0xd2, 0xc5, 0xf3, 0x24, 0x97, 0x7c, 0x8c, 0x58, 0x81, 0x02, 0xcd, 0xc1, 0x20,
+	0xf7, 0x8a, 0x72, 0x30, 0x40, 0xd7, 0x61, 0x05, 0x5b, 0x9a, 0x6b, 0x1b, 0x9a, 0xe2, 0x60, 0xf5,
+	0x10, 0xeb, 0x24, 0x9e, 0x64, 0x28, 0x9c, 0xdb, 0x0b, 0xa6, 0x58, 0xbe, 0x7d, 0xcc, 0xc3, 0xc2,
+	0x89, 0xf5, 0xb2, 0xc3, 0xec, 0x3d, 0x28, 0x52, 0x84, 0x81, 0xbc, 0xdc, 0x29, 0x72, 0x9d, 0x32,
+	0x94, 0xa9, 0x56, 0x4d, 0x86, 0x6a, 0x67, 0x18, 0xa6, 0x79, 0x16, 0xa6, 0xd7, 0x27, 0xdc, 0x82,
+	0xe2, 0x50, 0xb6, 0x9a, 0xad, 0x54, 0x8c, 0x4e, 0x17, 0x59, 0x11, 0x1b, 0x76, 0xc9, 0x68, 0xa5,
+	0x23, 0xab, 0xd9, 0x4a, 0x46, 0x56, 0xb3, 0x15, 0x45, 0xd6, 0x1f, 0x38, 0xb8, 0x50, 0x75, 0x9c,
+	0xce, 0xc1, 0x81, 0xa1, 0x1a, 0xd8, 0x64, 0x5a, 0x9d, 0x37, 0xc0, 0xce, 0x5f, 0x82, 0xa6, 0xb0,
+	0xc1, 0x67, 0x3c, 0xac, 0x8c, 0x28, 0x92, 0xed, 0xeb, 0x4d, 0x58, 0xa2, 0xbe, 0xb6, 0xc3, 0xa5,
+	0xcc, 0xe9, 0xa1, 0x26, 0x8b, 0x38, 0xc9, 0x62, 0xe4, 0x6e, 0x9d, 0x1b, 0xbd, 0x5b, 0xef, 0xa5,
+	0x5c, 0xff, 0xf5, 0x89, 0x71, 0x33, 0x02, 0x70, 0xab, 0xda, 0x69, 0xa6, 0x42, 0x60, 0xd8, 0x74,
+	0x0a, 0x67, 0x6c, 0x3a, 0x53, 0xd8, 0xed, 0x2e, 0x14, 0x87, 0x00, 0xe8, 0x51, 0xbe, 0xda, 0x69,
+	0x26, 0xa2, 0x67, 0x11, 0x4a, 0x94, 0x74, 0x12, 0x3e, 0xf3, 0x30, 0x47, 0x09, 0x61, 0xfc, 0xfc,
+	0x87, 0x87, 0x0b, 0xf5, 0x63, 0x0b, 0xf7, 0x0d, 0xb5, 0x65, 0xab, 0xdb, 0xae, 0x3d, 0x70, 0xce,
+	0x1d, 0x3f, 0xcb, 0x50, 0x30, 0xf5, 0xa8, 0x3c, 0xe5, 0xe5, 0xbc, 0xa9, 0x4b, 0x1a, 0x7a, 0x08,
+	0x45, 0xd5, 0xee, 0xf7, 0x83, 0x37, 0xad, 0x12, 0x33, 0xf4, 0xbb, 0xe3, 0xf5, 0xcb, 0x86, 0xb4,
+	0x55, 0x37, 0xf5, 0x9a, 0xdd, 0xef, 0xf7, 0x8e, 0x1d, 0x22, 0xcf, 0xa9, 0xe1, 0x2f, 0xf6, 0x1a,
+	0xe6, 0x11, 0x57, 0x61, 0x8f, 0xaa, 0xf3, 0xe1, 0x6b, 0x98, 0x47, 0xdc, 0x3a, 0xf6, 0x71, 0xbc,
+	0x5a, 0x2e, 0x9c, 0xb7, 0x5a, 0xbe, 0x07, 0xa5, 0x18, 0x02, 0x6a, 0xed, 0x7a, 0x6b, 0x3b, 0x9d,
+	0xab, 0x94, 0xd4, 0x6d, 0xd4, 0xf6, 0xe5, 0x46, 0x60, 0x6c, 0x3a, 0xee, 0xec, 0x35, 0xda, 0x02,
+	0x2f, 0xfe, 0x8d, 0x83, 0x95, 0x11, 0xcd, 0x5e, 0xc8, 0xbb, 0xe4, 0x3a, 0x00, 0x71, 0x5d, 0xdb,
+	0x55, 0x54, 0x5b, 0x23, 0x61, 0x9b, 0x28, 0x32, 0x4a, 0xcd, 0xd6, 0xd8, 0xb1, 0x51, 0xa7, 0xd2,
+	0x23, 0x37, 0x86, 0x0f, 0xbe, 0x8c, 0x16, 0x3a, 0x71, 0x0a, 0xf3, 0xd8, 0x50, 0xfa, 0x8e, 0xed,
+	0xed, 0xd9, 0x9e, 0xc1, 0x8a, 0xc0, 0x06, 0x80, 0x13, 0xfe, 0x36, 0x34, 0xa6, 0x5b, 0x4e, 0x8e,
+	0x51, 0x46, 0xca, 0x0c, 0x7f, 0xd6, 0x32, 0x23, 0x1e, 0xc2, 0xc2, 0xfb, 0xd8, 0xd2, 0xba, 0xc4,
+	0x24, 0x2a, 0x13, 0xb9, 0x0a, 0x33, 0x2e, 0xf6, 0x95, 0x9b, 0x7a, 0x85, 0x0b, 0x5a, 0x8e, 0x8b,
+	0xfd, 0x9b, 0x7a, 0x44, 0xbe, 0xa5, 0x57, 0xf8, 0x21, 0xf9, 0xd6, 0x90, 0x7c, 0x5b, 0x67, 0x0d,
+	0x23, 0x20, 0xdf, 0x1e, 0x92, 0xef, 0xe8, 0x51, 0xdf, 0x72, 0xb1, 0x7f, 0x47, 0x17, 0xff, 0xc2,
+	0x03, 0x8a, 0xa9, 0x77, 0xee, 0x2c, 0xa9, 0x41, 0x31, 0x32, 0x46, 0xd4, 0xb1, 0x26, 0x38, 0x39,
+	0x2e, 0xf9, 0x64, 0x1f, 0x75, 0xa4, 0xe9, 0x13, 0x45, 0xc5, 0x3e, 0xd1, 0x6d, 0xf7, 0x98, 0x55,
+	0xb0, 0x82, 0x5c, 0x32, 0x7d, 0x52, 0x0b, 0x49, 0xa8, 0x0d, 0xe5, 0x47, 0xd8, 0xd2, 0x14, 0x2f,
+	0xb2, 0x52, 0x78, 0x55, 0x7a, 0x73, 0xbc, 0xb0, 0x84, 0x51, 0xe5, 0x85, 0x47, 0x09, 0x1b, 0x3f,
+	0xcf, 0xe7, 0x9e, 0x9f, 0xe4, 0x61, 0x25, 0xa6, 0xd9, 0x3d, 0xc7, 0x90, 0x89, 0x37, 0x30, 0xfd,
+	0x17, 0x1f, 0x3b, 0xe8, 0x06, 0xac, 0x68, 0x26, 0xad, 0x12, 0xfe, 0x63, 0xd7, 0x1e, 0xe8, 0x8f,
+	0x9d, 0x81, 0xaf, 0xf4, 0x8d, 0xa0, 0x41, 0xf0, 0xf2, 0x72, 0x7a, 0x6e, 0xd7, 0xc8, 0xde, 0x82,
+	0x8f, 0x74, 0x66, 0xf4, 0x8c, 0x2d, 0xd5, 0x23, 0x3d, 0x5b, 0x0a, 0x7e, 0xca, 0x5c, 0x90, 0x25,
+	0x05, 0x3f, 0xa5, 0x5b, 0x06, 0x59, 0xc0, 0x66, 0x82, 0x2d, 0x83, 0x6c, 0x60, 0x83, 0x2c, 0x60,
+	0xb3, 0xd9, 0x5b, 0x42, 0x60, 0x83, 0x2c, 0x60, 0x73, 0x63, 0xa4, 0xe0, 0xa7, 0xe8, 0x4b, 0x50,
+	0x32, 0xb1, 0x4f, 0x2c, 0xf5, 0x98, 0xe1, 0x29, 0xb2, 0x95, 0x10, 0x92, 0x28, 0x8c, 0xd8, 0x02,
+	0x2a, 0x1d, 0x12, 0x0b, 0xa8, 0xd0, 0x38, 0x07, 0xfc, 0x94, 0x75, 0x81, 0x18, 0x07, 0xfc, 0x54,
+	0xfc, 0x8c, 0x83, 0xe5, 0x74, 0x3c, 0xbc, 0x90, 0xfa, 0xf8, 0x10, 0x84, 0x28, 0x9a, 0x14, 0x97,
+	0x85, 0x5c, 0x94, 0x83, 0x5b, 0xa7, 0xca, 0xc1, 0x61, 0xa4, 0xca, 0x8b, 0xce, 0xb0, 0x20, 0x30,
+	0x36, 0x53, 0xa4, 0xc1, 0xe6, 0x5d, 0x98, 0x95, 0xea, 0xb4, 0xa5, 0xb0, 0xe3, 0x9f, 0x54, 0x4f,
+	0xb4, 0x94, 0x39, 0xc8, 0x4b, 0xbb, 0x0d, 0x49, 0xe0, 0x10, 0xc0, 0xcc, 0x6e, 0x57, 0xea, 0xd6,
+	0xdb, 0x02, 0x4f, 0x7f, 0x4b, 0x7b, 0xd5, 0x7a, 0x5d, 0x16, 0x72, 0x9b, 0xef, 0x42, 0x29, 0xa6,
+	0x23, 0x65, 0x21, 0x77, 0xd3, 0x5d, 0x49, 0xee, 0x26, 0x4f, 0x90, 0x72, 0x37, 0x3c, 0x01, 0xdc,
+	0xfc, 0x5d, 0x09, 0xca, 0xbb, 0x14, 0x57, 0x83, 0xc1, 0xaa, 0x3a, 0x06, 0xfa, 0x29, 0x07, 0xe5,
+	0xe4, 0xe7, 0x33, 0x74, 0x6d, 0x92, 0x7d, 0x33, 0x3e, 0x5b, 0xae, 0x5d, 0x3d, 0xfd, 0x06, 0xc7,
+	0x3c, 0x16, 0xd7, 0x7f, 0xf0, 0xd7, 0x7f, 0xfe, 0x9c, 0x7f, 0x59, 0x44, 0xd7, 0x8e, 0x6e, 0x5c,
+	0x73, 0xc3, 0x05, 0xc1, 0x29, 0xed, 0x1d, 0x6e, 0x13, 0xfd, 0x88, 0x83, 0xf9, 0xf8, 0xd7, 0x07,
+	0x74, 0xf5, 0xb4, 0x5f, 0x29, 0x02, 0x34, 0x5f, 0x39, 0xc3, 0x47, 0x0d, 0xf1, 0x22, 0xc3, 0xb2,
+	0x2a, 0x0a, 0x14, 0xcb, 0x81, 0x61, 0x69, 0xd1, 0xb5, 0x91, 0x22, 0xf9, 0x25, 0x07, 0x2b, 0x59,
+	0x1f, 0x8a, 0xd0, 0x9d, 0xf1, 0x22, 0x26, 0x7c, 0x58, 0x3a, 0x1b, 0xb2, 0xd7, 0x19, 0xb2, 0x75,
+	0xb1, 0x42, 0x91, 0x39, 0x21, 0xd7, 0x34, 0x42, 0xea, 0xbd, 0xe4, 0x3b, 0xf4, 0x24, 0xef, 0x65,
+	0x7e, 0x9b, 0x98, 0xe4, 0xbd, 0x8c, 0x27, 0xee, 0xa4, 0xf7, 0x82, 0xcf, 0x03, 0x51, 0x69, 0xa6,
+	0x88, 0x3e, 0xe4, 0xa0, 0x14, 0x7b, 0x0f, 0x44, 0x5f, 0x3d, 0xe5, 0xb3, 0x61, 0x80, 0x65, 0xf3,
+	0xf4, 0x8f, 0x8c, 0xe2, 0x1a, 0x03, 0xb2, 0x22, 0x2e, 0x52, 0x20, 0x3a, 0xf1, 0xe3, 0x28, 0x7e,
+	0xc6, 0x41, 0xb9, 0xaa, 0x69, 0xfb, 0x1e, 0x71, 0x7b, 0x36, 0x3b, 0x7c, 0xa1, 0xeb, 0x67, 0x3d,
+	0x81, 0xae, 0x6d, 0x9d, 0x61, 0xc7, 0x88, 0x65, 0xb0, 0xa6, 0xb1, 0xb2, 0x6a, 0xb3, 0x83, 0x16,
+	0xc5, 0xf4, 0x63, 0x0e, 0xca, 0xdb, 0xc4, 0x8f, 0xbd, 0x7c, 0x4c, 0x32, 0xce, 0xe8, 0xcb, 0xe1,
+	0x24, 0xe3, 0xa4, 0x9f, 0x53, 0x92, 0x58, 0x74, 0xe2, 0x87, 0xcf, 0x39, 0xa6, 0xe1, 0xb1, 0xb8,
+	0xf9, 0x3e, 0x73, 0x52, 0x74, 0xbb, 0x45, 0x5f, 0x3e, 0xcd, 0x0d, 0x38, 0x00, 0xf1, 0xe6, 0x29,
+	0x2f, 0xcb, 0x23, 0xee, 0xa1, 0x37, 0xb7, 0x48, 0xfc, 0xc7, 0xc1, 0x0b, 0x7a, 0xea, 0x8a, 0x35,
+	0xc9, 0x45, 0xd9, 0xf7, 0xde, 0x49, 0x2e, 0xca, 0xba, 0xbf, 0x89, 0xaf, 0x31, 0x50, 0x17, 0xc5,
+	0x0b, 0x27, 0x66, 0x89, 0xae, 0x96, 0x14, 0x1f, 0xc5, 0xf6, 0x11, 0x07, 0x4b, 0xdb, 0xc4, 0x4f,
+	0x36, 0x80, 0x49, 0x9e, 0x1a, 0x3d, 0x28, 0x4e, 0x4a, 0xa9, 0x8c, 0x96, 0x27, 0x5e, 0x62, 0xa8,
+	0xd6, 0xc4, 0xd5, 0x10, 0xd5, 0x13, 0xdb, 0x8b, 0x3a, 0xcd, 0xa1, 0x63, 0xbc, 0xc3, 0x6d, 0x5e,
+	0xe7, 0xde, 0x17, 0x3e, 0xfd, 0xc7, 0xc6, 0x4b, 0x9f, 0x3e, 0xdb, 0xe0, 0xfe, 0xfc, 0x6c, 0x83,
+	0xfb, 0xfb, 0xb3, 0x0d, 0xee, 0xd1, 0x0c, 0xfb, 0xf3, 0xc9, 0xad, 0xff, 0x05, 0x00, 0x00, 0xff,
+	0xff, 0xb2, 0x16, 0x8a, 0x65, 0xe4, 0x22, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -2439,6 +2454,47 @@ var _MatchEngineApi_serviceDesc = grpc.ServiceDesc{
 	Metadata: "app-client.proto",
 }
 
+func (m *Tag) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Tag) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Tag) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Data) > 0 {
+		i -= len(m.Data)
+		copy(dAtA[i:], m.Data)
+		i = encodeVarintAppClient(dAtA, i, uint64(len(m.Data)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Type) > 0 {
+		i -= len(m.Type)
+		copy(dAtA[i:], m.Type)
+		i = encodeVarintAppClient(dAtA, i, uint64(len(m.Type)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *RegisterClientRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -2464,24 +2520,19 @@ func (m *RegisterClientRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if len(m.UniqueId) > 0 {
@@ -2571,24 +2622,19 @@ func (m *RegisterClientReply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if len(m.UniqueId) > 0 {
@@ -2657,24 +2703,19 @@ func (m *FindCloudletRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.CellId != 0 {
@@ -2741,24 +2782,19 @@ func (m *PlatformFindCloudletRequest) MarshalToSizedBuffer(dAtA []byte) (int, er
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if len(m.ClientToken) > 0 {
@@ -2815,24 +2851,19 @@ func (m *FindCloudletReply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.CloudletLocation != nil {
@@ -2906,24 +2937,19 @@ func (m *VerifyLocationRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.CellId != 0 {
@@ -2997,24 +3023,19 @@ func (m *VerifyLocationReply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.GpsLocationAccuracyKm != 0 {
@@ -3066,24 +3087,19 @@ func (m *GetLocationRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.CellId != 0 {
@@ -3138,24 +3154,19 @@ func (m *GetLocationReply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.NetworkLocation != nil {
@@ -3220,24 +3231,19 @@ func (m *AppInstListRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.Limit != 0 {
@@ -3451,24 +3457,19 @@ func (m *AppInstListReply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if len(m.Cloudlets) > 0 {
@@ -3523,24 +3524,19 @@ func (m *FqdnListRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.CellId != 0 {
@@ -3652,24 +3648,19 @@ func (m *FqdnListReply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.Status != 0 {
@@ -3724,24 +3715,19 @@ func (m *AppOfficialFqdnRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.GpsLocation != nil {
@@ -3796,24 +3782,19 @@ func (m *AppOfficialFqdnReply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if len(m.Ports) > 0 {
@@ -3882,24 +3863,19 @@ func (m *DynamicLocGroupRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.CellId != 0 {
@@ -3964,24 +3940,19 @@ func (m *DynamicLocGroupReply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if len(m.GroupCookie) > 0 {
@@ -4141,24 +4112,19 @@ func (m *QosPositionRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if m.CellId != 0 {
@@ -4335,24 +4301,19 @@ func (m *QosPositionKpiReply) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for k := range m.Tags {
-			v := m.Tags[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintAppClient(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintAppClient(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAppClient(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0x6
 			i--
-			dAtA[i] = 0xa2
+			dAtA[i] = 0x9a
 		}
 	}
 	if len(m.PositionResults) > 0 {
@@ -4393,6 +4354,29 @@ func encodeVarintAppClient(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+func (m *Tag) CopyInFields(src *Tag) int {
+	changed := 0
+	if m.Type != src.Type {
+		m.Type = src.Type
+		changed++
+	}
+	if m.Data != src.Data {
+		m.Data = src.Data
+		changed++
+	}
+	return changed
+}
+
+func (m *Tag) DeepCopyIn(src *Tag) {
+	m.Type = src.Type
+	m.Data = src.Data
+}
+
+// Helper method to check that enums have valid values
+func (m *Tag) ValidateEnums() error {
+	return nil
+}
+
 func (m *RegisterClientRequest) CopyInFields(src *RegisterClientRequest) int {
 	changed := 0
 	if m.Ver != src.Ver {
@@ -4432,10 +4416,8 @@ func (m *RegisterClientRequest) CopyInFields(src *RegisterClientRequest) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -4454,9 +4436,11 @@ func (m *RegisterClientRequest) DeepCopyIn(src *RegisterClientRequest) {
 	m.UniqueIdType = src.UniqueIdType
 	m.UniqueId = src.UniqueId
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -4465,6 +4449,11 @@ func (m *RegisterClientRequest) DeepCopyIn(src *RegisterClientRequest) {
 
 // Helper method to check that enums have valid values
 func (m *RegisterClientRequest) ValidateEnums() error {
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -4495,10 +4484,8 @@ func (m *RegisterClientReply) CopyInFields(src *RegisterClientReply) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -4514,9 +4501,11 @@ func (m *RegisterClientReply) DeepCopyIn(src *RegisterClientReply) {
 	m.UniqueIdType = src.UniqueIdType
 	m.UniqueId = src.UniqueId
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -4527,6 +4516,11 @@ func (m *RegisterClientReply) DeepCopyIn(src *RegisterClientReply) {
 func (m *RegisterClientReply) ValidateEnums() error {
 	if _, ok := ReplyStatus_name[int32(m.Status)]; !ok {
 		return errors.New("invalid Status")
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -4598,10 +4592,8 @@ func (m *FindCloudletRequest) CopyInFields(src *FindCloudletRequest) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -4622,9 +4614,11 @@ func (m *FindCloudletRequest) DeepCopyIn(src *FindCloudletRequest) {
 	}
 	m.CellId = src.CellId
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -4635,6 +4629,11 @@ func (m *FindCloudletRequest) DeepCopyIn(src *FindCloudletRequest) {
 func (m *FindCloudletRequest) ValidateEnums() error {
 	if err := m.GpsLocation.ValidateEnums(); err != nil {
 		return err
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -4658,10 +4657,8 @@ func (m *PlatformFindCloudletRequest) CopyInFields(src *PlatformFindCloudletRequ
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -4675,9 +4672,11 @@ func (m *PlatformFindCloudletRequest) DeepCopyIn(src *PlatformFindCloudletReques
 	m.CarrierName = src.CarrierName
 	m.ClientToken = src.ClientToken
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -4686,6 +4685,11 @@ func (m *PlatformFindCloudletRequest) DeepCopyIn(src *PlatformFindCloudletReques
 
 // Helper method to check that enums have valid values
 func (m *PlatformFindCloudletRequest) ValidateEnums() error {
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -4759,10 +4763,8 @@ func (m *FindCloudletReply) CopyInFields(src *FindCloudletReply) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -4792,9 +4794,11 @@ func (m *FindCloudletReply) DeepCopyIn(src *FindCloudletReply) {
 		m.CloudletLocation = nil
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -4813,6 +4817,11 @@ func (m *FindCloudletReply) ValidateEnums() error {
 	}
 	if err := m.CloudletLocation.ValidateEnums(); err != nil {
 		return err
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -4888,10 +4897,8 @@ func (m *VerifyLocationRequest) CopyInFields(src *VerifyLocationRequest) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -4913,9 +4920,11 @@ func (m *VerifyLocationRequest) DeepCopyIn(src *VerifyLocationRequest) {
 	m.VerifyLocToken = src.VerifyLocToken
 	m.CellId = src.CellId
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -4926,6 +4935,11 @@ func (m *VerifyLocationRequest) DeepCopyIn(src *VerifyLocationRequest) {
 func (m *VerifyLocationRequest) ValidateEnums() error {
 	if err := m.GpsLocation.ValidateEnums(); err != nil {
 		return err
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -4949,10 +4963,8 @@ func (m *VerifyLocationReply) CopyInFields(src *VerifyLocationReply) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -4966,9 +4978,11 @@ func (m *VerifyLocationReply) DeepCopyIn(src *VerifyLocationReply) {
 	m.GpsLocationStatus = src.GpsLocationStatus
 	m.GpsLocationAccuracyKm = src.GpsLocationAccuracyKm
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -4982,6 +4996,11 @@ func (m *VerifyLocationReply) ValidateEnums() error {
 	}
 	if _, ok := VerifyLocationReply_GPSLocationStatus_name[int32(m.GpsLocationStatus)]; !ok {
 		return errors.New("invalid GpsLocationStatus")
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -5005,10 +5024,8 @@ func (m *GetLocationRequest) CopyInFields(src *GetLocationRequest) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5022,9 +5039,11 @@ func (m *GetLocationRequest) DeepCopyIn(src *GetLocationRequest) {
 	m.CarrierName = src.CarrierName
 	m.CellId = src.CellId
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5033,6 +5052,11 @@ func (m *GetLocationRequest) DeepCopyIn(src *GetLocationRequest) {
 
 // Helper method to check that enums have valid values
 func (m *GetLocationRequest) ValidateEnums() error {
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -5103,10 +5127,8 @@ func (m *GetLocationReply) CopyInFields(src *GetLocationReply) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5127,9 +5149,11 @@ func (m *GetLocationReply) DeepCopyIn(src *GetLocationReply) {
 		m.NetworkLocation = nil
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5143,6 +5167,11 @@ func (m *GetLocationReply) ValidateEnums() error {
 	}
 	if err := m.NetworkLocation.ValidateEnums(); err != nil {
 		return err
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -5218,10 +5247,8 @@ func (m *AppInstListRequest) CopyInFields(src *AppInstListRequest) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5243,9 +5270,11 @@ func (m *AppInstListRequest) DeepCopyIn(src *AppInstListRequest) {
 	m.CellId = src.CellId
 	m.Limit = src.Limit
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5256,6 +5285,11 @@ func (m *AppInstListRequest) DeepCopyIn(src *AppInstListRequest) {
 func (m *AppInstListRequest) ValidateEnums() error {
 	if err := m.GpsLocation.ValidateEnums(); err != nil {
 		return err
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -5441,10 +5475,8 @@ func (m *AppInstListReply) CopyInFields(src *AppInstListReply) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5466,9 +5498,11 @@ func (m *AppInstListReply) DeepCopyIn(src *AppInstListReply) {
 		m.Cloudlets = nil
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5481,6 +5515,11 @@ func (m *AppInstListReply) ValidateEnums() error {
 		return errors.New("invalid Status")
 	}
 	for _, e := range m.Cloudlets {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
+	}
+	for _, e := range m.Tags {
 		if err := e.ValidateEnums(); err != nil {
 			return err
 		}
@@ -5503,10 +5542,8 @@ func (m *FqdnListRequest) CopyInFields(src *FqdnListRequest) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5519,9 +5556,11 @@ func (m *FqdnListRequest) DeepCopyIn(src *FqdnListRequest) {
 	m.SessionCookie = src.SessionCookie
 	m.CellId = src.CellId
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5530,6 +5569,11 @@ func (m *FqdnListRequest) DeepCopyIn(src *FqdnListRequest) {
 
 // Helper method to check that enums have valid values
 func (m *FqdnListRequest) ValidateEnums() error {
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -5599,10 +5643,8 @@ func (m *FqdnListReply) CopyInFields(src *FqdnListReply) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5624,9 +5666,11 @@ func (m *FqdnListReply) DeepCopyIn(src *FqdnListReply) {
 	}
 	m.Status = src.Status
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5642,6 +5686,11 @@ func (m *FqdnListReply) ValidateEnums() error {
 	}
 	if _, ok := FqdnListReply_FLStatus_name[int32(m.Status)]; !ok {
 		return errors.New("invalid Status")
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -5705,10 +5754,8 @@ func (m *AppOfficialFqdnRequest) CopyInFields(src *AppOfficialFqdnRequest) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5727,9 +5774,11 @@ func (m *AppOfficialFqdnRequest) DeepCopyIn(src *AppOfficialFqdnRequest) {
 		m.GpsLocation = nil
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5740,6 +5789,11 @@ func (m *AppOfficialFqdnRequest) DeepCopyIn(src *AppOfficialFqdnRequest) {
 func (m *AppOfficialFqdnRequest) ValidateEnums() error {
 	if err := m.GpsLocation.ValidateEnums(); err != nil {
 		return err
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -5770,10 +5824,8 @@ func (m *AppOfficialFqdnReply) CopyInFields(src *AppOfficialFqdnReply) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5797,9 +5849,11 @@ func (m *AppOfficialFqdnReply) DeepCopyIn(src *AppOfficialFqdnReply) {
 		m.Ports = nil
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5812,6 +5866,11 @@ func (m *AppOfficialFqdnReply) ValidateEnums() error {
 		return errors.New("invalid Status")
 	}
 	for _, e := range m.Ports {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
+	}
+	for _, e := range m.Tags {
 		if err := e.ValidateEnums(); err != nil {
 			return err
 		}
@@ -5846,10 +5905,8 @@ func (m *DynamicLocGroupRequest) CopyInFields(src *DynamicLocGroupRequest) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5865,9 +5922,11 @@ func (m *DynamicLocGroupRequest) DeepCopyIn(src *DynamicLocGroupRequest) {
 	m.UserData = src.UserData
 	m.CellId = src.CellId
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5878,6 +5937,11 @@ func (m *DynamicLocGroupRequest) DeepCopyIn(src *DynamicLocGroupRequest) {
 func (m *DynamicLocGroupRequest) ValidateEnums() error {
 	if _, ok := DynamicLocGroupRequest_DlgCommType_name[int32(m.CommType)]; !ok {
 		return errors.New("invalid CommType")
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -5901,10 +5965,8 @@ func (m *DynamicLocGroupReply) CopyInFields(src *DynamicLocGroupReply) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -5918,9 +5980,11 @@ func (m *DynamicLocGroupReply) DeepCopyIn(src *DynamicLocGroupReply) {
 	m.ErrorCode = src.ErrorCode
 	m.GroupCookie = src.GroupCookie
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -5931,6 +5995,11 @@ func (m *DynamicLocGroupReply) DeepCopyIn(src *DynamicLocGroupReply) {
 func (m *DynamicLocGroupReply) ValidateEnums() error {
 	if _, ok := ReplyStatus_name[int32(m.Status)]; !ok {
 		return errors.New("invalid Status")
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -6144,10 +6213,8 @@ func (m *QosPositionRequest) CopyInFields(src *QosPositionRequest) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -6178,9 +6245,11 @@ func (m *QosPositionRequest) DeepCopyIn(src *QosPositionRequest) {
 	}
 	m.CellId = src.CellId
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -6196,6 +6265,11 @@ func (m *QosPositionRequest) ValidateEnums() error {
 	}
 	if err := m.BandSelection.ValidateEnums(); err != nil {
 		return err
+	}
+	for _, e := range m.Tags {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -6339,10 +6413,8 @@ func (m *QosPositionKpiReply) CopyInFields(src *QosPositionKpiReply) int {
 		changed++
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k0, _ := range src.Tags {
-			m.Tags[k0] = src.Tags[k0]
-		}
+		m.Tags = src.Tags
+		changed++
 	} else if m.Tags != nil {
 		m.Tags = nil
 		changed++
@@ -6364,9 +6436,11 @@ func (m *QosPositionKpiReply) DeepCopyIn(src *QosPositionKpiReply) {
 		m.PositionResults = nil
 	}
 	if src.Tags != nil {
-		m.Tags = make(map[string]string)
-		for k, v := range src.Tags {
-			m.Tags[k] = v
+		m.Tags = make([]*Tag, len(src.Tags), len(src.Tags))
+		for ii, s := range src.Tags {
+			var tmp_s Tag
+			tmp_s.DeepCopyIn(s)
+			m.Tags[ii] = &tmp_s
 		}
 	} else {
 		m.Tags = nil
@@ -6379,6 +6453,11 @@ func (m *QosPositionKpiReply) ValidateEnums() error {
 		return errors.New("invalid Status")
 	}
 	for _, e := range m.PositionResults {
+		if err := e.ValidateEnums(); err != nil {
+			return err
+		}
+	}
+	for _, e := range m.Tags {
 		if err := e.ValidateEnums(); err != nil {
 			return err
 		}
@@ -7293,6 +7372,26 @@ func IsShow(cmd string) bool {
 	return found
 }
 
+func (m *Tag) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Type)
+	if l > 0 {
+		n += 1 + l + sovAppClient(uint64(l))
+	}
+	l = len(m.Data)
+	if l > 0 {
+		n += 1 + l + sovAppClient(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
 func (m *RegisterClientRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -7334,11 +7433,9 @@ func (m *RegisterClientRequest) Size() (n int) {
 		n += 1 + l + sovAppClient(uint64(l))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7376,11 +7473,9 @@ func (m *RegisterClientReply) Size() (n int) {
 		n += 1 + l + sovAppClient(uint64(l))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7414,11 +7509,9 @@ func (m *FindCloudletRequest) Size() (n int) {
 		n += 1 + sovAppClient(uint64(m.CellId))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7449,11 +7542,9 @@ func (m *PlatformFindCloudletRequest) Size() (n int) {
 		n += 1 + l + sovAppClient(uint64(l))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7489,11 +7580,9 @@ func (m *FindCloudletReply) Size() (n int) {
 		n += 1 + l + sovAppClient(uint64(l))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7531,11 +7620,9 @@ func (m *VerifyLocationRequest) Size() (n int) {
 		n += 1 + sovAppClient(uint64(m.CellId))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7563,11 +7650,9 @@ func (m *VerifyLocationReply) Size() (n int) {
 		n += 9
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7597,11 +7682,9 @@ func (m *GetLocationRequest) Size() (n int) {
 		n += 1 + sovAppClient(uint64(m.CellId))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7634,11 +7717,9 @@ func (m *GetLocationReply) Size() (n int) {
 		n += 1 + l + sovAppClient(uint64(l))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7675,11 +7756,9 @@ func (m *AppInstListRequest) Size() (n int) {
 		n += 1 + sovAppClient(uint64(m.Limit))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7774,11 +7853,9 @@ func (m *AppInstListReply) Size() (n int) {
 		}
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7804,11 +7881,9 @@ func (m *FqdnListRequest) Size() (n int) {
 		n += 1 + sovAppClient(uint64(m.CellId))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7870,11 +7945,9 @@ func (m *FqdnListReply) Size() (n int) {
 		n += 1 + sovAppClient(uint64(m.Status))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7901,11 +7974,9 @@ func (m *AppOfficialFqdnRequest) Size() (n int) {
 		n += 1 + l + sovAppClient(uint64(l))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7941,11 +8012,9 @@ func (m *AppOfficialFqdnReply) Size() (n int) {
 		}
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -7981,11 +8050,9 @@ func (m *DynamicLocGroupRequest) Size() (n int) {
 		n += 1 + sovAppClient(uint64(m.CellId))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -8014,11 +8081,9 @@ func (m *DynamicLocGroupReply) Size() (n int) {
 		n += 1 + l + sovAppClient(uint64(l))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -8112,11 +8177,9 @@ func (m *QosPositionRequest) Size() (n int) {
 		n += 1 + sovAppClient(uint64(m.CellId))
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -8190,11 +8253,9 @@ func (m *QosPositionKpiReply) Size() (n int) {
 		}
 	}
 	if len(m.Tags) > 0 {
-		for k, v := range m.Tags {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovAppClient(uint64(len(k))) + 1 + len(v) + sovAppClient(uint64(len(v)))
-			n += mapEntrySize + 2 + sovAppClient(uint64(mapEntrySize))
+		for _, e := range m.Tags {
+			l = e.Size()
+			n += 2 + l + sovAppClient(uint64(l))
 		}
 	}
 	if m.XXX_unrecognized != nil {
@@ -8208,6 +8269,124 @@ func sovAppClient(x uint64) (n int) {
 }
 func sozAppClient(x uint64) (n int) {
 	return sovAppClient(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *Tag) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAppClient
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Tag: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Tag: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAppClient
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAppClient
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAppClient
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Type = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Data", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAppClient
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAppClient
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAppClient
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Data = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAppClient(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAppClient
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthAppClient
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *RegisterClientRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -8500,7 +8679,7 @@ func (m *RegisterClientRequest) Unmarshal(dAtA []byte) error {
 			}
 			m.UniqueId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -8529,103 +8708,10 @@ func (m *RegisterClientRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -8847,7 +8933,7 @@ func (m *RegisterClientReply) Unmarshal(dAtA []byte) error {
 			}
 			m.UniqueId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -8876,103 +8962,10 @@ func (m *RegisterClientReply) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -9166,7 +9159,7 @@ func (m *FindCloudletRequest) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -9195,103 +9188,10 @@ func (m *FindCloudletRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -9462,7 +9362,7 @@ func (m *PlatformFindCloudletRequest) Unmarshal(dAtA []byte) error {
 			}
 			m.ClientToken = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -9491,103 +9391,10 @@ func (m *PlatformFindCloudletRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -9783,7 +9590,7 @@ func (m *FindCloudletReply) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -9812,103 +9619,10 @@ func (m *FindCloudletReply) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -10134,7 +9848,7 @@ func (m *VerifyLocationRequest) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -10163,103 +9877,10 @@ func (m *VerifyLocationRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -10383,7 +10004,7 @@ func (m *VerifyLocationReply) Unmarshal(dAtA []byte) error {
 			v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
 			iNdEx += 8
 			m.GpsLocationAccuracyKm = float64(math.Float64frombits(v))
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -10412,103 +10033,10 @@ func (m *VerifyLocationReply) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -10666,7 +10194,7 @@ func (m *GetLocationRequest) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -10695,103 +10223,10 @@ func (m *GetLocationRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -10972,7 +10407,7 @@ func (m *GetLocationReply) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -11001,103 +10436,10 @@ func (m *GetLocationReply) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -11310,7 +10652,7 @@ func (m *AppInstListRequest) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -11339,103 +10681,10 @@ func (m *AppInstListRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -11978,7 +11227,7 @@ func (m *AppInstListReply) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -12007,103 +11256,10 @@ func (m *AppInstListReply) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -12229,7 +11385,7 @@ func (m *FqdnListRequest) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -12258,103 +11414,10 @@ func (m *FqdnListRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -12696,7 +11759,7 @@ func (m *FqdnListReply) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -12725,103 +11788,10 @@ func (m *FqdnListReply) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -12964,7 +11934,7 @@ func (m *AppOfficialFqdnRequest) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -12993,103 +11963,10 @@ func (m *AppOfficialFqdnRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -13281,7 +12158,7 @@ func (m *AppOfficialFqdnReply) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -13310,103 +12187,10 @@ func (m *AppOfficialFqdnReply) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -13602,7 +12386,7 @@ func (m *DynamicLocGroupRequest) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -13631,103 +12415,10 @@ func (m *DynamicLocGroupRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -13872,7 +12563,7 @@ func (m *DynamicLocGroupReply) Unmarshal(dAtA []byte) error {
 			}
 			m.GroupCookie = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -13901,103 +12592,10 @@ func (m *DynamicLocGroupReply) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -14503,7 +13101,7 @@ func (m *QosPositionRequest) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -14532,103 +13130,10 @@ func (m *QosPositionRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -14964,7 +13469,7 @@ func (m *QosPositionKpiReply) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 100:
+		case 99:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
 			}
@@ -14993,103 +13498,10 @@ func (m *QosPositionKpiReply) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Tags == nil {
-				m.Tags = make(map[string]string)
+			m.Tags = append(m.Tags, &Tag{})
+			if err := m.Tags[len(m.Tags)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowAppClient
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowAppClient
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipAppClient(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if skippy < 0 {
-						return ErrInvalidLengthAppClient
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Tags[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/gencmd/app-client.cmd.go
+++ b/gencmd/app-client.cmd.go
@@ -628,6 +628,17 @@ var MatchEngineApiCmds = []*cobra.Command{
 	GetQosPositionKpiCmd.GenCmd(),
 }
 
+var TagRequiredArgs = []string{}
+var TagOptionalArgs = []string{
+	"type",
+	"data",
+}
+var TagAliasArgs = []string{}
+var TagComments = map[string]string{
+	"type": "type of data",
+	"data": "data value",
+}
+var TagSpecialArgs = map[string]string{}
 var RegisterClientRequestRequiredArgs = []string{}
 var RegisterClientRequestOptionalArgs = []string{
 	"ver",
@@ -639,7 +650,8 @@ var RegisterClientRequestOptionalArgs = []string{
 	"cellid",
 	"uniqueidtype",
 	"uniqueid",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var RegisterClientRequestAliasArgs = []string{}
 var RegisterClientRequestComments = map[string]string{
@@ -652,11 +664,10 @@ var RegisterClientRequestComments = map[string]string{
 	"cellid":       "Cell ID _(optional)_ Cellular ID of where the client is connected.",
 	"uniqueidtype": "Unique ID Type _(optional)_ Type of unique ID provided by the client. If left blank, a new Unique ID type will be assigned in the RegisterClient Reply.",
 	"uniqueid":     "Unique ID _(optional)_ Unique identification of the client device or user. May be overridden by the server. If left blank, a new Unique ID will be assigned in the RegisterClient Reply.",
-	"tags":         "Tags _(optional)_ Vendor specific data",
+	"tags:#.type":  "type of data",
+	"tags:#.data":  "data value",
 }
-var RegisterClientRequestSpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var RegisterClientRequestSpecialArgs = map[string]string{}
 var RegisterClientReplyRequiredArgs = []string{}
 var RegisterClientReplyOptionalArgs = []string{
 	"ver",
@@ -665,7 +676,8 @@ var RegisterClientReplyOptionalArgs = []string{
 	"tokenserveruri",
 	"uniqueidtype",
 	"uniqueid",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var RegisterClientReplyAliasArgs = []string{}
 var RegisterClientReplyComments = map[string]string{
@@ -675,11 +687,10 @@ var RegisterClientReplyComments = map[string]string{
 	"tokenserveruri": "URI for the Token Server",
 	"uniqueidtype":   "Unique ID Type _(optional)_ Type of unique ID provided by the server A unique_id_type and unique_id may be provided by the client to be registered. During registering, if a unique_id_type and unique_id are provided by the client in their request, the unique_id_type and unique_id will be left blank in the response. But, if the client does not provide a unique_id_type and unique_id, then the server generates one and provides the unique_id in the response. If possible, the unique_id should be saved by the client locally and used for subsequent RegisterClient API calls. Otherwise, a new unique_id will be generated for further API calls.",
 	"uniqueid":       "Unique ID _(optional)_ Unique identification of the client device or user A unique_id_type and unique_id may be provided by the client to be registered. During registering, if a unique_id_type and unique_id are provided by the client in their request, the unique_id_type and unique_id will be left blank in the response. But, if the client does not provide a unique_id_type and unique_id, then the server generates one and provides the unique_id in the response. If possible, the unique_id should be saved by the client locally and used for subsequent RegisterClient API calls. Otherwise, a new unique_id will be generated for further API calls.",
-	"tags":           "Vendor specific data _(optional)_ Array of Tags.",
+	"tags:#.type":    "type of data",
+	"tags:#.data":    "data value",
 }
-var RegisterClientReplySpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var RegisterClientReplySpecialArgs = map[string]string{}
 var FindCloudletRequestRequiredArgs = []string{}
 var FindCloudletRequestOptionalArgs = []string{
 	"ver",
@@ -695,7 +706,8 @@ var FindCloudletRequestOptionalArgs = []string{
 	"gpslocation.timestamp.seconds",
 	"gpslocation.timestamp.nanos",
 	"cellid",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var FindCloudletRequestAliasArgs = []string{}
 var FindCloudletRequestComments = map[string]string{
@@ -710,18 +722,18 @@ var FindCloudletRequestComments = map[string]string{
 	"gpslocation.course":             "course (IOS) / bearing (Android) (degrees east relative to true north)",
 	"gpslocation.speed":              "speed (IOS) / velocity (Android) (meters/sec)",
 	"cellid":                         "Cell ID _(optional)_ Cell ID where the client is",
-	"tags":                           "Tags _(optional)_ Vendor specific data",
+	"tags:#.type":                    "type of data",
+	"tags:#.data":                    "data value",
 }
-var FindCloudletRequestSpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var FindCloudletRequestSpecialArgs = map[string]string{}
 var PlatformFindCloudletRequestRequiredArgs = []string{}
 var PlatformFindCloudletRequestOptionalArgs = []string{
 	"ver",
 	"sessioncookie",
 	"carriername",
 	"clienttoken",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var PlatformFindCloudletRequestAliasArgs = []string{}
 var PlatformFindCloudletRequestComments = map[string]string{
@@ -729,11 +741,10 @@ var PlatformFindCloudletRequestComments = map[string]string{
 	"sessioncookie": "Session Cookie Session Cookie from RegisterClientRequest",
 	"carriername":   "Carrier Name _(optional)_ By default, all SDKs will automatically fill in this parameter with the MCC+MNC of your current provider. Only override this parameter if you need to filter for a specific carrier on the DME. The DME will filter for App instances that are associated with the specified carrier. If you wish to search for any app instance on the DME regardless of carrier name, you can input “” to consider all carriers as “Any”.",
 	"clienttoken":   "Client Token Token with encoded client data",
-	"tags":          "Tags _(optional)_ Vendor specific data",
+	"tags:#.type":   "type of data",
+	"tags:#.data":   "data value",
 }
-var PlatformFindCloudletRequestSpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var PlatformFindCloudletRequestSpecialArgs = map[string]string{}
 var FindCloudletReplyRequiredArgs = []string{}
 var FindCloudletReplyOptionalArgs = []string{
 	"ver",
@@ -755,7 +766,8 @@ var FindCloudletReplyOptionalArgs = []string{
 	"cloudletlocation.speed",
 	"cloudletlocation.timestamp.seconds",
 	"cloudletlocation.timestamp.nanos",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var FindCloudletReplyAliasArgs = []string{}
 var FindCloudletReplyComments = map[string]string{
@@ -776,11 +788,10 @@ var FindCloudletReplyComments = map[string]string{
 	"cloudletlocation.altitude":           "On android only lat and long are guaranteed to be supplied altitude in meters",
 	"cloudletlocation.course":             "course (IOS) / bearing (Android) (degrees east relative to true north)",
 	"cloudletlocation.speed":              "speed (IOS) / velocity (Android) (meters/sec)",
-	"tags":                                "_(optional)_ Vendor specific data",
+	"tags:#.type":                         "type of data",
+	"tags:#.data":                         "data value",
 }
-var FindCloudletReplySpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var FindCloudletReplySpecialArgs = map[string]string{}
 var VerifyLocationRequestRequiredArgs = []string{}
 var VerifyLocationRequestOptionalArgs = []string{
 	"ver",
@@ -797,7 +808,8 @@ var VerifyLocationRequestOptionalArgs = []string{
 	"gpslocation.timestamp.nanos",
 	"verifyloctoken",
 	"cellid",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var VerifyLocationRequestAliasArgs = []string{}
 var VerifyLocationRequestComments = map[string]string{
@@ -813,18 +825,18 @@ var VerifyLocationRequestComments = map[string]string{
 	"gpslocation.speed":              "speed (IOS) / velocity (Android) (meters/sec)",
 	"verifyloctoken":                 "Verify Location Token Must be retrieved from TokenServerURI",
 	"cellid":                         "Cell ID _(optional)_ Cell ID where the client is",
-	"tags":                           "Tags _(optional)_ Vendor specific data",
+	"tags:#.type":                    "type of data",
+	"tags:#.data":                    "data value",
 }
-var VerifyLocationRequestSpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var VerifyLocationRequestSpecialArgs = map[string]string{}
 var VerifyLocationReplyRequiredArgs = []string{}
 var VerifyLocationReplyOptionalArgs = []string{
 	"ver",
 	"towerstatus",
 	"gpslocationstatus",
 	"gpslocationaccuracykm",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var VerifyLocationReplyAliasArgs = []string{}
 var VerifyLocationReplyComments = map[string]string{
@@ -832,18 +844,18 @@ var VerifyLocationReplyComments = map[string]string{
 	"towerstatus":           ", one of TowerUnknown, ConnectedToSpecifiedTower, NotConnectedToSpecifiedTower",
 	"gpslocationstatus":     ", one of LocUnknown, LocVerified, LocMismatchSameCountry, LocMismatchOtherCountry, LocRoamingCountryMatch, LocRoamingCountryMismatch, LocErrorUnauthorized, LocErrorOther",
 	"gpslocationaccuracykm": "location accuracy, the location is verified to be within this number of kilometers.  Negative value means no verification was performed",
-	"tags":                  "_(optional)_ Vendor specific data",
+	"tags:#.type":           "type of data",
+	"tags:#.data":           "data value",
 }
-var VerifyLocationReplySpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var VerifyLocationReplySpecialArgs = map[string]string{}
 var GetLocationRequestRequiredArgs = []string{}
 var GetLocationRequestOptionalArgs = []string{
 	"ver",
 	"sessioncookie",
 	"carriername",
 	"cellid",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var GetLocationRequestAliasArgs = []string{}
 var GetLocationRequestComments = map[string]string{
@@ -851,11 +863,10 @@ var GetLocationRequestComments = map[string]string{
 	"sessioncookie": "Session Cookie from RegisterClientRequest",
 	"carriername":   "Unique carrier identification (typically MCC + MNC)",
 	"cellid":        "_(optional)_ Cell id where the client is",
-	"tags":          "_(optional)_ Vendor specific data",
+	"tags:#.type":   "type of data",
+	"tags:#.data":   "data value",
 }
-var GetLocationRequestSpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var GetLocationRequestSpecialArgs = map[string]string{}
 var GetLocationReplyRequiredArgs = []string{}
 var GetLocationReplyOptionalArgs = []string{
 	"ver",
@@ -871,7 +882,8 @@ var GetLocationReplyOptionalArgs = []string{
 	"networklocation.speed",
 	"networklocation.timestamp.seconds",
 	"networklocation.timestamp.nanos",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var GetLocationReplyAliasArgs = []string{}
 var GetLocationReplyComments = map[string]string{
@@ -886,11 +898,10 @@ var GetLocationReplyComments = map[string]string{
 	"networklocation.altitude":           "On android only lat and long are guaranteed to be supplied altitude in meters",
 	"networklocation.course":             "course (IOS) / bearing (Android) (degrees east relative to true north)",
 	"networklocation.speed":              "speed (IOS) / velocity (Android) (meters/sec)",
-	"tags":                               "_(optional)_ Vendor specific data",
+	"tags:#.type":                        "type of data",
+	"tags:#.data":                        "data value",
 }
-var GetLocationReplySpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var GetLocationReplySpecialArgs = map[string]string{}
 var AppInstListRequestRequiredArgs = []string{}
 var AppInstListRequestOptionalArgs = []string{
 	"ver",
@@ -907,7 +918,8 @@ var AppInstListRequestOptionalArgs = []string{
 	"gpslocation.timestamp.nanos",
 	"cellid",
 	"limit",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var AppInstListRequestAliasArgs = []string{}
 var AppInstListRequestComments = map[string]string{
@@ -923,11 +935,10 @@ var AppInstListRequestComments = map[string]string{
 	"gpslocation.speed":              "speed (IOS) / velocity (Android) (meters/sec)",
 	"cellid":                         "_(optional)_ Cell id where the client is",
 	"limit":                          "_(optional)_ Limit the number of results, defaults to 3",
-	"tags":                           "_(optional)_ Vendor specific data",
+	"tags:#.type":                    "type of data",
+	"tags:#.data":                    "data value",
 }
-var AppInstListRequestSpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var AppInstListRequestSpecialArgs = map[string]string{}
 var AppinstanceRequiredArgs = []string{}
 var AppinstanceOptionalArgs = []string{
 	"appname",
@@ -1035,7 +1046,8 @@ var AppInstListReplyOptionalArgs = []string{
 	"cloudlets:#.appinstances:#.ports:#.tls",
 	"cloudlets:#.appinstances:#.ports:#.nginx",
 	"cloudlets:#.appinstances:#.orgname",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var AppInstListReplyAliasArgs = []string{}
 var AppInstListReplyComments = map[string]string{
@@ -1062,28 +1074,27 @@ var AppInstListReplyComments = map[string]string{
 	"cloudlets:#.appinstances:#.ports:#.tls":          "TLS termination for this port",
 	"cloudlets:#.appinstances:#.ports:#.nginx":        "use nginx proxy for this port if you really need a transparent proxy (udp only)",
 	"cloudlets:#.appinstances:#.orgname":              "App Organization Name",
-	"tags":                                            "_(optional)_ Vendor specific data",
+	"tags:#.type":                                     "type of data",
+	"tags:#.data":                                     "data value",
 }
-var AppInstListReplySpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var AppInstListReplySpecialArgs = map[string]string{}
 var FqdnListRequestRequiredArgs = []string{}
 var FqdnListRequestOptionalArgs = []string{
 	"ver",
 	"sessioncookie",
 	"cellid",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var FqdnListRequestAliasArgs = []string{}
 var FqdnListRequestComments = map[string]string{
 	"ver":           "API version _(hidden)_ Reserved for future use",
 	"sessioncookie": "Session Cookie from RegisterClientRequest",
 	"cellid":        "_(optional)_ Cell id where the client is",
-	"tags":          "_(optional)_ Vendor specific data",
+	"tags:#.type":   "type of data",
+	"tags:#.data":   "data value",
 }
-var FqdnListRequestSpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var FqdnListRequestSpecialArgs = map[string]string{}
 var AppFqdnRequiredArgs = []string{}
 var AppFqdnOptionalArgs = []string{
 	"appname",
@@ -1112,7 +1123,8 @@ var FqdnListReplyOptionalArgs = []string{
 	"appfqdns:#.fqdns",
 	"appfqdns:#.androidpackagename",
 	"status",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var FqdnListReplyAliasArgs = []string{}
 var FqdnListReplyComments = map[string]string{
@@ -1123,11 +1135,11 @@ var FqdnListReplyComments = map[string]string{
 	"appfqdns:#.fqdns":              "App FQDN",
 	"appfqdns:#.androidpackagename": "_(optional)_ Android package name",
 	"status":                        ", one of FlUndefined, FlSuccess, FlFail",
-	"tags":                          "_(optional)_ Vendor specific data",
+	"tags:#.type":                   "type of data",
+	"tags:#.data":                   "data value",
 }
 var FqdnListReplySpecialArgs = map[string]string{
 	"appfqdns:#.fqdns": "StringArray",
-	"tags":             "StringToString",
 }
 var AppOfficialFqdnRequestRequiredArgs = []string{}
 var AppOfficialFqdnRequestOptionalArgs = []string{
@@ -1142,7 +1154,8 @@ var AppOfficialFqdnRequestOptionalArgs = []string{
 	"gpslocation.speed",
 	"gpslocation.timestamp.seconds",
 	"gpslocation.timestamp.nanos",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var AppOfficialFqdnRequestAliasArgs = []string{}
 var AppOfficialFqdnRequestComments = map[string]string{
@@ -1155,11 +1168,10 @@ var AppOfficialFqdnRequestComments = map[string]string{
 	"gpslocation.altitude":           "On android only lat and long are guaranteed to be supplied altitude in meters",
 	"gpslocation.course":             "course (IOS) / bearing (Android) (degrees east relative to true north)",
 	"gpslocation.speed":              "speed (IOS) / velocity (Android) (meters/sec)",
-	"tags":                           "_(optional)_ Vendor specific data",
+	"tags:#.type":                    "type of data",
+	"tags:#.data":                    "data value",
 }
-var AppOfficialFqdnRequestSpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var AppOfficialFqdnRequestSpecialArgs = map[string]string{}
 var AppOfficialFqdnReplyRequiredArgs = []string{}
 var AppOfficialFqdnReplyOptionalArgs = []string{
 	"ver",
@@ -1173,7 +1185,8 @@ var AppOfficialFqdnReplyOptionalArgs = []string{
 	"ports:#.endport",
 	"ports:#.tls",
 	"ports:#.nginx",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var AppOfficialFqdnReplyAliasArgs = []string{}
 var AppOfficialFqdnReplyComments = map[string]string{
@@ -1188,11 +1201,10 @@ var AppOfficialFqdnReplyComments = map[string]string{
 	"ports:#.endport":      "A non-zero end port indicates a port range from internal port to end port, inclusive.",
 	"ports:#.tls":          "TLS termination for this port",
 	"ports:#.nginx":        "use nginx proxy for this port if you really need a transparent proxy (udp only)",
-	"tags":                 "_(optional)_ Vendor specific data",
+	"tags:#.type":          "type of data",
+	"tags:#.data":          "data value",
 }
-var AppOfficialFqdnReplySpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var AppOfficialFqdnReplySpecialArgs = map[string]string{}
 var DynamicLocGroupRequestRequiredArgs = []string{}
 var DynamicLocGroupRequestOptionalArgs = []string{
 	"ver",
@@ -1201,7 +1213,8 @@ var DynamicLocGroupRequestOptionalArgs = []string{
 	"commtype",
 	"userdata",
 	"cellid",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var DynamicLocGroupRequestAliasArgs = []string{}
 var DynamicLocGroupRequestComments = map[string]string{
@@ -1211,18 +1224,18 @@ var DynamicLocGroupRequestComments = map[string]string{
 	"commtype":      ", one of DlgUndefined, DlgSecure, DlgOpen",
 	"userdata":      "Unused",
 	"cellid":        "_(optional)_ Cell id where the client is",
-	"tags":          "_(optional)_ Vendor specific data",
+	"tags:#.type":   "type of data",
+	"tags:#.data":   "data value",
 }
-var DynamicLocGroupRequestSpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var DynamicLocGroupRequestSpecialArgs = map[string]string{}
 var DynamicLocGroupReplyRequiredArgs = []string{}
 var DynamicLocGroupReplyOptionalArgs = []string{
 	"ver",
 	"status",
 	"errorcode",
 	"groupcookie",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var DynamicLocGroupReplyAliasArgs = []string{}
 var DynamicLocGroupReplyComments = map[string]string{
@@ -1230,11 +1243,10 @@ var DynamicLocGroupReplyComments = map[string]string{
 	"status":      "Status of the reply, one of RsUndefined, RsSuccess, RsFail",
 	"errorcode":   "Error Code based on Failure",
 	"groupcookie": "Group Cookie for Secure Group Communication",
-	"tags":        "_(optional)_ Vendor specific data",
+	"tags:#.type": "type of data",
+	"tags:#.data": "data value",
 }
-var DynamicLocGroupReplySpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var DynamicLocGroupReplySpecialArgs = map[string]string{}
 var QosPositionRequiredArgs = []string{}
 var QosPositionOptionalArgs = []string{
 	"positionid",
@@ -1297,7 +1309,8 @@ var QosPositionRequestOptionalArgs = []string{
 	"bandselection.rat_4g",
 	"bandselection.rat_5g",
 	"cellid",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var QosPositionRequestAliasArgs = []string{}
 var QosPositionRequestComments = map[string]string{
@@ -1314,14 +1327,14 @@ var QosPositionRequestComments = map[string]string{
 	"ltecategory":                                "_(optional)_ Clients device LTE category number.",
 	"bandselection.rat_2g":                       "Radio Access Technologies",
 	"cellid":                                     "_(optional)_ Cell id where the client is",
-	"tags":                                       "_(optional)_ Vendor specific data",
+	"tags:#.type":                                "type of data",
+	"tags:#.data":                                "data value",
 }
 var QosPositionRequestSpecialArgs = map[string]string{
 	"bandselection.rat_2g": "StringArray",
 	"bandselection.rat_3g": "StringArray",
 	"bandselection.rat_4g": "StringArray",
 	"bandselection.rat_5g": "StringArray",
-	"tags":                 "StringToString",
 }
 var QosPositionKpiResultRequiredArgs = []string{}
 var QosPositionKpiResultOptionalArgs = []string{
@@ -1381,7 +1394,8 @@ var QosPositionKpiReplyOptionalArgs = []string{
 	"positionresults:#.latencymin",
 	"positionresults:#.latencyavg",
 	"positionresults:#.latencymax",
-	"tags",
+	"tags:#.type",
+	"tags:#.data",
 }
 var QosPositionKpiReplyAliasArgs = []string{}
 var QosPositionKpiReplyComments = map[string]string{
@@ -1396,8 +1410,7 @@ var QosPositionKpiReplyComments = map[string]string{
 	"positionresults:#.gpslocation.course":             "course (IOS) / bearing (Android) (degrees east relative to true north)",
 	"positionresults:#.gpslocation.speed":              "speed (IOS) / velocity (Android) (meters/sec)",
 	"positionresults:#.dluserthroughputmin":            "throughput",
-	"tags":                                             "_(optional)_ Vendor specific data",
+	"tags:#.type":                                      "type of data",
+	"tags:#.data":                                      "data value",
 }
-var QosPositionKpiReplySpecialArgs = map[string]string{
-	"tags": "StringToString",
-}
+var QosPositionKpiReplySpecialArgs = map[string]string{}

--- a/setup-env/e2e-tests/e2e-tests.go
+++ b/setup-env/e2e-tests/e2e-tests.go
@@ -243,7 +243,11 @@ func runTests(dirName, fileName, progName string, depth int, mods []string) (int
 				}
 				continue
 			}
-			cmdstr := fmt.Sprintf("%s -testConfig '%s' -testSpec '%s' -mods '%s'", progName, configStr, string(testSpec), string(modsSpec))
+			sof := ""
+			if *stopOnFail {
+				sof = "-stop"
+			}
+			cmdstr := fmt.Sprintf("%s -testConfig '%s' -testSpec '%s' -mods '%s' %s", progName, configStr, string(testSpec), string(modsSpec), sof)
 			cmd := exec.Command("sh", "-c", cmdstr)
 			var out bytes.Buffer
 			var stderr bytes.Buffer


### PR DESCRIPTION
This changes the event log index name to have the deployment tag in it. This allows all deployments (main, qa, etc) to share the same ElasticSearch backend. It will still require a few more changes from Venky to modify ansible to set the deployment tag for all our services.

Ah, also I just realized chef will need to be updated as well to pass it to CRM/etc. I may ask Ashish to do that.

Since every service now needs the deployment tag to be able to log to the correct index in ES, I moved the deployment tag flag to the common nodeMgr.

Also added a tweak to the e2e-test code to stop immediately on failure (and avoid running multiple show commands after the failure was hit).