### PR TITLE
EDGECLOUD-4461: TMNL VMpool cloudlet fail to add few VM's to VMpool

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -1183,14 +1183,14 @@ func (cd *ControllerData) UpdateVMPool(ctx context.Context, k interface{}) {
 	var cloudletInfo edgeproto.CloudletInfo
 	if !cd.CloudletInfoCache.Get(&cd.cloudletKey, &cloudletInfo) {
 		log.SpanLog(ctx, log.DebugLevelInfra, "failed to update vmpool flavors, missing cloudletinfo", "vmpool", key, "cloudlet", cd.cloudletKey)
-		return
+	} else {
+		err = cd.platform.GatherCloudletInfo(ctx, &cloudletInfo)
+		if err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfra, "failed to gather vmpool flavors", "vmpool", key, "cloudlet", cd.cloudletKey, "err", err)
+		} else {
+			cd.CloudletInfoCache.Update(ctx, &cloudletInfo, 0)
+		}
 	}
-	err = cd.platform.GatherCloudletInfo(ctx, &cloudletInfo)
-	if err != nil {
-		log.SpanLog(ctx, log.DebugLevelInfra, "failed to gather vmpool flavors", "vmpool", key, "cloudlet", cd.cloudletKey, "err", err)
-		return
-	}
-	cd.CloudletInfoCache.Update(ctx, &cloudletInfo, 0)
 
 	// notify controller
 	cd.UpdateVMPoolInfo(ctx, edgeproto.TrackedState_READY, "")


### PR DESCRIPTION
Found an issue during TMNL testing, we were not setting the READY state for the VMPool object if there were any failure to fetch the flavor list