### PR TITLE
EDGECLOUD-3458 invite developer org to cloudlet pool

### DIFF
--- a/setup-env/apis/controllerapi.go
+++ b/setup-env/apis/controllerapi.go
@@ -142,7 +142,7 @@ func RunControllerAPI(api string, ctrlname string, apiFile string, outputDir str
 		case "remove":
 			//run in reverse order to delete child keys
 			output := &testutil.AllDataOut{}
-			testutil.RunAllDataReverseApis(run, &appData, appDataMap, output)
+			testutil.RunAllDataReverseApis(run, &appData, appDataMap, output, testutil.NoApiCallback)
 			util.PrintToYamlFile("api-output.yml", outputDir, output, true)
 		case "create":
 			fallthrough
@@ -152,7 +152,7 @@ func RunControllerAPI(api string, ctrlname string, apiFile string, outputDir str
 			fallthrough
 		case "update":
 			output := &testutil.AllDataOut{}
-			testutil.RunAllDataApis(run, &appData, appDataMap, output)
+			testutil.RunAllDataApis(run, &appData, appDataMap, output, testutil.NoApiCallback)
 			util.PrintToYamlFile("api-output.yml", outputDir, output, true)
 		case "stream":
 			output := &testutil.AllDataStreamOut{}
@@ -354,7 +354,7 @@ func runDebug(run *testutil.Run, api, apiFile, outputDir string) {
 		*run.Rc = false
 		return
 	}
-	testutil.RunDebugDataApis(run, &data, make(map[string]interface{}), &output)
+	testutil.RunDebugDataApis(run, &data, make(map[string]interface{}), &output, testutil.NoApiCallback)
 	util.PrintToYamlFile("api-output.yml", outputDir, &output, true)
 }
 
@@ -373,6 +373,6 @@ func runOrg(run *testutil.Run, api, apiFile, outputDir string) {
 	}
 
 	output := testutil.OrganizationDataOut{}
-	testutil.RunOrganizationDataApis(run, &data, make(map[string]interface{}), &output)
+	testutil.RunOrganizationDataApis(run, &data, make(map[string]interface{}), &output, testutil.NoApiCallback)
 	util.PrintToYamlFile("api-output.yml", outputDir, &output, true)
 }

--- a/testutil/alldata_testutil.go
+++ b/testutil/alldata_testutil.go
@@ -38,43 +38,82 @@ type AllDataOut struct {
 	Errors                     []Err
 }
 
