### PR TITLE
EDGECLOUD-3025 mcctl reorg commands

### DIFF
--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -144,9 +143,6 @@ const EnvoyImageDigest = "sha256:9bc06553ad6add6bfef1d8a1b04f09721415975e2507da0
 var platformApps = map[string]bool{
 	OrganizationSamsung + ":" + SamsungEnablingLayer: true,
 }
-
-// Common regular expression for quoted strings parse
-var QuotedStringRegex = regexp.MustCompile(`"(.*?)"`)
 
 // IsPlatformApp true if the developer/app combo is a platform app
 func IsPlatformApp(devname string, appname string) bool {

--- a/edgeproto/app.pb.go
+++ b/edgeproto/app.pb.go
@@ -597,7 +597,9 @@ type AppApiClient interface {
 	// Show Applications. Lists all Application definitions managed from the Edge Controller.
 	// Any fields specified will be used to filter results.
 	ShowApp(ctx context.Context, in *App, opts ...grpc.CallOption) (AppApi_ShowAppClient, error)
+	// Add an AutoProvPolicy to the App
 	AddAppAutoProvPolicy(ctx context.Context, in *AppAutoProvPolicy, opts ...grpc.CallOption) (*Result, error)
+	// Remove an AutoProvPolicy from the App
 	RemoveAppAutoProvPolicy(ctx context.Context, in *AppAutoProvPolicy, opts ...grpc.CallOption) (*Result, error)
 }
 
@@ -698,7 +700,9 @@ type AppApiServer interface {
 	// Show Applications. Lists all Application definitions managed from the Edge Controller.
 	// Any fields specified will be used to filter results.
 	ShowApp(*App, AppApi_ShowAppServer) error
+	// Add an AutoProvPolicy to the App
 	AddAppAutoProvPolicy(context.Context, *AppAutoProvPolicy) (*Result, error)
+	// Remove an AutoProvPolicy from the App
 	RemoveAppAutoProvPolicy(context.Context, *AppAutoProvPolicy) (*Result, error)
 }
 

--- a/edgeproto/app.proto
+++ b/edgeproto/app.proto
@@ -235,6 +235,7 @@ service AppApi {
     };
     option (protogen.mc2_api) = "ResourceApps,ActionView,Key.Organization";
   }
