### PR TITLE
EDGECLOUD-3268: In the absence of cloudlet ResTagMap reject a gpu flavor

### DIFF
--- a/vmspec/vmspec_matcher.go
+++ b/vmspec/vmspec_matcher.go
@@ -274,17 +274,15 @@ func GetVMSpec(ctx context.Context, nodeflavor edgeproto.Flavor, cli edgeproto.C
 				continue
 			}
 		} else {
-			// xxx hack back: Our mex flavor is not requesting any optional resources. (OptResMap in mex flavor = nil)
+			// Our mex flavor is not requesting any optional resources. (OptResMap in mex flavor = nil)
 			// so to prevent _any_ race condition or absence of cloudlet config, skip any o.s. flavor with
-			// "gpu" in its name. xxx
+			// "gpu" in its name.
 			if strings.Contains(flavor.Name, "gpu") {
 				log.SpanLog(ctx, log.DebugLevelApi, "No opt resource requested, skipping gpu ", "flavor", flavor.Name)
 				continue
 			}
 			// Finally, if the os flavor we're about to return happens to be offering an optional resource
-			// that was not requested, we need to skip it. (if no cloudlet ResTagMap map[string]*ResTagTableKey, OSFlavorResources
-			// cannot reject a flavor by looking at the  o.s. flavor propteries. This config is manditory when the O.S. instance
-			// has gpu flavors available, whether anyone is using mex gpu flavors or not.
+			// that was not requested, we need to skip it.
 			if _, cnt := OSFlavorResources(ctx, *flavor, tbls); cnt != 0 {
 				log.SpanLog(ctx, log.DebugLevelApi, "No opt resource requested, skipping ", "flavor", flavor.Name)
 				continue


### PR DESCRIPTION
This brings back (hopefully temporarily) the test in GetVMSpec, that if no cloudlet config exists for ResTagMap (for whatever reason), and the OpenStack instance the cloudlet is being deployed on has gpu flavors to offer, the existing code can not tell the matching OpenStack flavor has an optional resource as it has no access to the OpenStack Flavor properties. This simply rejects such a case by checking if the os flavor name has "gpu" in it. The two SpanLogs:

log.SpanLog(ctx, log.DebugLevelApi, "No opt resource requested, skipping gpu ", "flavor", flavor.Name)
and 
log.SpanLog(ctx, log.DebugLevelApi, "No opt resource requested, skipping ", "flavor", flavor.Name)

Can be used to tell if the required cloudlet config exists or not. The first indicates no config was present on the cloudlet.

This leaves EC-3550 open for the CLI/ and maybe? UI changes to proceed to cover this case, basically making this config mandatory and supported, rather than optional as it is today.