### PR TITLE
Remove logs from Show API call

### DIFF
--- a/edgeproto/alert.pb.go
+++ b/edgeproto/alert.pb.go
@@ -842,15 +842,12 @@ func (c *AlertCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *AlertCache) Show(filter *Alert, cb func(ret *Alert) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show Alert", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare Alert", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show Alert", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/app.pb.go
+++ b/edgeproto/app.pb.go
@@ -2655,15 +2655,12 @@ func (c *AppCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *AppCache) Show(filter *App, cb func(ret *App) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show App", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare App", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show App", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/appinst.pb.go
+++ b/edgeproto/appinst.pb.go
@@ -3668,15 +3668,12 @@ func (c *AppInstCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *AppInstCache) Show(filter *AppInst, cb func(ret *AppInst) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show AppInst", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare AppInst", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show AppInst", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err
@@ -4867,15 +4864,12 @@ func (c *AppInstInfoCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *AppInstInfoCache) Show(filter *AppInstInfo, cb func(ret *AppInstInfo) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show AppInstInfo", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare AppInstInfo", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show AppInstInfo", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/appinstclient.pb.go
+++ b/edgeproto/appinstclient.pb.go
@@ -883,15 +883,12 @@ func (c *AppInstClientKeyCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *AppInstClientKeyCache) Show(filter *AppInstClientKey, cb func(ret *AppInstClientKey) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show AppInstClientKey", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare AppInstClientKey", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show AppInstClientKey", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/autoprovpolicy.pb.go
+++ b/edgeproto/autoprovpolicy.pb.go
@@ -1797,15 +1797,12 @@ func (c *AutoProvPolicyCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *AutoProvPolicyCache) Show(filter *AutoProvPolicy, cb func(ret *AutoProvPolicy) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show AutoProvPolicy", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare AutoProvPolicy", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show AutoProvPolicy", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err
@@ -2948,15 +2945,12 @@ func (c *AutoProvInfoCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *AutoProvInfoCache) Show(filter *AutoProvInfo, cb func(ret *AutoProvInfo) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show AutoProvInfo", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare AutoProvInfo", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show AutoProvInfo", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/autoscalepolicy.pb.go
+++ b/edgeproto/autoscalepolicy.pb.go
@@ -1148,15 +1148,12 @@ func (c *AutoScalePolicyCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *AutoScalePolicyCache) Show(filter *AutoScalePolicy, cb func(ret *AutoScalePolicy) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show AutoScalePolicy", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare AutoScalePolicy", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show AutoScalePolicy", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/cloudlet.pb.go
+++ b/edgeproto/cloudlet.pb.go
@@ -6198,15 +6198,12 @@ func (c *CloudletCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *CloudletCache) Show(filter *Cloudlet, cb func(ret *Cloudlet) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show Cloudlet", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare Cloudlet", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show Cloudlet", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err
@@ -8220,15 +8217,12 @@ func (c *CloudletInfoCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *CloudletInfoCache) Show(filter *CloudletInfo, cb func(ret *CloudletInfo) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show CloudletInfo", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare CloudletInfo", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show CloudletInfo", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/cloudletpool.pb.go
+++ b/edgeproto/cloudletpool.pb.go
@@ -1331,15 +1331,12 @@ func (c *CloudletPoolCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *CloudletPoolCache) Show(filter *CloudletPool, cb func(ret *CloudletPool) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show CloudletPool", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare CloudletPool", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show CloudletPool", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/clusterinst.pb.go
+++ b/edgeproto/clusterinst.pb.go
@@ -2701,15 +2701,12 @@ func (c *ClusterInstCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *ClusterInstCache) Show(filter *ClusterInst, cb func(ret *ClusterInst) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show ClusterInst", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare ClusterInst", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show ClusterInst", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err
@@ -3909,15 +3906,12 @@ func (c *ClusterInstInfoCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *ClusterInstInfoCache) Show(filter *ClusterInstInfo, cb func(ret *ClusterInstInfo) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show ClusterInstInfo", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare ClusterInstInfo", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show ClusterInstInfo", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/controller.pb.go
+++ b/edgeproto/controller.pb.go
@@ -943,15 +943,12 @@ func (c *ControllerCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *ControllerCache) Show(filter *Controller, cb func(ret *Controller) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show Controller", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare Controller", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show Controller", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/device.pb.go
+++ b/edgeproto/device.pb.go
@@ -1612,15 +1612,12 @@ func (c *DeviceCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *DeviceCache) Show(filter *Device, cb func(ret *Device) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show Device", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare Device", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show Device", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/flavor.pb.go
+++ b/edgeproto/flavor.pb.go
@@ -1225,15 +1225,12 @@ func (c *FlavorCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *FlavorCache) Show(filter *Flavor, cb func(ret *Flavor) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show Flavor", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare Flavor", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show Flavor", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/node.pb.go
+++ b/edgeproto/node.pb.go
@@ -1421,15 +1421,12 @@ func (c *NodeCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *NodeCache) Show(filter *Node, cb func(ret *Node) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show Node", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare Node", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show Node", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/operatorcode.pb.go
+++ b/edgeproto/operatorcode.pb.go
@@ -702,15 +702,12 @@ func (c *OperatorCodeCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *OperatorCodeCache) Show(filter *OperatorCode, cb func(ret *OperatorCode) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show OperatorCode", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare OperatorCode", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show OperatorCode", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/refs.pb.go
+++ b/edgeproto/refs.pb.go
@@ -1521,15 +1521,12 @@ func (c *CloudletRefsCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *CloudletRefsCache) Show(filter *CloudletRefs, cb func(ret *CloudletRefs) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show CloudletRefs", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare CloudletRefs", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show CloudletRefs", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err
@@ -2159,15 +2156,12 @@ func (c *ClusterRefsCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *ClusterRefsCache) Show(filter *ClusterRefs, cb func(ret *ClusterRefs) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show ClusterRefs", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare ClusterRefs", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show ClusterRefs", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err
@@ -2756,15 +2750,12 @@ func (c *AppInstRefsCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *AppInstRefsCache) Show(filter *AppInstRefs, cb func(ret *AppInstRefs) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show AppInstRefs", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare AppInstRefs", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show AppInstRefs", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/restagtable.pb.go
+++ b/edgeproto/restagtable.pb.go
@@ -1306,15 +1306,12 @@ func (c *ResTagTableCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *ResTagTableCache) Show(filter *ResTagTable, cb func(ret *ResTagTable) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show ResTagTable", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare ResTagTable", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show ResTagTable", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/settings.pb.go
+++ b/edgeproto/settings.pb.go
@@ -1448,15 +1448,12 @@ func (c *SettingsCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *SettingsCache) Show(filter *Settings, cb func(ret *Settings) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show Settings", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare Settings", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show Settings", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/trustpolicy.pb.go
+++ b/edgeproto/trustpolicy.pb.go
@@ -1125,15 +1125,12 @@ func (c *TrustPolicyCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *TrustPolicyCache) Show(filter *TrustPolicy, cb func(ret *TrustPolicy) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show TrustPolicy", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare TrustPolicy", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show TrustPolicy", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/edgeproto/vmpool.pb.go
+++ b/edgeproto/vmpool.pb.go
@@ -2366,15 +2366,12 @@ func (c *VMPoolCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *VMPoolCache) Show(filter *VMPool, cb func(ret *VMPool) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show VMPool", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare VMPool", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show VMPool", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err
@@ -3716,15 +3713,12 @@ func (c *VMPoolInfoCache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *VMPoolInfoCache) Show(filter *VMPoolInfo, cb func(ret *VMPoolInfo) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show VMPoolInfo", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
-		log.DebugLog(log.DebugLevelApi, "Compare VMPoolInfo", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
-		log.DebugLog(log.DebugLevelApi, "Show VMPoolInfo", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err

--- a/protoc-gen-gomex/mexgen/mex.go
+++ b/protoc-gen-gomex/mexgen/mex.go
@@ -1383,17 +1383,14 @@ func (c *{{.Name}}Cache) Flush(ctx context.Context, notifyId int64) {
 }
 
 func (c *{{.Name}}Cache) Show(filter *{{.Name}}, cb func(ret *{{.Name}}) error) error {
-	log.DebugLog(log.DebugLevelApi, "Show {{.Name}}", "count", len(c.Objs))
 	c.Mux.Lock()
 	defer c.Mux.Unlock()
 	for _, data := range c.Objs {
 {{- if .CudCache}}
-		log.DebugLog(log.DebugLevelApi, "Compare {{.Name}}", "filter", filter, "data", data)
 		if !data.Obj.Matches(filter, MatchFilter()) {
 			continue
 		}
 {{- end}}
-		log.DebugLog(log.DebugLevelApi, "Show {{.Name}}", "obj", data.Obj)
 		err := cb(data.Obj)
 		if err != nil {
 			return err


### PR DESCRIPTION
* An effort to remove cluttering of log files, especially ShowAlert API call, as it is called periodically.
* I don't see much use of these logs, let me know if it is required