### PR TITLE
EDGECLOUD-3862: Cloudlet Offline event is not getting generated when CRM service is killed

### DIFF
--- a/controller/cloudletinfo_api.go
+++ b/controller/cloudletinfo_api.go
@@ -154,6 +154,7 @@ func (s *CloudletInfoApi) Flush(ctx context.Context, notifyId int64) {
 	}
 	s.cache.Mux.Unlock()
 
+	// this creates a new span if there was none - which can happen if this is a cancelled context
 	span := log.SpanFromContext(ctx)
 	ectx := log.ContextWithSpan(context.Background(), span)
 


### PR DESCRIPTION
* In Flush function, context is already cancelled and hence event was not being sent to ES
* Create a new context for event send to ES