### PR TITLE
EDGECLOUD-4089 Deletion of app inst fails when controller and CRM are running different versions

### DIFF
--- a/controller/appinstinfo_api.go
+++ b/controller/appinstinfo_api.go
@@ -23,7 +23,8 @@ func (s *AppInstInfoApi) Update(ctx context.Context, in *edgeproto.AppInstInfo, 
 }
 
 func (s *AppInstInfoApi) Delete(ctx context.Context, in *edgeproto.AppInstInfo, rev int64) {
-	// no-op
+	// for backwards compatibility
+	appInstApi.DeleteFromInfo(ctx, in)
 }
 
 func (s *AppInstInfoApi) Flush(ctx context.Context, notifyId int64) {

--- a/controller/clusterinstinfo_api.go
+++ b/controller/clusterinstinfo_api.go
@@ -23,7 +23,8 @@ func (s *ClusterInstInfoApi) Update(ctx context.Context, in *edgeproto.ClusterIn
 }
 
 func (s *ClusterInstInfoApi) Delete(ctx context.Context, in *edgeproto.ClusterInstInfo, rev int64) {
-	// no-op
+	// for backwards compatibility
+	clusterInstApi.DeleteFromInfo(ctx, in)
 }
 
 func (s *ClusterInstInfoApi) Flush(ctx context.Context, notifyId int64) {


### PR DESCRIPTION
* New versions (R2.4) of CRM sets `DELETE_DONE` state to indicate deletion of clusterInst/appInst. And hence controller also expects the same. Support old way of deletion as well for backwards compatibility as old versions (<2.4), deleted *Info obj to indicate deletion of clusterInst/appInst obj.