### PR TITLE
EDGECLOUD-4111: Hide ChefClient private key from ShowCloudlet output

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -1215,6 +1215,7 @@ func (s *CloudletApi) deleteCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 func (s *CloudletApi) ShowCloudlet(in *edgeproto.Cloudlet, cb edgeproto.CloudletApi_ShowCloudletServer) error {
 	err := s.cache.Show(in, func(obj *edgeproto.Cloudlet) error {
 		obj.Status = edgeproto.StatusInfo{}
+		obj.ChefClientKey = make(map[string]string)
 		err := cb.Send(obj)
 		return err
 	})


### PR DESCRIPTION
* Quick change to hide chefClient private key from ShowCloudlet output
* Note: We need this key for `GetCloudletManifest` and hence we cannot avoid storing it in etcd.