### PR TITLE
EDGECLOUD-3650 crm access key part 2

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -1224,7 +1224,7 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		autoerr := clusterInstApi.deleteClusterInstInternal(cctx, &clusterInst, cb)
 		if autoerr != nil {
 			log.InfoLog("Failed to delete auto-ClusterInst",
-				"clusterInst", clusterInst, "err", err)
+				"clusterInst", clusterInst, "err", autoerr)
 		}
 	}
 	return err

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -594,6 +594,7 @@ func validateClusterInstUpdates(ctx context.Context, stm concurrency.STM, in *ed
 }
 
 func (s *ClusterInstApi) deleteClusterInstInternal(cctx *CallContext, in *edgeproto.ClusterInst, inCb edgeproto.ClusterInstApi_DeleteClusterInstServer) (reterr error) {
+	log.SpanLog(inCb.Context(), log.DebugLevelApi, "delete ClusterInst internal", "key", in.Key)
 	if err := in.Key.ValidateKey(); err != nil {
 		return err
 	}
@@ -629,7 +630,7 @@ func (s *ClusterInstApi) deleteClusterInstInternal(cctx *CallContext, in *edgepr
 				cb.Send(&edgeproto.Result{Message: fmt.Sprintf("Previous delete failed, %v", in.Errors)})
 				cb.Send(&edgeproto.Result{Message: "Use CreateClusterInst to rebuild, and try again"})
 			}
-			return errors.New("ClusterInst busy, cannot delete")
+			return fmt.Errorf("ClusterInst busy (%s), cannot delete", in.State.String())
 		}
 		prevState = in.State
 		in.State = edgeproto.TrackedState_DELETE_PREPARE

--- a/controller/dummy_info_responder.go
+++ b/controller/dummy_info_responder.go
@@ -23,6 +23,7 @@ func NewDummyInfoResponder(appInstCache *edgeproto.AppInstCache, clusterInstCach
 		ClusterInstCache:    clusterInstCache,
 		RecvAppInstInfo:     recvAppInstInfo,
 		RecvClusterInstInfo: recvClusterInstInfo,
+		enable:              true,
 	}
 	d.AppInstCache.SetNotifyCb(d.runAppInstChanged)
 	d.ClusterInstCache.SetNotifyCb(d.runClusterInstChanged)
@@ -46,6 +47,7 @@ type DummyInfoResponder struct {
 	simulateClusterCreateFailure bool
 	simulateClusterUpdateFailure bool
 	simulateClusterDeleteFailure bool
+	enable                       bool
 }
 
 func (d *DummyInfoResponder) SetSimulateAppCreateFailure(state bool) {
@@ -65,10 +67,16 @@ func (d *DummyInfoResponder) SetSimulateClusterDeleteFailure(state bool) {
 }
 
 func (d *DummyInfoResponder) runClusterInstChanged(ctx context.Context, key *edgeproto.ClusterInstKey, old *edgeproto.ClusterInst, modRev int64) {
+	if !d.enable {
+		return
+	}
 	go d.clusterInstChanged(ctx, key, modRev)
 }
 
 func (d *DummyInfoResponder) runAppInstChanged(ctx context.Context, key *edgeproto.AppInstKey, old *edgeproto.AppInst, modRev int64) {
+	if !d.enable {
+		return
+	}
 	go d.appInstChanged(ctx, key, modRev)
 }
 


### PR DESCRIPTION
These changes actually fix a very intermittent error in unit tests. The problem was the "force state" function would trigger that dummy info responder to send back the next state transition (which happened in a separate thread), causing a race condition between the responder causing a state change and the test thread running ClusterInst delete, which expected a certain state for the ClusterInst. The fix is for force state, disable the responder, because we don't actually want it to trigger a subsequent state change.