### PR TITLE
EDGECLOUD-3833: SimpleHTTP on Load Balancer is Blocking Port 8000

### DIFF
--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -35,7 +35,8 @@ var ValidConfigKinds = map[string]struct{}{
 }
 
 var ReservedPlatformPorts = map[string]string{
-	"tcp:22": "Platform inter-node SSH",
+	"tcp:22":    "Platform inter-node SSH",
+	"tcp:20800": "Kubernetes master join server",
 }
 
 // sort each slice by key


### PR DESCRIPTION
Reserve this port as it is used to serve k8s join cmd to k8s worker nodes.