### PR TITLE
Fix build properties in infra workspace

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,8 +12,6 @@
 edge-cloud/controller/etcdLocal_data
 edge-cloud/edge-mvp
 
-edge-cloud-infra/terraform
-
 # postgres comes from unit tests
 edge-cloud-infra/mc/orm/.postgres
 edge-cloud-infra/openstack-tenant/agent/build


### PR DESCRIPTION
Terraform files are not necessary for docker builds, but skipping those
makes the workspace unclean as git thinks those files have been deleted.
This ends up flagging the workspace as dirty resulting in a "+" suffix
in the BuildHead properties in the output of ShowNode.