### PR TITLE
EDGECLOUD-4644: etcd database spike seen during regression run

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -1197,6 +1197,7 @@ func (s *CloudletApi) deleteCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 				cctx.Override != edgeproto.CRMOverride_IGNORE_CRM_ERRORS {
 				cb.Send(&edgeproto.Result{Message: fmt.Sprintf("Previous delete failed, %v", in.Errors)})
 				cb.Send(&edgeproto.Result{Message: "Use CreateCloudlet to rebuild, and try again"})
+				return fmt.Errorf("Cloudlet busy (%s), cannot delete", in.State.String())
 			}
 			if in.State == edgeproto.TrackedState_DELETE_REQUESTED ||
 				in.State == edgeproto.TrackedState_DELETING ||

--- a/edgeproto/settings.go
+++ b/edgeproto/settings.go
@@ -112,7 +112,7 @@ func (s *Settings) Validate(fields map[string]struct{}) error {
 		case SettingsFieldDmeApiMetricsCollectionInterval:
 			v.CheckGT(f, s.DmeApiMetricsCollectionInterval, dur0)
 		case SettingsFieldCleanupReservableAutoClusterIdletime:
-			v.CheckGT(f, s.CleanupReservableAutoClusterIdletime, dur0)
+			v.CheckGT(f, s.CleanupReservableAutoClusterIdletime, Duration(30*time.Second))
 		case SettingsFieldAppinstClientCleanupInterval:
 			v.CheckGT(f, s.AppinstClientCleanupInterval, Duration(2*time.Second))
 		case SettingsFieldEdgeEventsMetricsCollectionInterval:


### PR DESCRIPTION
* Although I'm still unable to reproduce this issue. Here's a fix to avoid multiple unnecessary writes to etcd
* Issue: On QA setup, I observed the following:
  * `cleanupreservableautoclusteridletime` is set to `1s`
  * Cloudlet doesn't exist, but I see the following error:
```
  2021-03-24T15:38:55.801Z	INFO	f3611d5236dd5ee	controller/clusterinst_api.go:1460	ClusterInst cleanup   	{"ClusterInst": {"cluster_key":{"name":"reservable0"},"cloudlet_key":{"organization":"tmus","name":"cloudlet1613210968-9305868"},"organization":"MobiledgeX"}, "err": "Cloudlet key {\"organization\":\"tmus\",\"name\":\"cloudlet1613210968-9305868\"} not found"}
```
  * Reservable auto cluster cleanup fails continuously as CloudletKey doesn't exist
  * But the multiple writes happens due to streamObj being created and deleted on ClusterInst deletion failure.
  * Have fixed this to avoid streamObj creation if failure doesn't require one.