### PR TITLE
revert tag changes in influx

### DIFF
--- a/controller/app_checkpoints.go
+++ b/controller/app_checkpoints.go
@@ -85,14 +85,14 @@ func createAppUsageMetric(appInst *edgeproto.AppInst, appInfo *edgeproto.App, st
 	metric.AddTag("org", appInst.Key.AppKey.Organization)
 	metric.AddTag("app", appInst.Key.AppKey.Name)
 	metric.AddTag("ver", appInst.Key.AppKey.Version)
-	metric.AddStringVal("deployment", appInfo.Deployment)
+	metric.AddTag("deployment", appInfo.Deployment)
 	metric.AddStringVal("start", startUTC.Format(time.RFC3339))
 	metric.AddStringVal("end", endUTC.Format(time.RFC3339))
 	metric.AddDoubleVal("uptime", runTime.Seconds())
-	metric.AddStringVal("status", status)
+	metric.AddTag("status", status)
 
 	if appInfo.Deployment == cloudcommon.DeploymentTypeVM {
-		metric.AddStringVal("flavor", appInst.Flavor.Name)
+		metric.AddTag("flavor", appInst.Flavor.Name)
 	}
 
 	return &metric

--- a/controller/cluster_checkpoints.go
+++ b/controller/cluster_checkpoints.go
@@ -81,7 +81,7 @@ func createClusterUsageMetric(cluster *edgeproto.ClusterInst, startTime, endTime
 	metric.AddTag("cloudlet", cluster.Key.CloudletKey.Name)
 	metric.AddTag("cluster", cluster.Key.ClusterKey.Name)
 	metric.AddTag("clusterorg", cluster.Key.Organization)
-	metric.AddStringVal("flavor", cluster.Flavor.Name)
+	metric.AddTag("flavor", cluster.Flavor.Name)
 	metric.AddIntVal("nodecount", uint64(cluster.NumMasters+cluster.NumNodes))
 	metric.AddStringVal("ipaccess", cluster.IpAccess.String())
 	metric.AddStringVal("start", startUTC.Format(time.RFC3339))
@@ -92,7 +92,7 @@ func createClusterUsageMetric(cluster *edgeproto.ClusterInst, startTime, endTime
 	} else {
 		metric.AddTag("org", cluster.Key.Organization)
 	}
-	metric.AddStringVal("status", status)
+	metric.AddTag("status", status)
 	return &metric
 }
 


### PR DESCRIPTION
This reverts the changes in app_checkpoints.go and cluster_checkpoints.go in this PR: https://github.com/mobiledgex/edge-cloud/pull/1249

This way billing data gets preserved and we only have to delete the `metrics` and `persistent_metrics` dbs for the influx stability issues in edgecloud-4487. 