### PR TITLE
EDGECLOUD-4397: ShowCloudletInfo displays output even after cloudlet is deleted

### DIFF
--- a/controller/cloudletinfo_api.go
+++ b/controller/cloudletinfo_api.go
@@ -21,7 +21,7 @@ type CloudletInfoApi struct {
 }
 
 var cloudletInfoApi = CloudletInfoApi{}
-var cleanupCloudletInfoTimeout = 5 * time.Second
+var cleanupCloudletInfoTimeout = 5 * time.Minute
 
 func InitCloudletInfoApi(sync *Sync) {
 	cloudletInfoApi.sync = sync


### PR DESCRIPTION
It can take at least a minute or two for the notifyclient (CRM) to disconnect. Hence increase the timeout for cloudletInfo cleanup.