### PR TITLE
EDGECLOUD-4115 cloudlet chef client keys missing

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -1214,9 +1214,10 @@ func (s *CloudletApi) deleteCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 
 func (s *CloudletApi) ShowCloudlet(in *edgeproto.Cloudlet, cb edgeproto.CloudletApi_ShowCloudletServer) error {
 	err := s.cache.Show(in, func(obj *edgeproto.Cloudlet) error {
-		obj.Status = edgeproto.StatusInfo{}
-		obj.ChefClientKey = make(map[string]string)
-		err := cb.Send(obj)
+		copy := *obj
+		copy.Status = edgeproto.StatusInfo{}
+		copy.ChefClientKey = make(map[string]string)
+		err := cb.Send(&copy)
 		return err
 	})
 	return err


### PR DESCRIPTION
Fixes issue where calling ShowCloudlet would clear the Cloudlet's chef client keys. The problem is in the show func, obj is actually the data in the cache. So modifying it modifies the data in the cache, which is not what we want. We need to make a copy of the data before modifying it. Note that cb.Send(obj) makes an implicit copy because it marshals the obj.