### PR TITLE
EDGECLOUD-4499  Add dmeId to the api stats and change it to a tag

### DIFF
--- a/d-match-engine/dme-common/dme-stats.go
+++ b/d-match-engine/dme-common/dme-stats.go
@@ -68,6 +68,10 @@ type DmeStats struct {
 	stop      chan struct{}
 }
 
+func init() {
+	*ScaleID = cloudcommon.Hostname()
+}
+
 func NewDmeStats(interval time.Duration, numShards uint, send func(ctx context.Context, metric *edgeproto.Metric) bool) *DmeStats {
 	s := DmeStats{}
 	s.shards = make([]MapShard, numShards, numShards)
@@ -174,7 +178,7 @@ func ApiStatToMetric(ts *types.Timestamp, key *StatKey, stat *ApiStat) *edgeprot
 	metric.AddTag("ver", key.AppKey.Version)
 	metric.AddTag("cloudletorg", MyCloudletKey.Organization)
 	metric.AddTag("cloudlet", MyCloudletKey.Name)
-	metric.AddStringVal("id", *ScaleID)
+	metric.AddTag("dmeId", *ScaleID)
 	metric.AddTag("method", key.Method)
 	metric.AddIntVal("reqs", stat.reqs)
 	metric.AddIntVal("errs", stat.errs)


### PR DESCRIPTION
Set dme `scaleId` to the hostname  at init. Also changed `id` to `dmeId` to make it clear what it's for and made it a tag rather than a string, as we'll need to group on it in the later changes.