### PR TITLE
EDGECLOUD-3870: [mcctl] ShowDevice Should Return Error When Account is Unprviledged

### DIFF
--- a/testutil/run.go
+++ b/testutil/run.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 )
@@ -51,6 +52,11 @@ func (r *Run) CheckErrs(api, tag string) {
 	}
 	// should not be any errors
 	for _, err := range r.Errs {
+		if strings.HasPrefix(api, "show") {
+			if strings.Contains(err.Msg, "Forbidden") {
+				continue
+			}
+		}
 		log.Printf("\"%s\" run %s failed: %s\n", api, err.Desc, err.Msg)
 		*r.Rc = false
 	}


### PR DESCRIPTION
* Ignore `Forbidden` error for Show based output. Output will just be empty.
* Corresponding PR: https://github.com/mobiledgex/edge-cloud-infra/pull/1244