### PR TITLE
EDGECLOUD-4633 EDGECLOUD-4631 settings range check fixes

### DIFF
--- a/edgeproto/field_validator.go
+++ b/edgeproto/field_validator.go
@@ -2,6 +2,15 @@ package edgeproto
 
 import (
 	fmt "fmt"
+	reflect "reflect"
+)
+
+type CompareType int
+
+const (
+	CompareGT CompareType = iota
+	CompareGTE
+	CompareLT
 )
 
 type FieldValidator struct {
@@ -15,38 +24,95 @@ func NewFieldValidator(allFieldsStringMap map[string]string) *FieldValidator {
 	return &v
 }
 
-func (s *FieldValidator) CheckGT(field string, val, gt int64) {
-	if s.err != nil {
-		return
-	}
-	if val <= gt {
-		s.err = fmt.Errorf("%s must be greater than %d", s.fieldDesc[field], gt)
-	}
+func (s *FieldValidator) CheckGT(field string, val, gt interface{}) {
+	s.Check(field, val, gt, CompareGT)
 }
 
-func (s *FieldValidator) CheckFloatGE(field string, val, gt float64) {
-	if s.err != nil {
-		return
-	}
-	if val < gt {
-		s.err = fmt.Errorf("%s must be greater than or equal to %f", s.fieldDesc[field], gt)
-	}
+func (s *FieldValidator) CheckGTE(field string, val, gte interface{}) {
+	s.Check(field, val, gte, CompareGTE)
 }
 
-func (s *FieldValidator) CheckFloatGT(field string, val, gt float64) {
-	if s.err != nil {
-		return
-	}
-	if val <= gt {
-		s.err = fmt.Errorf("%s must be greater than %f", s.fieldDesc[field], gt)
-	}
+func (s *FieldValidator) CheckLT(field string, val, lt interface{}) {
+	s.Check(field, val, lt, CompareLT)
 }
 
-func (s *FieldValidator) CheckLT(field string, val, lt int64) {
+func (s *FieldValidator) Check(field string, valI, gtI interface{}, ct CompareType) {
 	if s.err != nil {
 		return
 	}
-	if val >= lt {
-		s.err = fmt.Errorf("%s must be less than %d", s.fieldDesc[field], lt)
+	if valI == nil || gtI == nil {
+		return
+	}
+	desc := s.fieldDesc[field]
+	valType := reflect.TypeOf(valI)
+	gtType := reflect.TypeOf(gtI)
+	if valType != gtType {
+		s.err = fmt.Errorf("Validator: cannot compare %s to %s for %s", valType.String(), gtType.String(), desc)
+		return
+	}
+	failVal := ""
+
+	switch valType {
+	case reflect.TypeOf(Duration(0)):
+		val := valI.(Duration)
+		gt := gtI.(Duration)
+		if ct == CompareGT && val <= gt ||
+			ct == CompareGTE && val < gt ||
+			ct == CompareLT && val >= gt {
+			failVal = gt.TimeDuration().String()
+		}
+	case reflect.TypeOf(int64(0)):
+		val := valI.(int64)
+		gt := gtI.(int64)
+		if ct == CompareGT && val <= gt ||
+			ct == CompareGTE && val < gt ||
+			ct == CompareLT && val >= gt {
+			failVal = fmt.Sprintf("%d", gt)
+		}
+	case reflect.TypeOf(int32(0)):
+		val := valI.(int32)
+		gt := gtI.(int32)
+		if ct == CompareGT && val <= gt ||
+			ct == CompareGTE && val < gt ||
+			ct == CompareLT && val >= gt {
+			failVal = fmt.Sprintf("%d", gt)
+		}
+	case reflect.TypeOf(uint32(0)):
+		val := valI.(uint32)
+		gt := gtI.(uint32)
+		if ct == CompareGT && val <= gt ||
+			ct == CompareGTE && val < gt ||
+			ct == CompareLT && val >= gt {
+			failVal = fmt.Sprintf("%d", gt)
+		}
+	case reflect.TypeOf(float32(0)):
+		val := valI.(float32)
+		gt := gtI.(float32)
+		if ct == CompareGT && val <= gt ||
+			ct == CompareGTE && val < gt ||
+			ct == CompareLT && val >= gt {
+			failVal = fmt.Sprintf("%g", gt)
+		}
+	case reflect.TypeOf(float64(0)):
+		val := valI.(float64)
+		gt := gtI.(float64)
+		if ct == CompareGT && val <= gt ||
+			ct == CompareGTE && val < gt ||
+			ct == CompareLT && val >= gt {
+			failVal = fmt.Sprintf("%g", gt)
+		}
+	default:
+		s.err = fmt.Errorf("Unhandled type %s", valType.String())
+	}
+
+	if failVal != "" {
+		switch ct {
+		case CompareGT:
+			s.err = fmt.Errorf("%s must be greater than %s", desc, failVal)
+		case CompareGTE:
+			s.err = fmt.Errorf("%s must be greater than or equal to %s", desc, failVal)
+		case CompareLT:
+			s.err = fmt.Errorf("%s must be less than %s", desc, failVal)
+		}
 	}
 }

--- a/edgeproto/settings.go
+++ b/edgeproto/settings.go
@@ -56,70 +56,70 @@ func (s *Settings) SetKey(key *SettingsKey) {}
 func SettingsKeyStringParse(str string, obj *Settings) {}
 
 func (s *Settings) Validate(fields map[string]struct{}) error {
-	// check durations
+	dur0 := Duration(0)
 	v := NewFieldValidator(SettingsAllFieldsStringMap)
 	for f, _ := range fields {
 		switch f {
 		case SettingsFieldShepherdMetricsCollectionInterval:
-			v.CheckGT(f, int64(s.ShepherdMetricsCollectionInterval), 0)
+			v.CheckGT(f, s.ShepherdMetricsCollectionInterval, dur0)
 		case SettingsFieldShepherdAlertEvaluationInterval:
-			v.CheckGT(f, int64(s.ShepherdAlertEvaluationInterval), 0)
+			v.CheckGT(f, s.ShepherdAlertEvaluationInterval, dur0)
 		case SettingsFieldShepherdHealthCheckRetries:
-			v.CheckGT(f, int64(s.ShepherdHealthCheckRetries), 0)
+			v.CheckGT(f, s.ShepherdHealthCheckRetries, int32(0))
 		case SettingsFieldShepherdHealthCheckInterval:
-			v.CheckGT(f, int64(s.ShepherdHealthCheckInterval), 0)
+			v.CheckGT(f, s.ShepherdHealthCheckInterval, dur0)
 		case SettingsFieldAutoDeployIntervalSec:
-			v.CheckFloatGT(f, s.AutoDeployIntervalSec, 0)
+			v.CheckGT(f, s.AutoDeployIntervalSec, float64(0))
 		case SettingsFieldAutoDeployOffsetSec:
-			v.CheckFloatGE(f, s.AutoDeployOffsetSec, 0)
+			v.CheckGTE(f, s.AutoDeployOffsetSec, float64(0))
 		case SettingsFieldAutoDeployMaxIntervals:
-			v.CheckGT(f, int64(s.AutoDeployMaxIntervals), 0)
+			v.CheckGT(f, s.AutoDeployMaxIntervals, uint32(0))
 		case SettingsFieldLoadBalancerMaxPortRange:
-			v.CheckGT(f, int64(s.LoadBalancerMaxPortRange), 0)
-			v.CheckLT(f, int64(s.LoadBalancerMaxPortRange), 65536)
+			v.CheckGT(f, s.LoadBalancerMaxPortRange, int32(0))
+			v.CheckLT(f, s.LoadBalancerMaxPortRange, int32(65536))
 		case SettingsFieldCreateAppInstTimeout:
-			v.CheckGT(f, int64(s.CreateAppInstTimeout), 0)
+			v.CheckGT(f, s.CreateAppInstTimeout, dur0)
 		case SettingsFieldUpdateAppInstTimeout:
-			v.CheckGT(f, int64(s.UpdateAppInstTimeout), 0)
+			v.CheckGT(f, s.UpdateAppInstTimeout, dur0)
 		case SettingsFieldDeleteAppInstTimeout:
-			v.CheckGT(f, int64(s.DeleteAppInstTimeout), 0)
+			v.CheckGT(f, s.DeleteAppInstTimeout, dur0)
 		case SettingsFieldCreateClusterInstTimeout:
-			v.CheckGT(f, int64(s.CreateClusterInstTimeout), 0)
+			v.CheckGT(f, s.CreateClusterInstTimeout, dur0)
 		case SettingsFieldUpdateClusterInstTimeout:
-			v.CheckGT(f, int64(s.UpdateClusterInstTimeout), 0)
+			v.CheckGT(f, s.UpdateClusterInstTimeout, dur0)
 		case SettingsFieldDeleteClusterInstTimeout:
-			v.CheckGT(f, int64(s.DeleteClusterInstTimeout), 0)
+			v.CheckGT(f, s.DeleteClusterInstTimeout, dur0)
 		case SettingsFieldCreateCloudletTimeout:
-			v.CheckGT(f, int64(s.CreateCloudletTimeout), 0)
+			v.CheckGT(f, s.CreateCloudletTimeout, dur0)
 		case SettingsFieldUpdateCloudletTimeout:
-			v.CheckGT(f, int64(s.UpdateCloudletTimeout), 0)
+			v.CheckGT(f, s.UpdateCloudletTimeout, dur0)
 		case SettingsFieldMasterNodeFlavor:
 			// no validation
 		case SettingsFieldMaxTrackedDmeClients:
-			v.CheckGT(f, int64(s.MaxTrackedDmeClients), 0)
+			v.CheckGT(f, s.MaxTrackedDmeClients, int32(0))
 		case SettingsFieldChefClientInterval:
-			v.CheckGT(f, int64(s.ChefClientInterval), 0)
+			v.CheckGT(f, s.ChefClientInterval, dur0)
 		case SettingsFieldCloudletMaintenanceTimeout:
-			v.CheckGT(f, int64(s.CloudletMaintenanceTimeout), 0)
+			v.CheckGT(f, s.CloudletMaintenanceTimeout, dur0)
 		case SettingsFieldInfluxDbMetricsRetention:
-			fallthrough
+			// no validation
 		case SettingsFieldInfluxDbCloudletUsageMetricsRetention:
 			// no validation
 		case SettingsFieldUpdateVmPoolTimeout:
-			v.CheckGT(f, int64(s.UpdateVmPoolTimeout), 0)
+			v.CheckGT(f, s.UpdateVmPoolTimeout, dur0)
 		case SettingsFieldUpdateTrustPolicyTimeout:
-			v.CheckGT(f, int64(s.UpdateTrustPolicyTimeout), 0)
+			v.CheckGT(f, s.UpdateTrustPolicyTimeout, dur0)
 		case SettingsFieldDmeApiMetricsCollectionInterval:
-			v.CheckGT(f, int64(s.DmeApiMetricsCollectionInterval), 0)
+			v.CheckGT(f, s.DmeApiMetricsCollectionInterval, dur0)
 		case SettingsFieldCleanupReservableAutoClusterIdletime:
-			v.CheckGT(f, int64(s.CleanupReservableAutoClusterIdletime), 0)
+			v.CheckGT(f, s.CleanupReservableAutoClusterIdletime, dur0)
 		case SettingsFieldAppinstClientCleanupInterval:
-			v.CheckGT(f, int64(s.AppinstClientCleanupInterval), int64(Duration(2*time.Second)))
+			v.CheckGT(f, s.AppinstClientCleanupInterval, Duration(2*time.Second))
 		case SettingsFieldEdgeEventsMetricsCollectionInterval:
-			v.CheckGT(f, int64(s.EdgeEventsMetricsCollectionInterval), 0)
+			v.CheckGT(f, s.EdgeEventsMetricsCollectionInterval, dur0)
 		case SettingsFieldEdgeEventsMetricsContinuousQueriesCollectionIntervals:
 			for _, val := range s.EdgeEventsMetricsContinuousQueriesCollectionIntervals {
-				v.CheckGT(f, int64(val.Interval), 0)
+				v.CheckGT(f, val.Interval, dur0)
 			}
 		case SettingsFieldEdgeEventsMetricsContinuousQueriesCollectionIntervalsInterval:
 			// no validation
@@ -128,7 +128,7 @@ func (s *Settings) Validate(fields map[string]struct{}) error {
 		case SettingsFieldInfluxDbDownsampledMetricsRetention:
 			// no validation
 		case SettingsFieldLocationTileSideLengthKm:
-			v.CheckGT(f, int64(s.LocationTileSideLengthKm), 0)
+			v.CheckGT(f, s.LocationTileSideLengthKm, int64(0))
 		default:
 			// If this is a setting field (and not "fields"), ensure there is an entry in the switch
 			// above.  If no validation is to be done for a field, make an empty case entry

--- a/edgeproto/settings_test.go
+++ b/edgeproto/settings_test.go
@@ -1,0 +1,38 @@
+package edgeproto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingsValidate(t *testing.T) {
+	// This exercises all the Validate checks, to make sure
+	// there aren't any mismatched types being passed to the check
+	// functions. Because those type checks are runtime checks,
+	// but we want to catch any type mismatches at compile-time.
+	settings := GetDefaultSettings()
+	err := settings.Validate(SettingsAllFieldsMap)
+	require.Nil(t, err)
+
+	// Check output format of float values (use %g instead of %f to avoid 0.0000)
+	settings = GetDefaultSettings()
+	settings.AutoDeployIntervalSec = -1
+	err = settings.Validate(SettingsAllFieldsMap)
+	require.NotNil(t, err)
+	require.Equal(t, "Auto Deploy Interval Sec must be greater than 0", err.Error())
+
+	// Check output format of duration values
+	// (make sure format is in human-readable string, instead of raw nanosec)
+	settings = GetDefaultSettings()
+	settings.AppinstClientCleanupInterval = Duration(time.Duration(time.Second))
+	err = settings.Validate(SettingsAllFieldsMap)
+	require.NotNil(t, err)
+	require.Equal(t, "Appinst Client Cleanup Interval must be greater than 2s", err.Error())
+	settings = GetDefaultSettings()
+	settings.CreateAppInstTimeout = Duration(0)
+	err = settings.Validate(SettingsAllFieldsMap)
+	require.NotNil(t, err)
+	require.Equal(t, "Create App Inst Timeout must be greater than 0s", err.Error())
+}

--- a/setup-env/e2e-tests/data/appdata_trustpol_incompat_rules.yml
+++ b/setup-env/e2e-tests/data/appdata_trustpol_incompat_rules.yml
@@ -17,6 +17,8 @@ settings:
   chefclientinterval: 10m
   influxdbmetricsretention: 2h
   cloudletmaintenancetimeout: 2s
+  edgeeventsmetricscontinuousqueriescollectionintervals:
+  - interval: 2s
 
 flavors:
 - key:

--- a/setup-env/e2e-tests/data/appdata_trustpol_incompat_rules_show.yml
+++ b/setup-env/e2e-tests/data/appdata_trustpol_incompat_rules_show.yml
@@ -37,11 +37,17 @@ settings:
   updatevmpooltimeout: 20m0s
   updatetrustpolicytimeout: 5s
   dmeapimetricscollectioninterval: 30s
-  persistentconnectionmetricscollectioninterval: 1h0m0s
+  edgeeventsmetricscollectioninterval: 1h0m0s
   cleanupreservableautoclusteridletime: 30m0s
   influxdbcloudletusagemetricsretention: 8760h0m0s
   createcloudlettimeout: 10s
   updatecloudlettimeout: 2s
+  locationtilesidelengthkm: 2
+  edgeeventsmetricscontinuousqueriescollectionintervals:
+  - interval: 2s
+  influxdbdownsampledmetricsretention: 8760h0m0s
+  influxdbedgeeventsmetricsretention: 672h0m0s
+  appinstclientcleanupinterval: 24h0m0s
 trustpolicies:
 - key:
     organization: tmus


### PR DESCRIPTION
4633: Fixes one error message to use %g instead of %f for float (prints 0 instead of 0.0000).
4631: Fixes another error message to use Duration as a string instead of a int64 (prints 2s instead of 2000000000).

The main problem with this code was the casting of all the fields to int64 to get them to work with the check functions. It leads to not being to able to convert the value to a proper string representation (int vs float vs duration) in the error message. So instead, I've changed the code to accept the field as is (as an interface{}), which allows the type to be carried along with it. This also allows all the type casting and consistency checking to be in the FieldValidator func, which won't change as new settings fields are added.