### PR TITLE
EDGECLOUD-4663: continuous queries are not working after updating settings

### DIFF
--- a/controller/influxq_client/influxq.go
+++ b/controller/influxq_client/influxq.go
@@ -283,7 +283,7 @@ func (q *InfluxQ) UpdateDefaultRetentionPolicy(retentionTime time.Duration) *Ret
 	if retentionTime < shard {
 		shard = retentionTime
 	}
-	rpName := fmt.Sprintf("%s_default", q.dbName)
+	rpName := getDefaultRetentionPolicyName(q.dbName)
 	res.RpName = rpName
 	res.RpTime = retentionTime
 	query := fmt.Sprintf("create retention policy \"%s\" ON \"%s\" duration %s replication 1 shard duration %s default", rpName, q.dbName, retentionTime.String(), shard.String())
@@ -306,4 +306,8 @@ func (q *InfluxQ) UpdateDefaultRetentionPolicy(retentionTime time.Duration) *Ret
 		}
 	}
 	return res
+}
+
+func getDefaultRetentionPolicyName(dbName string) string {
+	return fmt.Sprintf("%s_default", dbName)
 }

--- a/controller/influxq_client/influxq_cq.go
+++ b/controller/influxq_client/influxq_cq.go
@@ -120,7 +120,7 @@ func CreateLatencyContinuousQuerySettings(collectionInterval time.Duration, newD
 		AggregationFunctions:      LatencyAggregationFunctions,
 		NewDbName:                 newDbName,
 		CollectionInterval:        collectionInterval,
-		RetentionPolicyName:       fmt.Sprintf("%s_default", newDbName),
+		RetentionPolicyName:       getDefaultRetentionPolicyName(newDbName),
 		NewRetentionPolicyCreated: rpDone,
 	}
 }
@@ -136,7 +136,7 @@ func CreateDeviceInfoContinuousQuerySettings(collectionInterval time.Duration, n
 		AggregationFunctions:      DeviceInfoAggregationFunctions,
 		NewDbName:                 newDbName,
 		CollectionInterval:        collectionInterval,
-		RetentionPolicyName:       fmt.Sprintf("%s_default", newDbName),
+		RetentionPolicyName:       getDefaultRetentionPolicyName(newDbName),
 		NewRetentionPolicyCreated: rpDone,
 	}
 }


### PR DESCRIPTION
When mc pull metrics from influx, it only pulls from measurements attached to the default retention policy. Because we are updating the default retention policy of all the dbs when controller starts, autogen is no longer the default