### PR TITLE
Fix cloudlet resource usage related issues

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -806,7 +806,7 @@ func (s *CloudletApi) UpdateCloudlet(in *edgeproto.Cloudlet, inCb edgeproto.Clou
 
 	if !ignoreCRMState(cctx) {
 		var cloudletPlatform pf.Platform
-		cloudletPlatform, err := pfutils.GetPlatform(ctx, in.PlatformType.String(), nodeMgr.UpdateNodeProps)
+		cloudletPlatform, err := pfutils.GetPlatform(ctx, cur.PlatformType.String(), nodeMgr.UpdateNodeProps)
 		if err != nil {
 			return err
 		}
@@ -1819,7 +1819,7 @@ func GetCloudletResourceInfo(ctx context.Context, stm concurrency.STM, cloudlet 
 			if resTagTableApi.UsesGpu(ctx, stm, *vmRes.VmFlavor, *cloudlet) {
 				gpusInfo, ok := resInfo[cloudcommon.ResourceGpus]
 				if ok {
-					diskInfo.Value += 1
+					gpusInfo.Value += 1
 					resInfo[cloudcommon.ResourceGpus] = gpusInfo
 				}
 			}
@@ -1881,13 +1881,12 @@ func getResourceUsage(ctx context.Context, stm concurrency.STM, cloudlet *edgepr
 	if err != nil {
 		return nil, err
 	}
-	for resName, _ := range infraResInfoMap {
-		if diffResInfo, ok := diffResInfo[resName]; ok {
-			outInfo, ok := infraResInfoMap[resName]
-			if ok {
-				outInfo.Value += diffResInfo.Value
-				infraResInfoMap[resName] = outInfo
-			}
+	for resName, resInfo := range diffResInfo {
+		if infraResInfo, ok := infraResInfoMap[resName]; ok {
+			infraResInfo.Value += resInfo.Value
+			infraResInfoMap[resName] = infraResInfo
+		} else {
+			infraResInfoMap[resName] = resInfo
 		}
 	}
 	out := []edgeproto.InfraResource{}


### PR DESCRIPTION
Fixes following issues
* EDGECLOUD-4450: Unable to change number of Instances under resource quotas using UpdateCloudlet
* EDGECLOUD-4516: Unable to change number of Floating IPs under resource quotas using UpdateCloudlet for PlatformTypeOpenstack
* EDGECLOUD-4444: GetCloudletResourceUsage does not show GPU usage of a cloudlet