### PR TITLE
EDGECLOUD-4345 allow MobiledgeX apps for reservable autocluster fix

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -444,12 +444,6 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		}()
 	}
 
-	defer func() {
-		if reterr == nil {
-			RecordAppInstEvent(ctx, &in.Key, cloudcommon.CREATED, cloudcommon.InstanceUp)
-		}
-	}()
-
 	if setClusterOrg {
 		cb.Send(&edgeproto.Result{Message: "Setting ClusterInst developer to match App developer"})
 	}
@@ -464,7 +458,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 	cctx.SetOverride(&in.CrmOverride)
 
 	autocluster := false
-	tenant := false
+	sidecarApp := false
 	err = s.checkForAppinstCollisions(ctx, &in.Key)
 	if err != nil {
 		return err
@@ -474,10 +468,20 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 	var reservedClusterInstKey *edgeproto.ClusterInstKey
 	realClusterName := in.RealClusterName
 
+	defer func() {
+		if reterr != nil {
+			return
+		}
+		RecordAppInstEvent(ctx, &in.Key, cloudcommon.CREATED, cloudcommon.InstanceUp)
+		if reservedClusterInstKey != nil {
+			RecordClusterInstEvent(ctx, reservedClusterInstKey, cloudcommon.RESERVED, cloudcommon.InstanceUp)
+		}
+	}()
+
 	err = s.sync.ApplySTMWait(ctx, func(stm concurrency.STM) error {
 		// reset modified state in case STM hits conflict and runs again
 		autocluster = false
-		tenant = false
+		sidecarApp = false
 		reservedAutoClusterId = -1
 		reservedClusterInstKey = nil
 		in.RealClusterName = realClusterName
@@ -493,11 +497,9 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 				return fmt.Errorf("No AppInst or App flavor specified")
 			}
 		}
-		tenant = isTenantAppInst(&in.Key, app.DelOpt)
-		if in.Key.AppKey.Organization != in.Key.ClusterInstKey.Organization && in.Key.AppKey.Organization != cloudcommon.OrganizationMobiledgeX && !tenant {
-			return fmt.Errorf("Developer name mismatch between App: %s and ClusterInst: %s", in.Key.AppKey.Organization, in.Key.ClusterInstKey.Organization)
+		if in.Key.AppKey.Organization == cloudcommon.OrganizationMobiledgeX && app.DelOpt == edgeproto.DeleteType_AUTO_DELETE {
+			sidecarApp = true
 		}
-
 		// make sure cloudlet exists so we don't create refs for missing cloudlet
 		cloudlet := edgeproto.Cloudlet{}
 		if !cloudletApi.store.STMGet(stm, &in.Key.ClusterInstKey.CloudletKey, &cloudlet) {
@@ -517,13 +519,8 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			if !cloudcommon.IsClusterInstReqd(&app) {
 				return fmt.Errorf("No cluster required for App deployment type %s, cannot use cluster name %s which attempts to use or create a ClusterInst", app.Deployment, cloudcommon.AutoClusterPrefix)
 			}
-			if !tenant {
-				return fmt.Errorf("%s sidecar AppInst must specify the RealClusterName field to deploy to the virtual cluster name %s, or specify the real cluster name in the key", cloudcommon.OrganizationMobiledgeX, in.Key.ClusterInstKey.ClusterKey.Name)
-			}
-			// If this is an autodelete app, we should only allow those
-			// in existing cluster instances.
-			if app.DelOpt == edgeproto.DeleteType_AUTO_DELETE {
-				return fmt.Errorf("Autodelete App %s requires an existing ClusterInst", app.Key.Name)
+			if sidecarApp {
+				return fmt.Errorf("Sidecar AppInst (AutoDelete App) must specify the RealClusterName field to deploy to the virtual cluster name %s, or specify the real cluster name in the key", in.Key.ClusterInstKey.ClusterKey.Name)
 			}
 			if err := validateAutoDeployApp(stm, &app); err != nil {
 				return err
@@ -670,7 +667,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			if app.AccessType == edgeproto.AccessType_ACCESS_TYPE_DIRECT && clusterInst.IpAccess == edgeproto.IpAccess_IP_ACCESS_SHARED {
 				return fmt.Errorf("Direct Access App cannot be deployed on IP_ACCESS_SHARED ClusterInst")
 			}
-			if tenant && clusterInst.Reservable {
+			if !sidecarApp && clusterInst.Reservable {
 				// caller specified reservable ClusterInst
 				if clusterInst.ReservedBy != "" {
 					return fmt.Errorf("Specified ClusterInst is already reserved by another AppInst")
@@ -679,6 +676,9 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 				clusterInst.ReservedBy = in.Key.AppKey.Organization
 				clusterInstApi.store.STMPut(stm, &clusterInst)
 				reservedClusterInstKey = &clusterInst.Key
+			}
+			if !sidecarApp && !clusterInst.Reservable && in.Key.AppKey.Organization != in.Key.ClusterInstKey.Organization {
+				return fmt.Errorf("Developer name mismatch between App: %s and ClusterInst: %s", in.Key.AppKey.Organization, in.Key.ClusterInstKey.Organization)
 			}
 			// non-tenant just gets added to existing cluster,
 			// regardless of reservable or not.
@@ -878,7 +878,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			if clusterInst.State != edgeproto.TrackedState_READY {
 				return fmt.Errorf("ClusterInst %s not ready", clusterInst.Key.GetKeyString())
 			}
-			if tenant && clusterInst.Reservable && clusterInst.ReservedBy != in.Key.AppKey.Organization {
+			if !sidecarApp && clusterInst.Reservable && clusterInst.ReservedBy != in.Key.AppKey.Organization {
 				return fmt.Errorf("ClusterInst reservation changed unexpectedly, expected %s but was %s", in.Key.AppKey.Organization, clusterInst.ReservedBy)
 			}
 			needDeployment := app.Deployment
@@ -1328,6 +1328,8 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 	ctx := inCb.Context()
 
 	var app edgeproto.App
+	var reservationFreed bool
+	clusterInstKey := edgeproto.ClusterInstKey{}
 
 	s.setDefaultVMClusterKey(ctx, &in.Key)
 	if err := in.Key.AppKey.ValidateKey(); err != nil {
@@ -1350,8 +1352,12 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 	}
 	eventCtx := context.WithValue(ctx, in.Key, appInstInfo)
 	defer func() {
-		if reterr == nil {
-			RecordAppInstEvent(eventCtx, &in.Key, cloudcommon.DELETED, cloudcommon.InstanceDown)
+		if reterr != nil {
+			return
+		}
+		RecordAppInstEvent(eventCtx, &in.Key, cloudcommon.DELETED, cloudcommon.InstanceDown)
+		if reservationFreed {
+			RecordClusterInstEvent(ctx, &clusterInstKey, cloudcommon.UNRESERVED, cloudcommon.InstanceDown)
 		}
 	}()
 
@@ -1366,8 +1372,6 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 	if strings.HasPrefix(in.Key.ClusterInstKey.ClusterKey.Name, cloudcommon.AutoClusterPrefix) && in.Key.ClusterInstKey.Organization == "" {
 		in.Key.ClusterInstKey.Organization = in.Key.AppKey.Organization
 	}
-	clusterInstKey := edgeproto.ClusterInstKey{}
-	var reservationFreed bool
 	err = s.sync.ApplySTMWait(ctx, func(stm concurrency.STM) error {
 		// clear change tracking vars in case STM is rerun due to conflict.
 		reservationFreed = false
@@ -1802,19 +1806,6 @@ func RecordAppInstEvent(ctx context.Context, appInstKey *edgeproto.AppInstKey, e
 	metric.AddStringVal("realcluster", appInst.GetRealClusterName())
 
 	services.events.AddMetric(&metric)
-
-	// check to see if it was autoprovisioned and they used a reserved clusterinst, then log the start and stop of the clusterinst as well
-	if isTenantAppInst(appInstKey, app.DelOpt) && (event == cloudcommon.CREATED || event == cloudcommon.DELETED) {
-		clusterEvent := cloudcommon.RESERVED
-		if event == cloudcommon.DELETED {
-			clusterEvent = cloudcommon.UNRESERVED
-		}
-		RecordClusterInstEvent(ctx, appInst.ClusterInstKey(), clusterEvent, serverStatus)
-	}
-}
-
-func isTenantAppInst(appInstKey *edgeproto.AppInstKey, appDelOpt edgeproto.DeleteType) bool {
-	return appInstKey.ClusterInstKey.Organization == cloudcommon.OrganizationMobiledgeX && appInstKey.AppKey.Organization != cloudcommon.OrganizationMobiledgeX && appDelOpt != edgeproto.DeleteType_AUTO_DELETE
 }
 
 func clusterInstReservationEvent(ctx context.Context, eventName string, appInst *edgeproto.AppInst) {

--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -493,7 +493,7 @@ func TestAutoClusterInst(t *testing.T) {
 	autoDeleteAppInst.Key.ClusterInstKey.ClusterKey.Name = cloudcommon.AutoClusterPrefix + "foo"
 	err := appInstApi.CreateAppInst(&autoDeleteAppInst, testutil.NewCudStreamoutAppInst(ctx))
 	require.NotNil(t, err, "create autodelete appInst")
-	require.Contains(t, err.Error(), "MobiledgeX sidecar AppInst must specify the RealClusterName field to deploy to the virtual cluster")
+	require.Contains(t, err.Error(), "Sidecar AppInst (AutoDelete App) must specify the RealClusterName field to deploy to the virtual cluster")
 
 	dummy.Stop()
 }

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -82,7 +82,7 @@ var ClusterKeys = []edgeproto.ClusterKey{
 }
 
 var AppData = []edgeproto.App{
-	edgeproto.App{
+	edgeproto.App{ // 0
 		Key: edgeproto.AppKey{
 			Organization: DevData[0],
 			Name:         "Pokemon Go!",
@@ -93,7 +93,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 		DefaultFlavor: FlavorData[0].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 1
 		Key: edgeproto.AppKey{
 			Organization: DevData[0],
 			Name:         "Pokemon Go!",
@@ -104,7 +104,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 		DefaultFlavor: FlavorData[0].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 2
 		Key: edgeproto.AppKey{
 			Organization: DevData[0],
 			Name:         "Harry Potter Go! Go!",
@@ -115,7 +115,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 		DefaultFlavor: FlavorData[1].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 3
 		Key: edgeproto.AppKey{
 			Organization: DevData[1],
 			Name:         "AI",
@@ -127,7 +127,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_DIRECT,
 		DefaultFlavor: FlavorData[1].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 4
 		Key: edgeproto.AppKey{
 			Organization: DevData[2],
 			Name:         "my reality",
@@ -139,7 +139,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_DIRECT,
 		DefaultFlavor: FlavorData[2].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 5
 		Key: edgeproto.AppKey{
 			Organization: DevData[3],
 			Name:         "helmApp",
@@ -151,7 +151,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 		DefaultFlavor: FlavorData[2].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 6
 		Key: edgeproto.AppKey{
 			Organization: DevData[0],
 			Name:         "Neon",
@@ -162,7 +162,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 		DefaultFlavor: FlavorData[1].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 7
 		Key: edgeproto.AppKey{
 			Organization: DevData[0],
 			Name:         "NoPorts",
@@ -172,7 +172,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 		DefaultFlavor: FlavorData[0].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 8
 		Key: edgeproto.AppKey{
 			Organization: DevData[0],
 			Name:         "PortRangeApp",
@@ -183,7 +183,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 		DefaultFlavor: FlavorData[0].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 9
 		Key: edgeproto.AppKey{
 			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
 			Name:         "AutoDeleteApp",
@@ -194,7 +194,7 @@ var AppData = []edgeproto.App{
 		DefaultFlavor: FlavorData[0].Key,
 		DelOpt:        edgeproto.DeleteType_AUTO_DELETE,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 10
 		Key: edgeproto.AppKey{
 			Organization: DevData[1],
 			Name:         "Dev1App",
@@ -205,7 +205,7 @@ var AppData = []edgeproto.App{
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 		DefaultFlavor: FlavorData[1].Key,
 	},
-	edgeproto.App{
+	edgeproto.App{ // 11
 		Key: edgeproto.AppKey{
 			Organization: DevData[0],
 			Name:         "Pokemon Go!",
@@ -220,7 +220,7 @@ var AppData = []edgeproto.App{
 			AutoProvPolicyData[3].Key.Name,
 		},
 	},
-	edgeproto.App{
+	edgeproto.App{ // 12
 		Key: edgeproto.AppKey{
 			Organization: DevData[0],
 			Name:         "vm lb",
@@ -231,6 +231,17 @@ var AppData = []edgeproto.App{
 		ImagePath:     "http://somerepo/image/path/myreality/0.0.1#md5:7e9cfcb763e83573a4b9d9315f56cc5f",
 		AccessPorts:   "tcp:10003",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
+		DefaultFlavor: FlavorData[0].Key,
+	},
+	edgeproto.App{ // 13 - MobiledgeX app
+		Key: edgeproto.AppKey{
+			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+			Name:         "SampleApp",
+			Version:      "1.0.0",
+		},
+		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
+		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
+		AccessPorts:   "tcp:889",
 		DefaultFlavor: FlavorData[0].Key,
 	},
 }
@@ -460,7 +471,6 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 	edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey: edgeproto.ClusterKey{
-				//Name: util.K8SSanitize("AutoCluster" + AppData[1].Key.Name),
 				Name: "reservable0",
 			},
 			CloudletKey:  CloudletData[1].Key,
@@ -478,7 +488,6 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 	edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey: edgeproto.ClusterKey{
-				//Name: util.K8SSanitize("AutoCluster" + AppData[2].Key.Name),
 				Name: "reservable0",
 			},
 			CloudletKey:  CloudletData[2].Key,
@@ -496,7 +505,6 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 	edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey: edgeproto.ClusterKey{
-				//Name: util.K8SSanitize("AutoCluster" + AppData[6].Key.Name),
 				Name: "reservable1",
 			},
 			CloudletKey:  CloudletData[2].Key,
@@ -509,6 +517,23 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 		Auto:       true,
 		Reservable: true,
 		ReservedBy: DevData[0],
+	},
+	// from AppInstData[12] -> AppData[13]
+	edgeproto.ClusterInst{
+		Key: edgeproto.ClusterInstKey{
+			ClusterKey: edgeproto.ClusterKey{
+				Name: "reservable0",
+			},
+			CloudletKey:  CloudletData[3].Key,
+			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+		},
+		Flavor:     FlavorData[0].Key,
+		NumMasters: 1,
+		NumNodes:   1,
+		State:      edgeproto.TrackedState_READY,
+		Auto:       true,
+		Reservable: true,
+		ReservedBy: "MobiledgeX",
 	},
 }
 var AppInstData = []edgeproto.AppInst{
@@ -604,6 +629,13 @@ var AppInstData = []edgeproto.AppInst{
 			},
 		},
 		CloudletLoc: CloudletData[1].Location,
+	},
+	edgeproto.AppInst{ // 12 - deploy MobiledgeX app to reservable autocluster
+		Key: edgeproto.AppInstKey{
+			AppKey:         AppData[13].Key, // mobiledgex sample app
+			ClusterInstKey: *ClusterInstAutoData[3].Key.Virtual(util.K8SSanitize("autocluster" + AppData[13].Key.Name)),
+		},
+		CloudletLoc: CloudletData[3].Location,
 	},
 }
 
@@ -705,6 +737,12 @@ var AppInstRefsData = []edgeproto.AppInstRefs{
 		Key: AppData[12].Key,
 		Insts: map[string]uint32{
 			AppInstData[11].Key.GetKeyString(): 1,
+		},
+	},
+	edgeproto.AppInstRefs{
+		Key: AppData[13].Key,
+		Insts: map[string]uint32{
+			AppInstData[12].Key.GetKeyString(): 1,
 		},
 	},
 }
@@ -1127,7 +1165,9 @@ var CloudletRefsWithAppInstsData = []edgeproto.CloudletRefs{
 		RootLbPorts:            map[int32]int32{443: 1, 11111: 2, 2024: 2, 80: 1, 8001: 2, 65535: 1},
 		ReservedAutoClusterIds: 3,
 	},
-	// ClusterInstData[6]: (no app insts on this clusterinst) (shared)
+	// ClusterInstData[6]: (no app insts on this clusterinst) (shared),
+	// ClusterInstAutoData[3]: (shared)
+	// AppInstData[12] -> ports[tcp:889]
 	edgeproto.CloudletRefs{
 		Key: CloudletData[3].Key,
 		ClusterInsts: []edgeproto.ClusterInstRefKey{
@@ -1135,10 +1175,16 @@ var CloudletRefsWithAppInstsData = []edgeproto.CloudletRefs{
 				ClusterKey:   ClusterInstData[6].Key.ClusterKey,
 				Organization: ClusterInstData[6].Key.Organization,
 			},
+			edgeproto.ClusterInstRefKey{
+				ClusterKey:   ClusterInstAutoData[3].Key.ClusterKey,
+				Organization: ClusterInstAutoData[3].Key.Organization,
+			},
 		},
-		UsedRam:    GetCloudletUsedRam(6),
-		UsedVcores: GetCloudletUsedVcores(6),
-		UsedDisk:   GetCloudletUsedDisk(6),
+		UsedRam:                GetCloudletUsedRam(6, -1, 3),
+		UsedVcores:             GetCloudletUsedVcores(6, -1, 3),
+		UsedDisk:               GetCloudletUsedDisk(6, -1, 3),
+		RootLbPorts:            map[int32]int32{889: 1},
+		ReservedAutoClusterIds: 1,
 	},
 }
 


### PR DESCRIPTION
Another follow-up fix for MobiledgeX apps on reservable auto-clusters.

The previous definition of a "tenant" is no longer viable, as we don't make any distinction on the org of the App anymore. Instead we define a sidecar app as one that has the AutoDelete option.

I refactored the RecordClusterInst events for reservations since they're only called in two places.

I also added a MobiledgeX app to test_data.go.