### PR TITLE
EDGECLOUD-3549: AddVMPoolMember allows adding external/internal address of 0.0.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ envoy/certs/envoyTlsCerts.crt
 controller/envoy/certs/envoyTlsCerts.crt
 controller/data_test.json
 controller/etcdLocal_data/*
+cloud-resource-manager/cmd/crmserver/envoy/*

--- a/controller/vmpool_api_test.go
+++ b/controller/vmpool_api_test.go
@@ -58,11 +58,30 @@ func testAddRemoveVM(t *testing.T, ctx context.Context) {
 	cm2.Vm = edgeproto.VM{
 		Name: "vmY",
 		NetInfo: edgeproto.VMNetInfo{
+			ExternalIp: "0.0.0.0",
+			InternalIp: "192.168.100.121",
+		},
+	}
+	_, err = vmPoolApi.AddVMPoolMember(ctx, &cm2)
+	require.NotNil(t, err, "invalid external ip")
+
+	cm2.Vm = edgeproto.VM{
+		Name: "vmY",
+		NetInfo: edgeproto.VMNetInfo{
+			ExternalIp: "192.168.1.121",
+			InternalIp: "127.0.0.1",
+		},
+	}
+	_, err = vmPoolApi.AddVMPoolMember(ctx, &cm2)
+	require.NotNil(t, err, "invalid internal ip")
+
+	cm2.Vm = edgeproto.VM{
+		Name: "vmY",
+		NetInfo: edgeproto.VMNetInfo{
 			ExternalIp: "192.168.1.121",
 			InternalIp: "192.168.100.121",
 		},
 	}
-
 	_, err = vmPoolApi.AddVMPoolMember(ctx, &cm2)
 	require.Nil(t, err, "add cloudlet vm to cloudlet vm pool")
 

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -294,18 +294,31 @@ func (s *VM) ValidateName() error {
 	return nil
 }
 
+var invalidVMPoolIPs = map[string]struct{}{
+	"0.0.0.0":   struct{}{},
+	"127.0.0.1": struct{}{},
+}
+
 func (s *VM) Validate() error {
 	if err := s.ValidateName(); err != nil {
 		return err
 	}
-	if s.NetInfo.ExternalIp != "" && net.ParseIP(s.NetInfo.ExternalIp) == nil {
-		return fmt.Errorf("Invalid Address: %s", s.NetInfo.ExternalIp)
+	if s.NetInfo.ExternalIp != "" {
+		if net.ParseIP(s.NetInfo.ExternalIp) == nil {
+			return fmt.Errorf("Invalid Address: %s", s.NetInfo.ExternalIp)
+		}
+		if _, ok := invalidVMPoolIPs[s.NetInfo.ExternalIp]; ok {
+			return fmt.Errorf("Invalid Address: %s", s.NetInfo.ExternalIp)
+		}
 	}
 	if s.NetInfo.InternalIp == "" {
 		return fmt.Errorf("Missing internal IP for VM: %s", s.Name)
 	}
 	if net.ParseIP(s.NetInfo.InternalIp) == nil {
 		return fmt.Errorf("Invalid Address: %s", s.NetInfo.InternalIp)
+	}
+	if _, ok := invalidVMPoolIPs[s.NetInfo.InternalIp]; ok {
+		return fmt.Errorf("Invalid Address: %s", s.NetInfo.ExternalIp)
 	}
 	return nil
 }


### PR DESCRIPTION
* Disallow 0.0.0.0/127.0.0.1, otherwise it will pass our crm side SSH validation because most of the times ssh to localhost will work