### PR TITLE
EDGECLOUD-4277 controller crash in vault login

### DIFF
--- a/vault/auth_approle.go
+++ b/vault/auth_approle.go
@@ -28,6 +28,9 @@ func (s *AppRoleAuth) Login(client *api.Client) error {
 	if err != nil {
 		return err
 	}
+	if resp == nil {
+		return fmt.Errorf("Empty response from Vault for approle login, possible 404 not found")
+	}
 	if resp.Auth == nil {
 		return fmt.Errorf("no auth info returned")
 	}


### PR DESCRIPTION
Fix crash during Vault login. Apparently the response from write can be nil even when err is nil. From the Vault client code it appears to happen if there's a 404 response from Vault.