### PR TITLE
EDGECLOUD-4440 prevent vm app with autocluster

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -495,6 +495,11 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			return errors.New("Specified Cloudlet not found")
 		}
 
+		if autoClusterSpecified {
+			if !cloudcommon.IsClusterInstReqd(&app) {
+				return fmt.Errorf("No cluster required for App deployment type %s, cannot use cluster name %s which attempts to use or create a ClusterInst", app.Deployment, cloudcommon.AutoClusterPrefix)
+			}
+		}
 		// Check for autocluster. All auto-clusters are reservable.
 		// To allow for vanity naming, the cluster name in the key
 		// can by any name prefixed with the AutoClusterPrefix, but
@@ -505,9 +510,6 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		if in.RealClusterName == "" && autoClusterSpecified {
 			// search for free reservable ClusterInst
 			log.SpanLog(ctx, log.DebugLevelInfo, "reservable auto-cluster search", "key", in.Key)
-			if !cloudcommon.IsClusterInstReqd(&app) {
-				return fmt.Errorf("No cluster required for App deployment type %s, cannot use cluster name %s which attempts to use or create a ClusterInst", app.Deployment, cloudcommon.AutoClusterPrefix)
-			}
 			if sidecarApp {
 				return fmt.Errorf("Sidecar AppInst (AutoDelete App) must specify the RealClusterName field to deploy to the virtual cluster name %s, or specify the real cluster name in the key", in.Key.ClusterInstKey.ClusterKey.Name)
 			}

--- a/controller/clusterinst_api_test.go
+++ b/controller/clusterinst_api_test.go
@@ -289,6 +289,23 @@ func testReservableClusterInst(t *testing.T, ctx context.Context, api *testutil.
 	err = appInstApi.DeleteAppInst(&appinst2, streamOut)
 	require.Nil(t, err, "delete AppInst on reservable ClusterInst")
 	checkReservedBy(t, ctx, api, &cinst.Key, "")
+
+	// Cannot create VM with autocluster
+	appinstBad := edgeproto.AppInst{}
+	appinstBad.Key.AppKey = testutil.AppData[12].Key
+	appinstBad.Key.ClusterInstKey.CloudletKey = testutil.CloudletData[0].Key
+	appinstBad.Key.ClusterInstKey.ClusterKey.Name = "autoclusterBad"
+	appinstBad.Key.ClusterInstKey.Organization = cloudcommon.OrganizationMobiledgeX
+	err = appInstApi.CreateAppInst(&appinstBad, streamOut)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "No cluster required for App deployment type vm")
+
+	// Cannot create VM with autocluster and realclustername
+	appinstBad.RealClusterName = cinst.Key.ClusterKey.Name
+	err = appInstApi.CreateAppInst(&appinstBad, streamOut)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "No cluster required for App deployment type vm")
+
 	// Delete App
 	for _, app := range testutil.AppData {
 		_, err = appApi.DeleteApp(ctx, &app)


### PR DESCRIPTION
Prevent vm app with autoclusters. Just had to move the check so it couldn't be bypassed if the RealClusterName was specified.