+  // Add an AutoProvPolicy to the App
   rpc AddAppAutoProvPolicy(AppAutoProvPolicy) returns (Result) {
     option (google.api.http) = {
       post: "/add/appautoprovpolicy"
@@ -243,6 +244,7 @@ service AppApi {
     option (protogen.mc2_api) = "ResourceApps,ActionManage,AppKey.Organization";
     option (protogen.input_required) = true;
   }
+  // Remove an AutoProvPolicy from the App
   rpc RemoveAppAutoProvPolicy(AppAutoProvPolicy) returns (Result) {
     option (google.api.http) = {
       post: "/remove/appautoprovpolicy"

--- a/edgeproto/debug.pb.go
+++ b/edgeproto/debug.pb.go
@@ -228,9 +228,13 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type DebugApiClient interface {
+	// Enable debug log levels
 	EnableDebugLevels(ctx context.Context, in *DebugRequest, opts ...grpc.CallOption) (DebugApi_EnableDebugLevelsClient, error)
+	// Disable debug log levels
 	DisableDebugLevels(ctx context.Context, in *DebugRequest, opts ...grpc.CallOption) (DebugApi_DisableDebugLevelsClient, error)
+	// Show debug log levels
 	ShowDebugLevels(ctx context.Context, in *DebugRequest, opts ...grpc.CallOption) (DebugApi_ShowDebugLevelsClient, error)
+	// Run debug command
 	RunDebug(ctx context.Context, in *DebugRequest, opts ...grpc.CallOption) (DebugApi_RunDebugClient, error)
 }
 
@@ -372,9 +376,13 @@ func (x *debugApiRunDebugClient) Recv() (*DebugReply, error) {
 
 // DebugApiServer is the server API for DebugApi service.
 type DebugApiServer interface {
+	// Enable debug log levels
 	EnableDebugLevels(*DebugRequest, DebugApi_EnableDebugLevelsServer) error
+	// Disable debug log levels
 	DisableDebugLevels(*DebugRequest, DebugApi_DisableDebugLevelsServer) error
+	// Show debug log levels
 	ShowDebugLevels(*DebugRequest, DebugApi_ShowDebugLevelsServer) error
+	// Run debug command
 	RunDebug(*DebugRequest, DebugApi_RunDebugServer) error
 }
 

--- a/edgeproto/debug.proto
+++ b/edgeproto/debug.proto
@@ -41,6 +41,7 @@ message DebugReply {
 }
 
 service DebugApi {
+  // Enable debug log levels
   rpc EnableDebugLevels(DebugRequest) returns (stream DebugReply) {
     option (google.api.http) = {
       post: "/debug/enablelevels"
@@ -51,6 +52,7 @@ service DebugApi {
     option (protogen.mc2_api) = "ResourceConfig,ActionManage,";
     option (protogen.mc2_api_notifyroot) = true;
   }
+  // Disable debug log levels
   rpc DisableDebugLevels(DebugRequest) returns (stream DebugReply) {
     option (google.api.http) = {
       post: "/debug/disablelevels"
@@ -61,6 +63,7 @@ service DebugApi {
     option (protogen.mc2_api) = "ResourceConfig,ActionManage,";
     option (protogen.mc2_api_notifyroot) = true;
   }
+  // Show debug log levels
   rpc ShowDebugLevels(DebugRequest) returns (stream DebugReply) {
     option (google.api.http) = {
       post: "/debug/showlevels"
@@ -71,6 +74,7 @@ service DebugApi {
     option (protogen.mc2_api_notifyroot) = true;
     option (protogen.non_standard_show) = true;
   }
+  // Run debug command
   rpc RunDebug(DebugRequest) returns (stream DebugReply) {
     option (google.api.http) = {
       post: "/debug/run"

--- a/edgeproto/device.pb.go
+++ b/edgeproto/device.pb.go
@@ -299,8 +299,11 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type DeviceApiClient interface {
+	// Inject a device
 	InjectDevice(ctx context.Context, in *Device, opts ...grpc.CallOption) (*Result, error)
+	// Show devices
 	ShowDevice(ctx context.Context, in *Device, opts ...grpc.CallOption) (DeviceApi_ShowDeviceClient, error)
+	// Evict a device
 	EvictDevice(ctx context.Context, in *Device, opts ...grpc.CallOption) (*Result, error)
 	// Device Reports API.
 	ShowDeviceReport(ctx context.Context, in *DeviceReport, opts ...grpc.CallOption) (DeviceApi_ShowDeviceReportClient, error)
@@ -398,8 +401,11 @@ func (x *deviceApiShowDeviceReportClient) Recv() (*Device, error) {
 
 // DeviceApiServer is the server API for DeviceApi service.
 type DeviceApiServer interface {
+	// Inject a device
 	InjectDevice(context.Context, *Device) (*Result, error)
+	// Show devices
 	ShowDevice(*Device, DeviceApi_ShowDeviceServer) error
+	// Evict a device
 	EvictDevice(context.Context, *Device) (*Result, error)
 	// Device Reports API.
 	ShowDeviceReport(*DeviceReport, DeviceApi_ShowDeviceReportServer) error

--- a/edgeproto/device.proto
+++ b/edgeproto/device.proto
@@ -62,6 +62,7 @@ message Device {
 }
 
 service DeviceApi {
+  // Inject a device
   rpc InjectDevice(Device) returns (Result) {
     option (google.api.http) = {
       post: "/create/device"
@@ -69,6 +70,7 @@ service DeviceApi {
     };
     option (protogen.mc2_api) = "ResourceConfig,ActionManage,";
   }
+  // Show devices
   rpc ShowDevice(Device) returns (stream Device) {
     option (google.api.http) = {
       post: "/show/device"
@@ -76,6 +78,7 @@ service DeviceApi {
     };
     option (protogen.mc2_api) = "ResourceConfig,ActionView,";
   }
+  // Evict a device
   rpc EvictDevice(Device) returns (Result) {
     option (google.api.http) = {
       post: "/evict/device"

--- a/edgeproto/restagtable.pb.go
+++ b/edgeproto/restagtable.pb.go
@@ -276,12 +276,13 @@ type ResTagTableApiClient interface {
 	CreateResTagTable(ctx context.Context, in *ResTagTable, opts ...grpc.CallOption) (*Result, error)
 	// Delete TagTable
 	DeleteResTagTable(ctx context.Context, in *ResTagTable, opts ...grpc.CallOption) (*Result, error)
+	// Update TagTable
 	UpdateResTagTable(ctx context.Context, in *ResTagTable, opts ...grpc.CallOption) (*Result, error)
-	// show TagTable
+	// Show TagTable
 	ShowResTagTable(ctx context.Context, in *ResTagTable, opts ...grpc.CallOption) (ResTagTableApi_ShowResTagTableClient, error)
-	// add new tag(s) to TagTable
+	// Add new tag(s) to TagTable
 	AddResTag(ctx context.Context, in *ResTagTable, opts ...grpc.CallOption) (*Result, error)
-	// remove existing tag(s) from TagTable
+	// Remove existing tag(s) from TagTable
 	RemoveResTag(ctx context.Context, in *ResTagTable, opts ...grpc.CallOption) (*Result, error)
 	// Fetch a copy of the TagTable
 	GetResTagTable(ctx context.Context, in *ResTagTableKey, opts ...grpc.CallOption) (*ResTagTable, error)
@@ -387,12 +388,13 @@ type ResTagTableApiServer interface {
 	CreateResTagTable(context.Context, *ResTagTable) (*Result, error)
 	// Delete TagTable
 	DeleteResTagTable(context.Context, *ResTagTable) (*Result, error)
+	// Update TagTable
 	UpdateResTagTable(context.Context, *ResTagTable) (*Result, error)
-	// show TagTable
+	// Show TagTable
 	ShowResTagTable(*ResTagTable, ResTagTableApi_ShowResTagTableServer) error
-	// add new tag(s) to TagTable
+	// Add new tag(s) to TagTable
 	AddResTag(context.Context, *ResTagTable) (*Result, error)
-	// remove existing tag(s) from TagTable
+	// Remove existing tag(s) from TagTable
 	RemoveResTag(context.Context, *ResTagTable) (*Result, error)
 	// Fetch a copy of the TagTable
 	GetResTagTable(context.Context, *ResTagTableKey) (*ResTagTable, error)

--- a/edgeproto/restagtable.proto
+++ b/edgeproto/restagtable.proto
@@ -74,7 +74,7 @@ service ResTagTableApi {
     };
     option (protogen.mc2_api) = "ResourceResTagTable,ActionManage,Key.Organization";
   }
-
+  // Update TagTable
   rpc UpdateResTagTable(ResTagTable) returns (Result) {
     option (google.api.http) = {
       post: "/update/gputagtbl"
@@ -82,7 +82,7 @@ service ResTagTableApi {
     };
     option (protogen.mc2_api) = "ResourceResTagTable,ActionManage,Key.Organization";
   }
-  // show TagTable
+  // Show TagTable
   rpc ShowResTagTable(ResTagTable) returns (stream ResTagTable) {
       option (google.api.http) = {
         post: "/show/gputagtbl"
@@ -90,7 +90,7 @@ service ResTagTableApi {
       };
       option(protogen.mc2_api) = "ResourceResTagTable,ActionView,Key.Organization";
   }
-  // add new tag(s) to TagTable
+  // Add new tag(s) to TagTable
   rpc AddResTag(ResTagTable) returns (Result) {
       option(google.api.http) = {
         post: "/add/gputagtbl"
@@ -99,7 +99,7 @@ service ResTagTableApi {
       option(protogen.mc2_api) = "ResourceResTagTable,ActionManage,Key.Organization";
       option(protogen.input_required) = true;
   }
-  // remove existing tag(s) from TagTable
+  // Remove existing tag(s) from TagTable
   rpc RemoveResTag(ResTagTable) returns (Result) {
       option(google.api.http) = {
         post: "/rm/gputagtbl"


### PR DESCRIPTION
Edge-cloud changes for mcctl commands reorg. Just some tweaks to the usage printing, and adding missing comments to the proto files.