### PR TITLE
EDGECLOUD-4413: DME certs need to be wildcard certs for the domain *.dme.mobiledgex.net

### DIFF
--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -571,7 +571,7 @@ func main() {
 		accessApi = accessapi.NewVaultClient(cloudlet, nodeMgr.VaultConfig, *region)
 	}
 	// Setup PublicCertManager for dme
-	publicCertManager := node.NewPublicCertManager(nodeMgr.CommonName(), accessApi)
+	publicCertManager := node.NewPublicCertManager("_.dme.mobiledgex.net", accessApi)
 	if e2e := os.Getenv("E2ETEST_TLS"); e2e != "" || *testMode {
 		publicCertManager = node.NewPublicCertManager(nodeMgr.CommonName(), &cloudcommon.TestPublicCertApi{})
 	}


### PR DESCRIPTION
According to https://mobiledgex.atlassian.net/wiki/spaces/SWDEV/pages/387022871/Generate+Letsencrypt+Certs+using+Vault and following the old code at https://github.com/mobiledgex/edge-cloud/blob/6652a18/docker/vault-cert, public facing dme certs should be generated at /certs/cert/_.dme.mobiledgex.net. This will translate to a CommonName and DNS of "*.dme.mobiledgex.net" to account for all the mcc-mnc mappings.
