### PR TITLE
EDGECLOUD-4216  CreateApp with invalid helmCustomizationYaml config should give an error

### DIFF
--- a/cloudcommon/deployment.go
+++ b/cloudcommon/deployment.go
@@ -298,7 +298,7 @@ func GetDeploymentManifest(ctx context.Context, authApi RegistryAuthApi, manifes
 	if strings.HasPrefix(manifest, "http://") || strings.HasPrefix(manifest, "https://") {
 
 		if strings.HasSuffix(manifest, ".zip") {
-			log.DebugLog(log.DebugLevelApi, "zipfile manifest found", "manifest", manifest)
+			log.SpanLog(ctx, log.DebugLevelApi, "zipfile manifest found", "manifest", manifest)
 			return manifest, validateRemoteZipManifest(ctx, authApi, manifest)
 		}
 		mf, err := GetRemoteManifest(ctx, authApi, manifest)

--- a/cloudcommon/registry.go
+++ b/cloudcommon/registry.go
@@ -213,9 +213,18 @@ func handleWWWAuth(ctx context.Context, method, regUrl, authHeader string, auth 
  *   it and begins the session as usual
  */
 func SendHTTPReq(ctx context.Context, method, regUrl string, authApi RegistryAuthApi, reqConfig *RequestConfig) (*http.Response, error) {
-	auth, err := authApi.GetRegistryAuth(ctx, regUrl)
-	if err != nil {
-		return nil, err
+	var auth *RegistryAuth
+	var err error
+
+	// if authApi is nil, this is a public registry
+	if authApi != nil {
+		auth, err = authApi.GetRegistryAuth(ctx, regUrl)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		auth = nil
+		log.SpanLog(ctx, log.DebugLevelApi, "warning, cannot get registry credentials from vault - assume public registry", "err", err)
 	}
 	resp, err := SendHTTPReqAuth(ctx, method, regUrl, auth, reqConfig)
 	if err != nil {

--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -270,7 +270,7 @@ func (s *AppApi) configureApp(ctx context.Context, stm concurrency.STM, in *edge
 	if !cloudcommon.IsValidDeploymentForImage(in.ImageType, in.Deployment) {
 		return fmt.Errorf("Deployment is not valid for image type")
 	}
-	if err := validateAppConfigsForDeployment(in.Configs, in.Deployment); err != nil {
+	if err := validateAppConfigsForDeployment(ctx, in.Configs, in.Deployment); err != nil {
 		return err
 	}
 	if err := validateRequiredOutboundConnections(in.RequiredOutboundConnections); err != nil {
@@ -701,13 +701,18 @@ func (s *AppApi) RemoveAppAutoProvPolicy(ctx context.Context, in *edgeproto.AppA
 	return &edgeproto.Result{}, err
 }
 
-func validateAppConfigsForDeployment(configs []*edgeproto.ConfigFile, deployment string) error {
+func validateAppConfigsForDeployment(ctx context.Context, configs []*edgeproto.ConfigFile, deployment string) error {
 	for _, cfg := range configs {
 		invalid := false
 		switch cfg.Kind {
 		case edgeproto.AppConfigHelmYaml:
 			if deployment != cloudcommon.DeploymentTypeHelm {
 				invalid = true
+			}
+			// Validate that this is a valid url
+			_, err := cloudcommon.GetDeploymentManifest(ctx, nil, cfg.Config)
+			if err != nil {
+				return err
 			}
 		case edgeproto.AppConfigEnvYaml:
 			if deployment != cloudcommon.DeploymentTypeKubernetes {


### PR DESCRIPTION
Added url validation for helmCustomizationYaml at the time of app creation.
Unit-tests
Handle no-auth in  `SendHTTPReq`
