### PR TITLE
EDGECLOUD-4164 fix update autodeployintervalsec gt check

### DIFF
--- a/edgeproto/field_validator.go
+++ b/edgeproto/field_validator.go
@@ -33,6 +33,15 @@ func (s *FieldValidator) CheckFloatGE(field string, val, gt float64) {
 	}
 }
 
+func (s *FieldValidator) CheckFloatGT(field string, val, gt float64) {
+	if s.err != nil {
+		return
+	}
+	if val <= gt {
+		s.err = fmt.Errorf("%s must be greater than %f", s.fieldDesc[field], gt)
+	}
+}
+
 func (s *FieldValidator) CheckLT(field string, val, lt int64) {
 	if s.err != nil {
 		return

--- a/edgeproto/settings.go
+++ b/edgeproto/settings.go
@@ -69,9 +69,9 @@ func (s *Settings) Validate(fields map[string]struct{}) error {
 		case SettingsFieldShepherdHealthCheckInterval:
 			v.CheckGT(f, int64(s.ShepherdHealthCheckInterval), 0)
 		case SettingsFieldAutoDeployIntervalSec:
-			v.CheckGT(f, int64(s.AutoDeployIntervalSec), 0)
+			v.CheckFloatGT(f, s.AutoDeployIntervalSec, 0)
 		case SettingsFieldAutoDeployOffsetSec:
-			v.CheckFloatGE(f, float64(s.AutoDeployOffsetSec), 0)
+			v.CheckFloatGE(f, s.AutoDeployOffsetSec, 0)
 		case SettingsFieldAutoDeployMaxIntervals:
 			v.CheckGT(f, int64(s.AutoDeployMaxIntervals), 0)
 		case SettingsFieldLoadBalancerMaxPortRange:


### PR DESCRIPTION
Greater than check was not working properly because of int64 cast of float64 value.