### PR TITLE
EDGECLOUD-4393 ShowsNodes has empty BuildMaster in properties

### DIFF
--- a/version/version.sh
+++ b/version/version.sh
@@ -3,7 +3,7 @@
 REPO=$1
 OUT=version.go
 # if no local/branch commits beyond master, master and head will be the same
-BUILD_MASTER=`git describe --tags master`
+BUILD_MASTER=`git describe --tags origin/master`
 BUILD_HEAD=`git describe --tags --dirty=+`
 BUILD_AUTHOR=`git config user.name`
 DATE=`date`


### PR DESCRIPTION
The Jenkins git plugin checks out specific commit hashes and ends up
with detached heads and no branches in the local workspace.  The local
`master` is an invalid ref in such cases.