-func RunAllDataApis(run *Run, in *edgeproto.AllData, inMap map[string]interface{}, out *AllDataOut) {
+// used to intersperse other creates/deletes/checks
+// note the objs value is the previous one for create,
+// but the next one for delete
+type RunAllDataApiCallback func(objs string)
+
+func RunAllDataApis(run *Run, in *edgeproto.AllData, inMap map[string]interface{}, out *AllDataOut, apicb RunAllDataApiCallback) {
+	apicb("")
 	run.FlavorApi(&in.Flavors, inMap["flavors"], &out.Flavors)
+	apicb("flavors")
 	run.SettingsApi(in.Settings, inMap["settings"], &out.Settings)
+	apicb("settings")
 	run.OperatorCodeApi(&in.OperatorCodes, inMap["operatorcodes"], &out.OperatorCodes)
+	apicb("operatorcodes")
 	run.ResTagTableApi(&in.ResTagTables, inMap["restagtables"], &out.ResTagTables)
+	apicb("restagtables")
 	run.TrustPolicyApi(&in.TrustPolicies, inMap["trustpolicies"], &out.TrustPolicies)
+	apicb("trustpolicies")
 	run.CloudletApi(&in.Cloudlets, inMap["cloudlets"], &out.Cloudlets)
+	apicb("cloudlets")
 	run.CloudletInfoApi(&in.CloudletInfos, inMap["cloudletinfos"], &out.CloudletInfos)
+	apicb("cloudletinfos")
 	run.CloudletPoolApi(&in.CloudletPools, inMap["cloudletpools"], &out.CloudletPools)
+	apicb("cloudletpools")
 	run.AutoProvPolicyApi(&in.AutoProvPolicies, inMap["autoprovpolicies"], &out.AutoProvPolicies)
+	apicb("autoprovpolicies")
 	run.AutoProvPolicyApi_AutoProvPolicyCloudlet(&in.AutoProvPolicyCloudlets, inMap["autoprovpolicycloudlets"], &out.AutoProvPolicyCloudlets)
+	apicb("autoprovpolicycloudlets")
 	run.AutoScalePolicyApi(&in.AutoScalePolicies, inMap["autoscalepolicies"], &out.AutoScalePolicies)
+	apicb("autoscalepolicies")
 	run.ClusterInstApi_IdleReservableClusterInsts(in.IdleReservableClusterInsts, inMap["idlereservableclusterinsts"], &out.IdleReservableClusterInsts)
+	apicb("idlereservableclusterinsts")
 	run.ClusterInstApi(&in.ClusterInsts, inMap["clusterinsts"], &out.ClusterInsts)
+	apicb("clusterinsts")
 	run.AppApi(&in.Apps, inMap["apps"], &out.Apps)
+	apicb("apps")
 	run.AppInstApi(&in.AppInstances, inMap["appinstances"], &out.AppInstances)
+	apicb("appinstances")
 	run.VMPoolApi(&in.VmPools, inMap["vmpools"], &out.VmPools)
+	apicb("vmpools")
 	out.Errors = run.Errs
 }
 
-func RunAllDataReverseApis(run *Run, in *edgeproto.AllData, inMap map[string]interface{}, out *AllDataOut) {
+func RunAllDataReverseApis(run *Run, in *edgeproto.AllData, inMap map[string]interface{}, out *AllDataOut, apicb RunAllDataApiCallback) {
+	apicb("vmpools")
 	run.VMPoolApi(&in.VmPools, inMap["vmpools"], &out.VmPools)
+	apicb("appinstances")
 	run.AppInstApi(&in.AppInstances, inMap["appinstances"], &out.AppInstances)
+	apicb("apps")
 	run.AppApi(&in.Apps, inMap["apps"], &out.Apps)
+	apicb("clusterinsts")
 	run.ClusterInstApi(&in.ClusterInsts, inMap["clusterinsts"], &out.ClusterInsts)
+	apicb("idlereservableclusterinsts")
 	run.ClusterInstApi_IdleReservableClusterInsts(in.IdleReservableClusterInsts, inMap["idlereservableclusterinsts"], &out.IdleReservableClusterInsts)
+	apicb("autoscalepolicies")
 	run.AutoScalePolicyApi(&in.AutoScalePolicies, inMap["autoscalepolicies"], &out.AutoScalePolicies)
+	apicb("autoprovpolicycloudlets")
 	run.AutoProvPolicyApi_AutoProvPolicyCloudlet(&in.AutoProvPolicyCloudlets, inMap["autoprovpolicycloudlets"], &out.AutoProvPolicyCloudlets)
+	apicb("autoprovpolicies")
 	run.AutoProvPolicyApi(&in.AutoProvPolicies, inMap["autoprovpolicies"], &out.AutoProvPolicies)
+	apicb("cloudletpools")
 	run.CloudletPoolApi(&in.CloudletPools, inMap["cloudletpools"], &out.CloudletPools)
+	apicb("cloudletinfos")
 	run.CloudletInfoApi(&in.CloudletInfos, inMap["cloudletinfos"], &out.CloudletInfos)
+	apicb("cloudlets")
 	run.CloudletApi(&in.Cloudlets, inMap["cloudlets"], &out.Cloudlets)
+	apicb("trustpolicies")
 	run.TrustPolicyApi(&in.TrustPolicies, inMap["trustpolicies"], &out.TrustPolicies)
+	apicb("restagtables")
 	run.ResTagTableApi(&in.ResTagTables, inMap["restagtables"], &out.ResTagTables)
+	apicb("operatorcodes")
 	run.OperatorCodeApi(&in.OperatorCodes, inMap["operatorcodes"], &out.OperatorCodes)
+	apicb("settings")
 	run.SettingsApi(in.Settings, inMap["settings"], &out.Settings)
+	apicb("flavors")
 	run.FlavorApi(&in.Flavors, inMap["flavors"], &out.Flavors)
+	apicb("")
 	out.Errors = run.Errs
 }
 

--- a/testutil/run.go
+++ b/testutil/run.go
@@ -10,6 +10,8 @@ import (
 
 const TagExpectErr = "expecterr"
 
+var NoApiCallback = func(string) {}
+
 type Run struct {
 	client Client
 	ctx    context.Context


### PR DESCRIPTION
Auto-generated test-code changes for https://github.com/mobiledgex/edge-cloud-infra/pull/1365.

These allow the infra e2e-test code to intersperse infra-related creates/deletes in between the regional creates/deletes, via a callback function.