### PR TITLE
Start span lineno

### DIFF
--- a/log/jaeger.go
+++ b/log/jaeger.go
@@ -135,6 +135,7 @@ func SpanToString(ctx context.Context) string {
 }
 
 func NewSpanFromString(lvl uint64, val, spanName string) opentracing.Span {
+	linenoOpt := WithSpanLineno{GetLineno(1)}
 	if val != "" {
 		var t TraceData
 		t = make(map[string]string)
@@ -144,9 +145,9 @@ func NewSpanFromString(lvl uint64, val, spanName string) opentracing.Span {
 			if err == nil {
 				// parent span exists so new lvl is ignored,
 				// lvl used for parent is honored.
-				return StartSpan(IgnoreLvl, spanName, ext.RPCServerOption(spanCtx))
+				return StartSpan(IgnoreLvl, spanName, ext.RPCServerOption(spanCtx), linenoOpt)
 			}
 		}
 	}
-	return StartSpan(lvl, spanName)
+	return StartSpan(lvl, spanName, linenoOpt)
 }


### PR DESCRIPTION
This sets the line number of the StartSpan call on the span as a tag. This will allow us to track down where exactly in the code a span is started from, which would have been useful when debugging the flood of metric spans being generated by shepherd.

Also I fixed a problem that was causing the tags to be missing in the span show command, and removed some leftover debug prints.
