### PR TITLE
Fix CreateCloudlet errors ignored by controller

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -551,6 +551,9 @@ func (s *CloudletApi) createCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 		if err == nil {
 			if len(accessVars) > 0 {
 				err = cloudletPlatform.SaveCloudletAccessVars(ctx, in, accessVars, pfConfig, nodeMgr.VaultConfig, updatecb.cb)
+				if err != nil {
+					return err
+				}
 			}
 			var resProps *edgeproto.CloudletResourceQuotaProps
 			resProps, err = cloudletPlatform.GetCloudletResourceQuotaProps(ctx)


### PR DESCRIPTION
I noticed as part of testing that when CreateCloudlet hits an error condition, the controller is not reacting to it and just keeps going indefinitely.  I tracked this down to a recent change in which, there was "err" declared in a short assignment statement within the scope of if statement.   This then gets used when checking the results of cloudletPlatform.CreateCloudlet, but goes out of scope where err is checked to see if something fails.

Fix is to remove the short assignment of err and separately declare the new variable "resProps"

Sort of seems like the compiler should warn about this, it's hard to see.