### PR TITLE
EDGECLOUD-4090: Etcd database growing very fast during QA regressions

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -1289,16 +1289,8 @@ func (s *AppInstApi) UpdateFromInfo(ctx context.Context, in *edgeproto.AppInstIn
 			inst.HealthCheck == edgeproto.HealthCheck_HEALTH_CHECK_UNKNOWN {
 			inst.HealthCheck = edgeproto.HealthCheck_HEALTH_CHECK_OK
 		}
-		lastMsgId := int(inst.Status.MsgCount)
-		if lastMsgId < len(in.Status.Msgs) {
-			inst.Status.Msgs = []string{}
-			for ii := lastMsgId; ii < len(in.Status.Msgs); ii++ {
-				inst.Status.Msgs = append(inst.Status.Msgs, in.Status.Msgs[ii])
-			}
-			inst.Status.MsgCount += uint32(len(inst.Status.Msgs))
-		} else {
-			inst.Status.Msgs = []string{}
-		}
+		// update only diff of status msgs
+		edgeproto.UpdateStatusDiff(&in.Status, &inst.Status)
 		if inst.State == in.State {
 			// already in that state
 			if in.State == edgeproto.TrackedState_READY {

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -811,17 +811,8 @@ func (s *ClusterInstApi) UpdateFromInfo(ctx context.Context, in *edgeproto.Clust
 			return nil
 		}
 		inst.Resources = in.Resources
-		lastMsgId := int(inst.Status.MsgCount)
-		if lastMsgId < len(in.Status.Msgs) {
-			inst.Status.Msgs = []string{}
-			for ii := lastMsgId; ii < len(in.Status.Msgs); ii++ {
-				inst.Status.Msgs = append(inst.Status.Msgs, in.Status.Msgs[ii])
-			}
-			inst.Status.MsgCount += uint32(len(inst.Status.Msgs))
-		} else {
-			inst.Status.Msgs = []string{}
-		}
-
+		// update only diff of status msgs
+		edgeproto.UpdateStatusDiff(&in.Status, &inst.Status)
 		if inst.State == in.State {
 			log.SpanLog(ctx, log.DebugLevelApi, "no state change")
 			s.store.STMPut(stm, &inst)

--- a/edgeproto/appinst.pb.go
+++ b/edgeproto/appinst.pb.go
@@ -3524,7 +3524,6 @@ func (c *AppInstCache) WaitForState(ctx context.Context, key *AppInstKey, target
 	failed := make(chan bool, 1)
 	var lastMsg string
 	var err error
-	var isStatusMsgs bool
 
 	cancel := c.WatchKey(key, func(ctx context.Context) {
 		info := AppInst{}
@@ -3541,8 +3540,7 @@ func (c *AppInstCache) WaitForState(ctx context.Context, key *AppInstKey, target
 					lastMsg = msg
 				}
 			} else {
-				if len(info.Status.Msgs) > 0 {
-					isStatusMsgs = true
+				if len(info.Status.Msgs) > 0 || info.Status.MsgCount > 0 {
 					for ii := 0; ii < len(info.Status.Msgs); ii++ {
 						if lastMsg == info.Status.Msgs[ii] {
 							continue
@@ -3560,9 +3558,7 @@ func (c *AppInstCache) WaitForState(ctx context.Context, key *AppInstKey, target
 						msg = TrackedState_CamelName[int32(curState)]
 					}
 					lastMsg = msg
-					if !isStatusMsgs {
-						send(&Result{Message: msg})
-					}
+					send(&Result{Message: msg})
 				}
 			}
 		}

--- a/edgeproto/clusterinst.pb.go
+++ b/edgeproto/clusterinst.pb.go
@@ -2747,7 +2747,6 @@ func (c *ClusterInstCache) WaitForState(ctx context.Context, key *ClusterInstKey
 	failed := make(chan bool, 1)
 	var lastMsg string
 	var err error
-	var isStatusMsgs bool
 
 	cancel := c.WatchKey(key, func(ctx context.Context) {
 		info := ClusterInst{}
@@ -2764,8 +2763,7 @@ func (c *ClusterInstCache) WaitForState(ctx context.Context, key *ClusterInstKey
 					lastMsg = msg
 				}
 			} else {
-				if len(info.Status.Msgs) > 0 {
-					isStatusMsgs = true
+				if len(info.Status.Msgs) > 0 || info.Status.MsgCount > 0 {
 					for ii := 0; ii < len(info.Status.Msgs); ii++ {
 						if lastMsg == info.Status.Msgs[ii] {
 							continue
@@ -2783,9 +2781,7 @@ func (c *ClusterInstCache) WaitForState(ctx context.Context, key *ClusterInstKey
 						msg = TrackedState_CamelName[int32(curState)]
 					}
 					lastMsg = msg
-					if !isStatusMsgs {
-						send(&Result{Message: msg})
-					}
+					send(&Result{Message: msg})
 				}
 			}
 		}

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -868,3 +868,19 @@ func (s *AutoProvPolicy) GetCloudletKeys() map[CloudletKey]struct{} {
 	}
 	return keys
 }
+
+// Status from info will always contain the full status update list,
+// changes we copy to status that is saved to etcd is only the diff
+// from the last update.
+func UpdateStatusDiff(infoStatus *StatusInfo, diffStatus *StatusInfo) {
+	lastMsgId := int(diffStatus.MsgCount)
+	if lastMsgId < len(infoStatus.Msgs) {
+		diffStatus.Msgs = []string{}
+		for ii := lastMsgId; ii < len(infoStatus.Msgs); ii++ {
+			diffStatus.Msgs = append(diffStatus.Msgs, infoStatus.Msgs[ii])
+		}
+		diffStatus.MsgCount += uint32(len(diffStatus.Msgs))
+	} else {
+		diffStatus.Msgs = []string{}
+	}
+}

--- a/edgeproto/objs_test.go
+++ b/edgeproto/objs_test.go
@@ -1,0 +1,30 @@
+package edgeproto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testStatusMsgs(t *testing.T, infoStatus, diffStatus *StatusInfo, inMsgs, outMsgs []string, msgCnt int) {
+	infoStatus.Msgs = inMsgs
+	UpdateStatusDiff(infoStatus, diffStatus)
+	require.Equal(t, len(diffStatus.Msgs), len(outMsgs))
+	require.Equal(t, diffStatus.MsgCount, uint32(msgCnt))
+	for ii := 0; ii < len(diffStatus.Msgs); ii++ {
+		require.Equal(t, diffStatus.Msgs[ii], outMsgs[ii])
+	}
+}
+
+func TestUpdateStatusDiff(t *testing.T) {
+	diffStatus := StatusInfo{}
+	infoStatus := StatusInfo{}
+	testStatusMsgs(t, &infoStatus, &diffStatus, []string{"1"}, []string{"1"}, 1)
+	testStatusMsgs(t, &infoStatus, &diffStatus, []string{"1", "2"}, []string{"2"}, 2)
+	testStatusMsgs(t, &infoStatus, &diffStatus, []string{"1", "2"}, []string{}, 2)
+	testStatusMsgs(t, &infoStatus, &diffStatus, []string{"1", "2", "3"}, []string{"3"}, 3)
+	testStatusMsgs(t, &infoStatus, &diffStatus, []string{"1", "2"}, []string{}, 3)
+	testStatusMsgs(t, &infoStatus, &diffStatus, []string{"1", "2", "3", "4", "5"}, []string{"4", "5"}, 5)
+	testStatusMsgs(t, &infoStatus, &diffStatus, []string{"1", "2", "3"}, []string{}, 5)
+	testStatusMsgs(t, &infoStatus, &diffStatus, []string{"1", "2", "3", "4", "5"}, []string{}, 5)
+}

--- a/edgeproto/status_info.go
+++ b/edgeproto/status_info.go
@@ -50,7 +50,7 @@ func (s *StatusInfo) SetTask(task string) {
 	s.TaskNumber++
 	s.TaskName = task
 	s.StepName = ""
-
+	s.MsgCount++
 	s.Msgs = append(s.Msgs, s.ToString())
 }
 

--- a/edgeproto/vmpool.pb.go
+++ b/edgeproto/vmpool.pb.go
@@ -2542,7 +2542,6 @@ func (c *VMPoolCache) WaitForState(ctx context.Context, key *VMPoolKey, targetSt
 	failed := make(chan bool, 1)
 	var lastMsg string
 	var err error
-	var isStatusMsgs bool
 
 	cancel := c.WatchKey(key, func(ctx context.Context) {
 		info := VMPool{}
@@ -2559,8 +2558,7 @@ func (c *VMPoolCache) WaitForState(ctx context.Context, key *VMPoolKey, targetSt
 					lastMsg = msg
 				}
 			} else {
-				if len(info.Status.Msgs) > 0 {
-					isStatusMsgs = true
+				if len(info.Status.Msgs) > 0 || info.Status.MsgCount > 0 {
 					for ii := 0; ii < len(info.Status.Msgs); ii++ {
 						if lastMsg == info.Status.Msgs[ii] {
 							continue
@@ -2578,9 +2576,7 @@ func (c *VMPoolCache) WaitForState(ctx context.Context, key *VMPoolKey, targetSt
 						msg = TrackedState_CamelName[int32(curState)]
 					}
 					lastMsg = msg
-					if !isStatusMsgs {
-						send(&Result{Message: msg})
-					}
+					send(&Result{Message: msg})
 				}
 			}
 		}

--- a/protoc-gen-gomex/mexgen/mex.go
+++ b/protoc-gen-gomex/mexgen/mex.go
@@ -1505,7 +1505,6 @@ func (c *{{.Name}}Cache) WaitForState(ctx context.Context, key *{{.KeyType}}, ta
 	failed := make(chan bool, 1)
 	var lastMsg string
 	var err error
-	var isStatusMsgs bool
 
 	cancel := c.WatchKey(key, func(ctx context.Context) {
 		info := {{.Name}}{}
@@ -1522,8 +1521,7 @@ func (c *{{.Name}}Cache) WaitForState(ctx context.Context, key *{{.KeyType}}, ta
 					lastMsg = msg
 				}
 			} else {
-				if len(info.Status.Msgs) > 0 {
-					isStatusMsgs = true
+				if len(info.Status.Msgs) > 0  || info.Status.MsgCount > 0 {
 					for ii := 0; ii < len(info.Status.Msgs); ii++ {
 						if lastMsg == info.Status.Msgs[ii] {
 							continue
@@ -1541,9 +1539,7 @@ func (c *{{.Name}}Cache) WaitForState(ctx context.Context, key *{{.KeyType}}, ta
 						msg = {{.WaitForState}}_CamelName[int32(curState)]
 					}
 					lastMsg = msg
-					if !isStatusMsgs {
-						send(&Result{Message: msg})
-					}
+					send(&Result{Message: msg})
 				}
 			}
 		}


### PR DESCRIPTION
* Made the following optimization:
* CRM sends the message in following order:
  * 1, 2
  * 1, 2, 3
  * 1, 2, 3
  * 1, 2, 3, 4
  * 1, 2, 3
* Then controller will store following messages per status obj it receives from CRM:
  * 1, 2
  * 3
  *    
  * 4
  * 
* Rather than storing all the messages, we now only store above messages
* Passes all the tests