### PR TITLE
fix appinst dns name collisions

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -365,7 +365,7 @@ func (s *AppInstApi) checkForAppinstCollisions(ctx context.Context, key *edgepro
 		existingSanitizedKey := util.DNSSanitize(existingKeyString)
 		if sanitizedKey == existingSanitizedKey && keyString != existingKeyString {
 			log.SpanLog(ctx, log.DebugLevelApi, "AppInst collision", "keyString", keyString, "existingKeyString", existingKeyString, "sanitizedKey", sanitizedKey)
-			return fmt.Errorf("Cannot deploy AppInst due to DNS name collision with existing instance %s", existingKeyString)
+			return fmt.Errorf("Cannot deploy AppInst due to DNS name collision with existing instance %s - %s", existingKeyString, sanitizedKey)
 		}
 	}
 	return nil


### PR DESCRIPTION
EDGECLOUD-2345

If 2 AppInsts have the same name after sanitization in the CRM, various problems may arise:
- DNS collision
- k8s deployment name collision
- others

The solution to to check to ensure there are no conflicting AppInsts deployed which would have the same name after performing sanitization. 

It's not easy for the controller to determine what makes a unique appinst name in the CRM, as there are different node name sanitization implementations to fit the IaaS.   But DNSSanitize is more stringent than any others, and the most difficult to detect if it were to happen, so it is used here.