### PR TITLE
EDGECLOUD-4529 autoprov service deadlock

### DIFF
--- a/d-match-engine/dme-common/autoprov-stats.go
+++ b/d-match-engine/dme-common/autoprov-stats.go
@@ -64,10 +64,12 @@ func (s *AutoProvStats) Start() {
 
 func (s *AutoProvStats) Stop() {
 	s.mux.Lock()
-	defer s.mux.Unlock()
 	close(s.stop)
+	s.mux.Unlock()
 	s.waitGroup.Wait()
+	s.mux.Lock()
 	s.stop = nil
+	s.mux.Unlock()
 }
 
 func (s *AutoProvStats) UpdateSettings(intervalSec float64) {

--- a/d-match-engine/dme-common/dme-stats.go
+++ b/d-match-engine/dme-common/dme-stats.go
@@ -93,10 +93,12 @@ func (s *DmeStats) Start() {
 
 func (s *DmeStats) Stop() {
 	s.mux.Lock()
-	defer s.mux.Unlock()
 	close(s.stop)
+	s.mux.Unlock()
 	s.waitGroup.Wait()
+	s.mux.Lock()
 	s.stop = nil
+	s.mux.Unlock()
 }
 
 func (s *DmeStats) UpdateSettings(interval time.Duration) {

--- a/d-match-engine/dme-common/edgeevents-stats.go
+++ b/d-match-engine/dme-common/edgeevents-stats.go
@@ -71,10 +71,12 @@ func (e *EdgeEventStats) Start() {
 
 func (e *EdgeEventStats) Stop() {
 	e.mux.Lock()
-	defer e.mux.Unlock()
 	close(e.stop)
+	e.mux.Unlock()
 	e.waitGroup.Wait()
+	e.mux.Lock()
 	e.stop = nil
+	e.mux.Unlock()
 }
 
 func (e *EdgeEventStats) UpdateSettings(interval time.Duration) {


### PR DESCRIPTION
Fixed deadlock caused by waitGroup.Wait() being called while under lock (it doesn't release the lock like a C pthread_cond_wait).
