### PR TITLE
settings range validation

### DIFF
--- a/edgeproto/field_validator.go
+++ b/edgeproto/field_validator.go
@@ -24,12 +24,12 @@ func (s *FieldValidator) CheckGT(field string, val, gt int64) {
 	}
 }
 
-func (s *FieldValidator) CheckFloatGT(field string, val, gt float64) {
+func (s *FieldValidator) CheckFloatGE(field string, val, gt float64) {
 	if s.err != nil {
 		return
 	}
-	if val <= gt {
-		s.err = fmt.Errorf("%s must be greater than %f", s.fieldDesc[field], gt)
+	if val < gt {
+		s.err = fmt.Errorf("%s must be greater than or equal to %f", s.fieldDesc[field], gt)
 	}
 }
 

--- a/edgeproto/settings.go
+++ b/edgeproto/settings.go
@@ -71,7 +71,7 @@ func (s *Settings) Validate(fields map[string]struct{}) error {
 		case SettingsFieldAutoDeployIntervalSec:
 			v.CheckGT(f, int64(s.AutoDeployIntervalSec), 0)
 		case SettingsFieldAutoDeployOffsetSec:
-			v.CheckFloatGT(f, float64(s.AutoDeployOffsetSec), 0)
+			v.CheckFloatGE(f, float64(s.AutoDeployOffsetSec), 0)
 		case SettingsFieldAutoDeployMaxIntervals:
 			v.CheckGT(f, int64(s.AutoDeployMaxIntervals), 0)
 		case SettingsFieldLoadBalancerMaxPortRange:


### PR DESCRIPTION
EDGECLOUD-4168
EDGECLOUD-4167
EDGECLOUD-4189

There have been a several bugs opened because of missing validation of settings fields.  This adds validation for the ones missing, and also ensures that fields added in future get added to the range validation switch statement