### PR TITLE
Vars validate

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -426,6 +426,7 @@ func (s *AppApi) configureApp(ctx context.Context, stm concurrency.STM, in *edge
 			return err
 		}
 	}
+
 	if in.DefaultFlavor.Name != "" && !flavorApi.store.STMGet(stm, &in.DefaultFlavor, nil) {
 		return in.DefaultFlavor.NotFoundError()
 	}


### PR DESCRIPTION
EDGECLOUD-3238 
EDGECLOUD-3232

The type AppConfigEnvYaml is a no-op for everything besides Kubernetes.   This PR adds additional validation so it is not provisioned in other cases.