### PR TITLE
EDGECLOUD-4085 MEL - How we are counting Samsung devices should be changed

### DIFF
--- a/d-match-engine/dme-server/dme-stats.go
+++ b/d-match-engine/dme-server/dme-stats.go
@@ -260,7 +260,7 @@ func (s *DmeStats) UnaryStatsInterceptor(ctx context.Context, req interface{}, i
 		if err == nil {
 			// We want to count app registrations, not MEL platform registers
 			if strings.Contains(strings.ToLower(typ.UniqueIdType), strings.ToLower(cloudcommon.OrganizationSamsung)) &&
-				!strings.Contains(strings.ToLower(typ.UniqueIdType), strings.ToLower(cloudcommon.SamsungEnablingLayer)) {
+				!cloudcommon.IsPlatformApp(typ.OrgName, typ.AppName) {
 				go recordDevice(ctx, typ)
 			}
 		}

--- a/setup-env/e2e-tests/data/device_show.yml
+++ b/setup-env/e2e-tests/data/device_show.yml
@@ -1,6 +1,6 @@
 devices:
 - key:
-    uniqueidtype: Samsung
+    uniqueidtype: GSAFKDF:Samsung:SamsungEnablingLayer
     uniqueid: "123"
   firstseen:
     seconds: 1596232439


### PR DESCRIPTION
A follow up to https://github.com/mobiledgex/edge-cloud/pull/1155
We found out that our logic was incorrect and what we should do is to not count device registers that have app name and app org set to `Samsung` and `SamsungEnablingLayer`
Changed logic to detect platfrom MEL client based on what MEL will send.