### PR TITLE
Fix unit tests

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -1422,7 +1422,7 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 	// this is retained for old autoclusters that are not reservable,
 	// and can be removed once no old autoclusters exist anymore.
 	clusterInst := edgeproto.ClusterInst{}
-	if clusterInstApi.Get(&clusterInstKey, &clusterInst) && clusterInst.Auto && !appInstApi.UsesClusterInst(&clusterInstKey) && clusterInst.ReservationEndedAt.Seconds == 0 {
+	if clusterInstApi.Get(&clusterInstKey, &clusterInst) && clusterInst.Auto && !appInstApi.UsesClusterInst(&clusterInstKey) && !clusterInst.Reservable {
 		cb.Send(&edgeproto.Result{Message: "Deleting auto-ClusterInst"})
 		autoerr := clusterInstApi.deleteClusterInstInternal(cctx, &clusterInst, cb)
 		if autoerr != nil {


### PR DESCRIPTION
* Delete auto clusters only if they are not auto reservable cluster
* This deletion should only happen for autoclusters created before Jon's changes. Currently, it fails unit tests as deletion of Auto Apps deletes this cluster during DeleteClusterInst API run i.e.
DeleteClusterInst -> Delete Auto Apps -> If any auto apps were using this cluster -> DeleteClusterInst