### PR TITLE
EDGECLOUD-4538: AlertReceiver does not generate 'CloudletResourceUsage' alerts

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -3,6 +3,7 @@ package crmutil
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
@@ -228,10 +229,16 @@ func (cd *ControllerData) CaptureResourcesSnapshot(ctx context.Context, cloudlet
 	for k, _ := range deployedClusters {
 		deployedClusterKeys = append(deployedClusterKeys, k)
 	}
+	sort.Slice(deployedClusterKeys, func(ii, jj int) bool {
+		return deployedClusterKeys[ii].GetKeyString() < deployedClusterKeys[jj].GetKeyString()
+	})
 	deployedVMAppKeys := []edgeproto.AppInstRefKey{}
 	for k, _ := range deployedVMAppInsts {
 		deployedVMAppKeys = append(deployedVMAppKeys, k)
 	}
+	sort.Slice(deployedVMAppKeys, func(ii, jj int) bool {
+		return deployedVMAppKeys[ii].GetKeyString() < deployedVMAppKeys[jj].GetKeyString()
+	})
 	resources.ClusterInsts = deployedClusterKeys
 	resources.VmAppInsts = deployedVMAppKeys
 	return resources

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -490,6 +490,7 @@ func handleResourceUsageAlerts(ctx context.Context, stm concurrency.STM, key *ed
 		staleAlerts[*k] = struct{}{}
 	})
 	for _, alert := range alerts {
+		alertApi.setAlertMetadata(&alert)
 		alertApi.store.STMPut(stm, &alert)
 		delete(staleAlerts, alert.GetKeyVal())
 	}


### PR DESCRIPTION
* CloudletResourceUsage alerts were missing the `region` label. Refactored the code to fix this. Thanks, @levshvarts for helping out!
* Sort objects for predictable testing