### PR TITLE
Fix mex generator matches function for slices

### DIFF
--- a/edgeproto/alert.pb.go
+++ b/edgeproto/alert.pb.go
@@ -363,7 +363,7 @@ func (m *Alert) Matches(o *Alert, fopts ...MatchOpt) bool {
 		return false
 	}
 	if !opts.Filter || o.Labels != nil {
-		if m.Labels == nil && o.Labels != nil || m.Labels != nil && o.Labels == nil {
+		if len(m.Labels) == 0 && len(o.Labels) > 0 || len(m.Labels) > 0 && len(o.Labels) == 0 {
 			return false
 		} else if m.Labels != nil && o.Labels != nil {
 			if !opts.Filter && len(m.Labels) != len(o.Labels) {
@@ -381,7 +381,7 @@ func (m *Alert) Matches(o *Alert, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Annotations != nil {
-		if m.Annotations == nil && o.Annotations != nil || m.Annotations != nil && o.Annotations == nil {
+		if len(m.Annotations) == 0 && len(o.Annotations) > 0 || len(m.Annotations) > 0 && len(o.Annotations) == 0 {
 			return false
 		} else if m.Annotations != nil && o.Annotations != nil {
 			if !opts.Filter && len(m.Annotations) != len(o.Annotations) {

--- a/edgeproto/app.pb.go
+++ b/edgeproto/app.pb.go
@@ -1575,7 +1575,7 @@ func (m *App) Matches(o *App, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Configs != nil {
-		if m.Configs == nil && o.Configs != nil || m.Configs != nil && o.Configs == nil {
+		if len(m.Configs) == 0 && len(o.Configs) > 0 || len(m.Configs) > 0 && len(o.Configs) == 0 {
 			return false
 		} else if m.Configs != nil && o.Configs != nil {
 			if !opts.Filter && len(m.Configs) != len(o.Configs) {
@@ -1628,7 +1628,7 @@ func (m *App) Matches(o *App, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.AutoProvPolicies != nil {
-		if m.AutoProvPolicies == nil && o.AutoProvPolicies != nil || m.AutoProvPolicies != nil && o.AutoProvPolicies == nil {
+		if len(m.AutoProvPolicies) == 0 && len(o.AutoProvPolicies) > 0 || len(m.AutoProvPolicies) > 0 && len(o.AutoProvPolicies) == 0 {
 			return false
 		} else if m.AutoProvPolicies != nil && o.AutoProvPolicies != nil {
 			if !opts.Filter && len(m.AutoProvPolicies) != len(o.AutoProvPolicies) {
@@ -1661,7 +1661,7 @@ func (m *App) Matches(o *App, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RequiredOutboundConnections != nil {
-		if m.RequiredOutboundConnections == nil && o.RequiredOutboundConnections != nil || m.RequiredOutboundConnections != nil && o.RequiredOutboundConnections == nil {
+		if len(m.RequiredOutboundConnections) == 0 && len(o.RequiredOutboundConnections) > 0 || len(m.RequiredOutboundConnections) > 0 && len(o.RequiredOutboundConnections) == 0 {
 			return false
 		} else if m.RequiredOutboundConnections != nil && o.RequiredOutboundConnections != nil {
 			if !opts.Filter && len(m.RequiredOutboundConnections) != len(o.RequiredOutboundConnections) {

--- a/edgeproto/appinst.pb.go
+++ b/edgeproto/appinst.pb.go
@@ -2280,7 +2280,7 @@ func (m *AppInst) Matches(o *AppInst, fopts ...MatchOpt) bool {
 	}
 	if !opts.IgnoreBackend {
 		if !opts.Filter || o.MappedPorts != nil {
-			if m.MappedPorts == nil && o.MappedPorts != nil || m.MappedPorts != nil && o.MappedPorts == nil {
+			if len(m.MappedPorts) == 0 && len(o.MappedPorts) > 0 || len(m.MappedPorts) > 0 && len(o.MappedPorts) == 0 {
 				return false
 			} else if m.MappedPorts != nil && o.MappedPorts != nil {
 				if !opts.Filter && len(m.MappedPorts) != len(o.MappedPorts) {
@@ -2305,7 +2305,7 @@ func (m *AppInst) Matches(o *AppInst, fopts ...MatchOpt) bool {
 	}
 	if !opts.IgnoreBackend {
 		if !opts.Filter || o.Errors != nil {
-			if m.Errors == nil && o.Errors != nil || m.Errors != nil && o.Errors == nil {
+			if len(m.Errors) == 0 && len(o.Errors) > 0 || len(m.Errors) > 0 && len(o.Errors) == 0 {
 				return false
 			} else if m.Errors != nil && o.Errors != nil {
 				if !opts.Filter && len(m.Errors) != len(o.Errors) {
@@ -2351,7 +2351,7 @@ func (m *AppInst) Matches(o *AppInst, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Configs != nil {
-		if m.Configs == nil && o.Configs != nil || m.Configs != nil && o.Configs == nil {
+		if len(m.Configs) == 0 && len(o.Configs) > 0 || len(m.Configs) > 0 && len(o.Configs) == 0 {
 			return false
 		} else if m.Configs != nil && o.Configs != nil {
 			if !opts.Filter && len(m.Configs) != len(o.Configs) {
@@ -4133,7 +4133,7 @@ func (m *AppInstInfo) Matches(o *AppInstInfo, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Errors != nil {
-		if m.Errors == nil && o.Errors != nil || m.Errors != nil && o.Errors == nil {
+		if len(m.Errors) == 0 && len(o.Errors) > 0 || len(m.Errors) > 0 && len(o.Errors) == 0 {
 			return false
 		} else if m.Errors != nil && o.Errors != nil {
 			if !opts.Filter && len(m.Errors) != len(o.Errors) {

--- a/edgeproto/autoprovpolicy.pb.go
+++ b/edgeproto/autoprovpolicy.pb.go
@@ -1108,7 +1108,7 @@ func (m *AutoProvPolicy) Matches(o *AutoProvPolicy, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Cloudlets != nil {
-		if m.Cloudlets == nil && o.Cloudlets != nil || m.Cloudlets != nil && o.Cloudlets == nil {
+		if len(m.Cloudlets) == 0 && len(o.Cloudlets) > 0 || len(m.Cloudlets) > 0 && len(o.Cloudlets) == 0 {
 			return false
 		} else if m.Cloudlets != nil && o.Cloudlets != nil {
 			if !opts.Filter && len(m.Cloudlets) != len(o.Cloudlets) {
@@ -2410,7 +2410,7 @@ func (m *AutoProvInfo) Matches(o *AutoProvInfo, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Completed != nil {
-		if m.Completed == nil && o.Completed != nil || m.Completed != nil && o.Completed == nil {
+		if len(m.Completed) == 0 && len(o.Completed) > 0 || len(m.Completed) > 0 && len(o.Completed) == 0 {
 			return false
 		} else if m.Completed != nil && o.Completed != nil {
 			if !opts.Filter && len(m.Completed) != len(o.Completed) {
@@ -2424,7 +2424,7 @@ func (m *AutoProvInfo) Matches(o *AutoProvInfo, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Errors != nil {
-		if m.Errors == nil && o.Errors != nil || m.Errors != nil && o.Errors == nil {
+		if len(m.Errors) == 0 && len(o.Errors) > 0 || len(m.Errors) > 0 && len(o.Errors) == 0 {
 			return false
 		} else if m.Errors != nil && o.Errors != nil {
 			if !opts.Filter && len(m.Errors) != len(o.Errors) {

--- a/edgeproto/cloudlet.pb.go
+++ b/edgeproto/cloudlet.pb.go
@@ -3784,7 +3784,7 @@ func (m *Cloudlet) Matches(o *Cloudlet, fopts ...MatchOpt) bool {
 	}
 	if !opts.IgnoreBackend {
 		if !opts.Filter || o.Errors != nil {
-			if m.Errors == nil && o.Errors != nil || m.Errors != nil && o.Errors == nil {
+			if len(m.Errors) == 0 && len(o.Errors) > 0 || len(m.Errors) > 0 && len(o.Errors) == 0 {
 				return false
 			} else if m.Errors != nil && o.Errors != nil {
 				if !opts.Filter && len(m.Errors) != len(o.Errors) {
@@ -3840,7 +3840,7 @@ func (m *Cloudlet) Matches(o *Cloudlet, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.EnvVar != nil {
-		if m.EnvVar == nil && o.EnvVar != nil || m.EnvVar != nil && o.EnvVar == nil {
+		if len(m.EnvVar) == 0 && len(o.EnvVar) > 0 || len(m.EnvVar) > 0 && len(o.EnvVar) == 0 {
 			return false
 		} else if m.EnvVar != nil && o.EnvVar != nil {
 			if !opts.Filter && len(m.EnvVar) != len(o.EnvVar) {
@@ -3866,7 +3866,7 @@ func (m *Cloudlet) Matches(o *Cloudlet, fopts ...MatchOpt) bool {
 	}
 	if !opts.IgnoreBackend {
 		if !opts.Filter || o.ResTagMap != nil {
-			if m.ResTagMap == nil && o.ResTagMap != nil || m.ResTagMap != nil && o.ResTagMap == nil {
+			if len(m.ResTagMap) == 0 && len(o.ResTagMap) > 0 || len(m.ResTagMap) > 0 && len(o.ResTagMap) == 0 {
 				return false
 			} else if m.ResTagMap != nil && o.ResTagMap != nil {
 				if !opts.Filter && len(m.ResTagMap) != len(o.ResTagMap) {
@@ -3885,7 +3885,7 @@ func (m *Cloudlet) Matches(o *Cloudlet, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.AccessVars != nil {
-		if m.AccessVars == nil && o.AccessVars != nil || m.AccessVars != nil && o.AccessVars == nil {
+		if len(m.AccessVars) == 0 && len(o.AccessVars) > 0 || len(m.AccessVars) > 0 && len(o.AccessVars) == 0 {
 			return false
 		} else if m.AccessVars != nil && o.AccessVars != nil {
 			if !opts.Filter && len(m.AccessVars) != len(o.AccessVars) {
@@ -3919,7 +3919,7 @@ func (m *Cloudlet) Matches(o *Cloudlet, fopts ...MatchOpt) bool {
 	}
 	if !opts.IgnoreBackend {
 		if !opts.Filter || o.ChefClientKey != nil {
-			if m.ChefClientKey == nil && o.ChefClientKey != nil || m.ChefClientKey != nil && o.ChefClientKey == nil {
+			if len(m.ChefClientKey) == 0 && len(o.ChefClientKey) > 0 || len(m.ChefClientKey) > 0 && len(o.ChefClientKey) == 0 {
 				return false
 			} else if m.ChefClientKey != nil && o.ChefClientKey != nil {
 				if !opts.Filter && len(m.ChefClientKey) != len(o.ChefClientKey) {
@@ -6341,7 +6341,7 @@ func (m *CloudletInfo) Matches(o *CloudletInfo, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Errors != nil {
-		if m.Errors == nil && o.Errors != nil || m.Errors != nil && o.Errors == nil {
+		if len(m.Errors) == 0 && len(o.Errors) > 0 || len(m.Errors) > 0 && len(o.Errors) == 0 {
 			return false
 		} else if m.Errors != nil && o.Errors != nil {
 			if !opts.Filter && len(m.Errors) != len(o.Errors) {
@@ -6355,7 +6355,7 @@ func (m *CloudletInfo) Matches(o *CloudletInfo, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Flavors != nil {
-		if m.Flavors == nil && o.Flavors != nil || m.Flavors != nil && o.Flavors == nil {
+		if len(m.Flavors) == 0 && len(o.Flavors) > 0 || len(m.Flavors) > 0 && len(o.Flavors) == 0 {
 			return false
 		} else if m.Flavors != nil && o.Flavors != nil {
 			if !opts.Filter && len(m.Flavors) != len(o.Flavors) {
@@ -6371,7 +6371,7 @@ func (m *CloudletInfo) Matches(o *CloudletInfo, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.AvailabilityZones != nil {
-		if m.AvailabilityZones == nil && o.AvailabilityZones != nil || m.AvailabilityZones != nil && o.AvailabilityZones == nil {
+		if len(m.AvailabilityZones) == 0 && len(o.AvailabilityZones) > 0 || len(m.AvailabilityZones) > 0 && len(o.AvailabilityZones) == 0 {
 			return false
 		} else if m.AvailabilityZones != nil && o.AvailabilityZones != nil {
 			if !opts.Filter && len(m.AvailabilityZones) != len(o.AvailabilityZones) {
@@ -6382,7 +6382,7 @@ func (m *CloudletInfo) Matches(o *CloudletInfo, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.OsImages != nil {
-		if m.OsImages == nil && o.OsImages != nil || m.OsImages != nil && o.OsImages == nil {
+		if len(m.OsImages) == 0 && len(o.OsImages) > 0 || len(m.OsImages) > 0 && len(o.OsImages) == 0 {
 			return false
 		} else if m.OsImages != nil && o.OsImages != nil {
 			if !opts.Filter && len(m.OsImages) != len(o.OsImages) {

--- a/edgeproto/cloudletpool.pb.go
+++ b/edgeproto/cloudletpool.pb.go
@@ -801,7 +801,7 @@ func (m *CloudletPool) Matches(o *CloudletPool, fopts ...MatchOpt) bool {
 		return false
 	}
 	if !opts.Filter || o.Cloudlets != nil {
-		if m.Cloudlets == nil && o.Cloudlets != nil || m.Cloudlets != nil && o.Cloudlets == nil {
+		if len(m.Cloudlets) == 0 && len(o.Cloudlets) > 0 || len(m.Cloudlets) > 0 && len(o.Cloudlets) == 0 {
 			return false
 		} else if m.Cloudlets != nil && o.Cloudlets != nil {
 			if !opts.Filter && len(m.Cloudlets) != len(o.Cloudlets) {

--- a/edgeproto/clusterinst.pb.go
+++ b/edgeproto/clusterinst.pb.go
@@ -1424,7 +1424,7 @@ func (m *ClusterInst) Matches(o *ClusterInst, fopts ...MatchOpt) bool {
 	}
 	if !opts.IgnoreBackend {
 		if !opts.Filter || o.Errors != nil {
-			if m.Errors == nil && o.Errors != nil || m.Errors != nil && o.Errors == nil {
+			if len(m.Errors) == 0 && len(o.Errors) > 0 || len(m.Errors) > 0 && len(o.Errors) == 0 {
 				return false
 			} else if m.Errors != nil && o.Errors != nil {
 				if !opts.Filter && len(m.Errors) != len(o.Errors) {
@@ -3125,7 +3125,7 @@ func (m *ClusterInstInfo) Matches(o *ClusterInstInfo, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Errors != nil {
-		if m.Errors == nil && o.Errors != nil || m.Errors != nil && o.Errors == nil {
+		if len(m.Errors) == 0 && len(o.Errors) > 0 || len(m.Errors) > 0 && len(o.Errors) == 0 {
 			return false
 		} else if m.Errors != nil && o.Errors != nil {
 			if !opts.Filter && len(m.Errors) != len(o.Errors) {

--- a/edgeproto/flavor.pb.go
+++ b/edgeproto/flavor.pb.go
@@ -711,7 +711,7 @@ func (m *Flavor) Matches(o *Flavor, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.OptResMap != nil {
-		if m.OptResMap == nil && o.OptResMap != nil || m.OptResMap != nil && o.OptResMap == nil {
+		if len(m.OptResMap) == 0 && len(o.OptResMap) > 0 || len(m.OptResMap) > 0 && len(o.OptResMap) == 0 {
 			return false
 		} else if m.OptResMap != nil && o.OptResMap != nil {
 			if !opts.Filter && len(m.OptResMap) != len(o.OptResMap) {

--- a/edgeproto/refs.pb.go
+++ b/edgeproto/refs.pb.go
@@ -803,7 +803,7 @@ func (m *CloudletRefs) Matches(o *CloudletRefs, fopts ...MatchOpt) bool {
 		return false
 	}
 	if !opts.Filter || o.Clusters != nil {
-		if m.Clusters == nil && o.Clusters != nil || m.Clusters != nil && o.Clusters == nil {
+		if len(m.Clusters) == 0 && len(o.Clusters) > 0 || len(m.Clusters) > 0 && len(o.Clusters) == 0 {
 			return false
 		} else if m.Clusters != nil && o.Clusters != nil {
 			if !opts.Filter && len(m.Clusters) != len(o.Clusters) {
@@ -840,7 +840,7 @@ func (m *CloudletRefs) Matches(o *CloudletRefs, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RootLbPorts != nil {
-		if m.RootLbPorts == nil && o.RootLbPorts != nil || m.RootLbPorts != nil && o.RootLbPorts == nil {
+		if len(m.RootLbPorts) == 0 && len(o.RootLbPorts) > 0 || len(m.RootLbPorts) > 0 && len(o.RootLbPorts) == 0 {
 			return false
 		} else if m.RootLbPorts != nil && o.RootLbPorts != nil {
 			if !opts.Filter && len(m.RootLbPorts) != len(o.RootLbPorts) {
@@ -868,7 +868,7 @@ func (m *CloudletRefs) Matches(o *CloudletRefs, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.OptResUsedMap != nil {
-		if m.OptResUsedMap == nil && o.OptResUsedMap != nil || m.OptResUsedMap != nil && o.OptResUsedMap == nil {
+		if len(m.OptResUsedMap) == 0 && len(o.OptResUsedMap) > 0 || len(m.OptResUsedMap) > 0 && len(o.OptResUsedMap) == 0 {
 			return false
 		} else if m.OptResUsedMap != nil && o.OptResUsedMap != nil {
 			if !opts.Filter && len(m.OptResUsedMap) != len(o.OptResUsedMap) {
@@ -1528,7 +1528,7 @@ func (m *ClusterRefs) Matches(o *ClusterRefs, fopts ...MatchOpt) bool {
 		return false
 	}
 	if !opts.Filter || o.Apps != nil {
-		if m.Apps == nil && o.Apps != nil || m.Apps != nil && o.Apps == nil {
+		if len(m.Apps) == 0 && len(o.Apps) > 0 || len(m.Apps) > 0 && len(o.Apps) == 0 {
 			return false
 		} else if m.Apps != nil && o.Apps != nil {
 			if !opts.Filter && len(m.Apps) != len(o.Apps) {
@@ -2161,7 +2161,7 @@ func (m *AppInstRefs) Matches(o *AppInstRefs, fopts ...MatchOpt) bool {
 		return false
 	}
 	if !opts.Filter || o.Insts != nil {
-		if m.Insts == nil && o.Insts != nil || m.Insts != nil && o.Insts == nil {
+		if len(m.Insts) == 0 && len(o.Insts) > 0 || len(m.Insts) > 0 && len(o.Insts) == 0 {
 			return false
 		} else if m.Insts != nil && o.Insts != nil {
 			if !opts.Filter && len(m.Insts) != len(o.Insts) {

--- a/edgeproto/restagtable.pb.go
+++ b/edgeproto/restagtable.pb.go
@@ -803,7 +803,7 @@ func (m *ResTagTable) Matches(o *ResTagTable, fopts ...MatchOpt) bool {
 		return false
 	}
 	if !opts.Filter || o.Tags != nil {
-		if m.Tags == nil && o.Tags != nil || m.Tags != nil && o.Tags == nil {
+		if len(m.Tags) == 0 && len(o.Tags) > 0 || len(m.Tags) > 0 && len(o.Tags) == 0 {
 			return false
 		} else if m.Tags != nil && o.Tags != nil {
 			if !opts.Filter && len(m.Tags) != len(o.Tags) {

--- a/edgeproto/trustpolicy.pb.go
+++ b/edgeproto/trustpolicy.pb.go
@@ -637,7 +637,7 @@ func (m *TrustPolicy) Matches(o *TrustPolicy, fopts ...MatchOpt) bool {
 		return false
 	}
 	if !opts.Filter || o.OutboundSecurityRules != nil {
-		if m.OutboundSecurityRules == nil && o.OutboundSecurityRules != nil || m.OutboundSecurityRules != nil && o.OutboundSecurityRules == nil {
+		if len(m.OutboundSecurityRules) == 0 && len(o.OutboundSecurityRules) > 0 || len(m.OutboundSecurityRules) > 0 && len(o.OutboundSecurityRules) == 0 {
 			return false
 		} else if m.OutboundSecurityRules != nil && o.OutboundSecurityRules != nil {
 			if !opts.Filter && len(m.OutboundSecurityRules) != len(o.OutboundSecurityRules) {

--- a/edgeproto/vmpool.pb.go
+++ b/edgeproto/vmpool.pb.go
@@ -1560,7 +1560,7 @@ func (m *VMPool) Matches(o *VMPool, fopts ...MatchOpt) bool {
 		return false
 	}
 	if !opts.Filter || o.Vms != nil {
-		if m.Vms == nil && o.Vms != nil || m.Vms != nil && o.Vms == nil {
+		if len(m.Vms) == 0 && len(o.Vms) > 0 || len(m.Vms) > 0 && len(o.Vms) == 0 {
 			return false
 		} else if m.Vms != nil && o.Vms != nil {
 			if !opts.Filter && len(m.Vms) != len(o.Vms) {
@@ -1579,7 +1579,7 @@ func (m *VMPool) Matches(o *VMPool, fopts ...MatchOpt) bool {
 	}
 	if !opts.IgnoreBackend {
 		if !opts.Filter || o.Errors != nil {
-			if m.Errors == nil && o.Errors != nil || m.Errors != nil && o.Errors == nil {
+			if len(m.Errors) == 0 && len(o.Errors) > 0 || len(m.Errors) > 0 && len(o.Errors) == 0 {
 				return false
 			} else if m.Errors != nil && o.Errors != nil {
 				if !opts.Filter && len(m.Errors) != len(o.Errors) {
@@ -2930,7 +2930,7 @@ func (m *VMPoolInfo) Matches(o *VMPoolInfo, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Vms != nil {
-		if m.Vms == nil && o.Vms != nil || m.Vms != nil && o.Vms == nil {
+		if len(m.Vms) == 0 && len(o.Vms) > 0 || len(m.Vms) > 0 && len(o.Vms) == 0 {
 			return false
 		} else if m.Vms != nil && o.Vms != nil {
 			if !opts.Filter && len(m.Vms) != len(o.Vms) {
@@ -2949,7 +2949,7 @@ func (m *VMPoolInfo) Matches(o *VMPoolInfo, fopts ...MatchOpt) bool {
 	}
 	if !opts.IgnoreBackend {
 		if !opts.Filter || o.Errors != nil {
-			if m.Errors == nil && o.Errors != nil || m.Errors != nil && o.Errors == nil {
+			if len(m.Errors) == 0 && len(o.Errors) > 0 || len(m.Errors) > 0 && len(o.Errors) == 0 {
 				return false
 			} else if m.Errors != nil && o.Errors != nil {
 				if !opts.Filter && len(m.Errors) != len(o.Errors) {

--- a/testgen/sample.pb.go
+++ b/testgen/sample.pb.go
@@ -1335,7 +1335,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RepeatedInt != nil {
-		if m.RepeatedInt == nil && o.RepeatedInt != nil || m.RepeatedInt != nil && o.RepeatedInt == nil {
+		if len(m.RepeatedInt) == 0 && len(o.RepeatedInt) > 0 || len(m.RepeatedInt) > 0 && len(o.RepeatedInt) == 0 {
 			return false
 		} else if m.RepeatedInt != nil && o.RepeatedInt != nil {
 			if !opts.Filter && len(m.RepeatedInt) != len(o.RepeatedInt) {
@@ -1349,7 +1349,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Ip != nil {
-		if m.Ip == nil && o.Ip != nil || m.Ip != nil && o.Ip == nil {
+		if len(m.Ip) == 0 && len(o.Ip) > 0 || len(m.Ip) > 0 && len(o.Ip) == 0 {
 			return false
 		} else if m.Ip != nil && o.Ip != nil {
 			if !opts.Filter && len(m.Ip) != len(o.Ip) {
@@ -1363,7 +1363,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.Names != nil {
-		if m.Names == nil && o.Names != nil || m.Names != nil && o.Names == nil {
+		if len(m.Names) == 0 && len(o.Names) > 0 || len(m.Names) > 0 && len(o.Names) == 0 {
 			return false
 		} else if m.Names != nil && o.Names != nil {
 			if !opts.Filter && len(m.Names) != len(o.Names) {
@@ -1377,7 +1377,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RepeatedMsg != nil {
-		if m.RepeatedMsg == nil && o.RepeatedMsg != nil || m.RepeatedMsg != nil && o.RepeatedMsg == nil {
+		if len(m.RepeatedMsg) == 0 && len(o.RepeatedMsg) > 0 || len(m.RepeatedMsg) > 0 && len(o.RepeatedMsg) == 0 {
 			return false
 		} else if m.RepeatedMsg != nil && o.RepeatedMsg != nil {
 			if !opts.Filter && len(m.RepeatedMsg) != len(o.RepeatedMsg) {
@@ -1388,7 +1388,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RepeatedMsgNonnull != nil {
-		if m.RepeatedMsgNonnull == nil && o.RepeatedMsgNonnull != nil || m.RepeatedMsgNonnull != nil && o.RepeatedMsgNonnull == nil {
+		if len(m.RepeatedMsgNonnull) == 0 && len(o.RepeatedMsgNonnull) > 0 || len(m.RepeatedMsgNonnull) > 0 && len(o.RepeatedMsgNonnull) == 0 {
 			return false
 		} else if m.RepeatedMsgNonnull != nil && o.RepeatedMsgNonnull != nil {
 			if !opts.Filter && len(m.RepeatedMsgNonnull) != len(o.RepeatedMsgNonnull) {
@@ -1399,7 +1399,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RepeatedFields != nil {
-		if m.RepeatedFields == nil && o.RepeatedFields != nil || m.RepeatedFields != nil && o.RepeatedFields == nil {
+		if len(m.RepeatedFields) == 0 && len(o.RepeatedFields) > 0 || len(m.RepeatedFields) > 0 && len(o.RepeatedFields) == 0 {
 			return false
 		} else if m.RepeatedFields != nil && o.RepeatedFields != nil {
 			if !opts.Filter && len(m.RepeatedFields) != len(o.RepeatedFields) {
@@ -1410,7 +1410,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RepeatedFieldsNonnull != nil {
-		if m.RepeatedFieldsNonnull == nil && o.RepeatedFieldsNonnull != nil || m.RepeatedFieldsNonnull != nil && o.RepeatedFieldsNonnull == nil {
+		if len(m.RepeatedFieldsNonnull) == 0 && len(o.RepeatedFieldsNonnull) > 0 || len(m.RepeatedFieldsNonnull) > 0 && len(o.RepeatedFieldsNonnull) == 0 {
 			return false
 		} else if m.RepeatedFieldsNonnull != nil && o.RepeatedFieldsNonnull != nil {
 			if !opts.Filter && len(m.RepeatedFieldsNonnull) != len(o.RepeatedFieldsNonnull) {
@@ -1421,7 +1421,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RepeatedInnerMsg != nil {
-		if m.RepeatedInnerMsg == nil && o.RepeatedInnerMsg != nil || m.RepeatedInnerMsg != nil && o.RepeatedInnerMsg == nil {
+		if len(m.RepeatedInnerMsg) == 0 && len(o.RepeatedInnerMsg) > 0 || len(m.RepeatedInnerMsg) > 0 && len(o.RepeatedInnerMsg) == 0 {
 			return false
 		} else if m.RepeatedInnerMsg != nil && o.RepeatedInnerMsg != nil {
 			if !opts.Filter && len(m.RepeatedInnerMsg) != len(o.RepeatedInnerMsg) {
@@ -1432,7 +1432,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RepeatedInnerMsgNonnull != nil {
-		if m.RepeatedInnerMsgNonnull == nil && o.RepeatedInnerMsgNonnull != nil || m.RepeatedInnerMsgNonnull != nil && o.RepeatedInnerMsgNonnull == nil {
+		if len(m.RepeatedInnerMsgNonnull) == 0 && len(o.RepeatedInnerMsgNonnull) > 0 || len(m.RepeatedInnerMsgNonnull) > 0 && len(o.RepeatedInnerMsgNonnull) == 0 {
 			return false
 		} else if m.RepeatedInnerMsgNonnull != nil && o.RepeatedInnerMsgNonnull != nil {
 			if !opts.Filter && len(m.RepeatedInnerMsgNonnull) != len(o.RepeatedInnerMsgNonnull) {
@@ -1443,7 +1443,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RepeatedLoc != nil {
-		if m.RepeatedLoc == nil && o.RepeatedLoc != nil || m.RepeatedLoc != nil && o.RepeatedLoc == nil {
+		if len(m.RepeatedLoc) == 0 && len(o.RepeatedLoc) > 0 || len(m.RepeatedLoc) > 0 && len(o.RepeatedLoc) == 0 {
 			return false
 		} else if m.RepeatedLoc != nil && o.RepeatedLoc != nil {
 			if !opts.Filter && len(m.RepeatedLoc) != len(o.RepeatedLoc) {
@@ -1454,7 +1454,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.RepeatedLocNonnull != nil {
-		if m.RepeatedLocNonnull == nil && o.RepeatedLocNonnull != nil || m.RepeatedLocNonnull != nil && o.RepeatedLocNonnull == nil {
+		if len(m.RepeatedLocNonnull) == 0 && len(o.RepeatedLocNonnull) > 0 || len(m.RepeatedLocNonnull) > 0 && len(o.RepeatedLocNonnull) == 0 {
 			return false
 		} else if m.RepeatedLocNonnull != nil && o.RepeatedLocNonnull != nil {
 			if !opts.Filter && len(m.RepeatedLocNonnull) != len(o.RepeatedLocNonnull) {
@@ -1465,7 +1465,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.IntMap != nil {
-		if m.IntMap == nil && o.IntMap != nil || m.IntMap != nil && o.IntMap == nil {
+		if len(m.IntMap) == 0 && len(o.IntMap) > 0 || len(m.IntMap) > 0 && len(o.IntMap) == 0 {
 			return false
 		} else if m.IntMap != nil && o.IntMap != nil {
 			if !opts.Filter && len(m.IntMap) != len(o.IntMap) {
@@ -1483,7 +1483,7 @@ func (m *TestGen) Matches(o *TestGen, fopts ...MatchOpt) bool {
 		}
 	}
 	if !opts.Filter || o.MsgMap != nil {
-		if m.MsgMap == nil && o.MsgMap != nil || m.MsgMap != nil && o.MsgMap == nil {
+		if len(m.MsgMap) == 0 && len(o.MsgMap) > 0 || len(m.MsgMap) > 0 && len(o.MsgMap) == 0 {
 			return false
 		} else if m.MsgMap != nil && o.MsgMap != nil {
 			if !opts.Filter && len(m.MsgMap) != len(o.MsgMap) {


### PR DESCRIPTION
* At times I see some tests failing if the slice is set to nil and comparison is done against an empty slice.
* Initializing a slice to nil or an empty slice should be the same and hence modified the `Matches` function to perform checks based on length rather than nil value for slices.