### PR TITLE
fix  AtomicCertsUpdater permissions

### DIFF
--- a/cloud-resource-manager/proxy/envoy.go
+++ b/cloud-resource-manager/proxy/envoy.go
@@ -40,7 +40,6 @@ func CreateEnvoyProxy(ctx context.Context, client ssh.Client, name, listenIP, ba
 
 	dir := pwd + "/envoy/" + name
 	log.SpanLog(ctx, log.DebugLevelInfra, "envoy remote dir", "name", name, "dir", dir)
-
 	err = pc.Run(client, "mkdir -p "+dir)
 	if err != nil {
 		return err
@@ -80,9 +79,11 @@ func CreateEnvoyProxy(ctx context.Context, client ssh.Client, name, listenIP, ba
 	cmdArgs = append(cmdArgs, []string{
 		"-v", certsDir + ":/etc/envoy/certs",
 		"-v", accesslogFile + ":/tmp/access.log",
-		"-v", eyamlName + ":/etc/envoy/envoy.yaml",
-		"-u", "1000:1000",
-		"docker.mobiledgex.net/mobiledgex/mobiledgex_public/envoy-with-curl@" + cloudcommon.EnvoyImageDigest}...)
+		"-v", eyamlName + ":/etc/envoy/envoy.yaml"}...)
+	if opts.DockerUser != "" {
+		cmdArgs = append(cmdArgs, []string{"-u", fmt.Sprintf("%s:%s", opts.DockerUser, opts.DockerUser)}...)
+	}
+	cmdArgs = append(cmdArgs, "docker.mobiledgex.net/mobiledgex/mobiledgex_public/envoy-with-curl@"+cloudcommon.EnvoyImageDigest)
 	cmd := "docker " + strings.Join(cmdArgs, " ")
 	log.SpanLog(ctx, log.DebugLevelInfra, "envoy docker command", "name", "envoy"+name,
 		"cmd", cmd)

--- a/cloud-resource-manager/proxy/nginx.go
+++ b/cloud-resource-manager/proxy/nginx.go
@@ -338,6 +338,7 @@ type Options struct {
 	DockerPublishPorts bool
 	DockerNetwork      string
 	Cert               *access.TLSCert
+	DockerUser         string
 }
 
 type Op func(opts *Options)
@@ -358,6 +359,12 @@ func WithTLSCert(cert *access.TLSCert) Op {
 	return func(opts *Options) {
 		opts.Cert = cert
 		opts.Cert.CommonName = strings.Replace(opts.Cert.CommonName, "*", "_", 1)
+	}
+}
+
+func WithDockerUser(user string) Op {
+	return func(opts *Options) {
+		opts.DockerUser = user
 	}
 }
 


### PR DESCRIPTION
EDGECLOUD-4120
EDGECLOUD-4532

Fix the following issues:
- VMApp TLS is not working because the AtomicCertsHelper is running without sudo permissions.   Fix is to use the same sudoType as the certs are generated with.  There is also an infra side to the problem in that the envoy is created before the TLS certs exist.  This causes delays as per EDGECLOUD-4120 because envoy keeps restarting for some time, but I have also seen where envoy doesn't restart at all, it just fails the TLS indefinitely
- An unrelated cosmetic issue in the envoy LB exists in which when you login to the container it shows "No name" because it's running as ubuntu user (1000, first non-root user created) and envoy doesn't know this id.  It doesn't cause any problems but it looks bad and confusing to login to the container.  Because k8s baremetal needs the 1000 user due to some permissions issues, and VM platforms do not, I made the docker user for envoy optional