### PR TITLE
trustpolicy error to user

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -1834,6 +1834,7 @@ func (s *CloudletApi) UpdateCloudletsUsingTrustPolicy(ctx context.Context, trust
 		if result.errString == "" {
 			numPassed++
 		} else {
+			cb.Send(&edgeproto.Result{Message: fmt.Sprintf("Failed to update cloudlet: %s - %s", k, result.errString)})
 			numFailed++
 		}
 	}


### PR DESCRIPTION
EDGECLOUD-4237

Per Andy's request, send a message back to the user when UpdateTrustPolicy fails on a particular cloudlet to show the details.
