### PR TITLE
EDGECLOUD-4662 cloudetinfos lost when etcd busy

### DIFF
--- a/controller/cloudletinfo_api.go
+++ b/controller/cloudletinfo_api.go
@@ -11,7 +11,6 @@ import (
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
-	"github.com/mobiledgex/edge-cloud/objstore"
 )
 
 type CloudletInfoApi struct {
@@ -34,7 +33,7 @@ func InitCloudletInfoApi(sync *Sync) {
 // and CRM suddenly go away, etcd will remove the stale CloudletInfo data.
 
 func (s *CloudletInfoApi) InjectCloudletInfo(ctx context.Context, in *edgeproto.CloudletInfo) (*edgeproto.Result, error) {
-	return s.store.Put(ctx, in, s.sync.syncWait, objstore.WithLease(controllerAliveLease))
+	return s.store.Put(ctx, in, s.sync.syncWait)
 }
 
 func (s *CloudletInfoApi) EvictCloudletInfo(ctx context.Context, in *edgeproto.CloudletInfo) (*edgeproto.Result, error) {
@@ -64,7 +63,7 @@ func (s *CloudletInfoApi) Update(ctx context.Context, in *edgeproto.CloudletInfo
 				changedToOnline = true
 			}
 		}
-		s.store.STMPut(stm, in, objstore.WithLease(controllerAliveLease))
+		s.store.STMPut(stm, in)
 		return nil
 	})
 	if changedToOnline {
@@ -205,7 +204,7 @@ func (s *CloudletInfoApi) Delete(ctx context.Context, in *edgeproto.CloudletInfo
 		}
 		buf.State = dme.CloudletState_CLOUDLET_STATE_OFFLINE
 		buf.Fields = []string{edgeproto.CloudletInfoFieldState}
-		s.store.STMPut(stm, &buf, objstore.WithLease(controllerAliveLease))
+		s.store.STMPut(stm, &buf)
 		return nil
 	})
 	if err != nil {
@@ -250,7 +249,7 @@ func (s *CloudletInfoApi) Flush(ctx context.Context, notifyId int64) {
 			}
 			info.State = dme.CloudletState_CLOUDLET_STATE_OFFLINE
 			log.SpanLog(ctx, log.DebugLevelNotify, "mark cloudlet offline", "key", matches[ii], "notifyid", notifyId)
-			s.store.STMPut(stm, &info, objstore.WithLease(controllerAliveLease))
+			s.store.STMPut(stm, &info)
 			return nil
 		})
 		if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -236,12 +236,9 @@ func startServices() error {
 	// an access key (as long as pki internal cert is verified).
 	cloudletApi.accessKeyServer.SetRequireTlsAccessKey(*requireNotifyAccessKey)
 
-	// register controller must be called before starting Notify protocol
-	// to set up controllerAliveLease.
-	err = controllerApi.registerController(ctx)
-	if err != nil {
-		return fmt.Errorf("Failed to register controller, %v", err)
-	}
+	InitSyncLeaseData(sync)
+	syncLeaseData.Start(ctx)
+
 	err = settingsApi.initDefaults(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to init settings, %v", err)
@@ -542,6 +539,7 @@ func stopServices() {
 	if services.downsampledMetricsInfluxQ != nil {
 		services.downsampledMetricsInfluxQ.Stop()
 	}
+	syncLeaseData.Stop()
 	if services.sync != nil {
 		services.sync.Done()
 	}

--- a/controller/dummy_etcd.go
+++ b/controller/dummy_etcd.go
@@ -229,6 +229,10 @@ func (e *dummyEtcd) Grant(ctx context.Context, ttl int64) (int64, error) {
 	return 0, errors.New("dummy etcd grant unsupported")
 }
 
+func (e *dummyEtcd) Revoke(ctx context.Context, lease int64) error {
+	return errors.New("dummy etcd revoke unsupported")
+}
+
 func (e *dummyEtcd) KeepAlive(ctx context.Context, leaseID int64) error {
 	return errors.New("dummy etcd keepalive unsupported")
 }

--- a/controller/etcd.go
+++ b/controller/etcd.go
@@ -333,6 +333,14 @@ func (e *EtcdClient) Grant(ctx context.Context, ttl int64) (int64, error) {
 	return int64(resp.ID), nil
 }
 
+func (e *EtcdClient) Revoke(ctx context.Context, lease int64) error {
+	_, err := e.client.Revoke(ctx, clientv3.LeaseID(lease))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (e *EtcdClient) KeepAlive(ctx context.Context, leaseID int64) error {
 	for {
 		ch, err := e.client.KeepAlive(ctx, clientv3.LeaseID(leaseID))
@@ -357,7 +365,7 @@ func (e *EtcdClient) KeepAlive(ctx context.Context, leaseID int64) error {
 			break
 		}
 	}
-	return nil
+	return fmt.Errorf("keep alive finished unexpectedly")
 }
 
 func (e *EtcdClient) spanForRev(rev int64, spanName string) opentracing.Span {

--- a/controller/sync_lease_data.go
+++ b/controller/sync_lease_data.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
+	"github.com/mobiledgex/edge-cloud/log"
+)
+
+var leaseTimeoutSec int64 = 5
+var syncLeaseDataRetry = time.Minute
+
+var syncLeaseData = SyncLeaseData{}
+
+// This synchronizes lease data with the persistent storage (etcd).
+// Data associated with the lease is meant to be deleted after the lease
+// expires, if this controller goes away. However, it's also possible
+// due to network/cpu congestion, that the lease keepalives fail even
+// though both Controller and Etcd are running. If that happens,
+// etcd will flush the lease data, and this Controller needs to restore
+// it once a new lease can be established.
+type SyncLeaseData struct {
+	sync    *Sync
+	leaseID int64
+	stop    chan struct{}
+	cancel  func()
+	mux     sync.Mutex
+	wg      sync.WaitGroup
+}
+
+func InitSyncLeaseData(sy *Sync) {
+	syncLeaseData.sync = sy
+}
+
+func (s *SyncLeaseData) Start(ctx context.Context) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	if s.stop != nil {
+		// already running
+		return
+	}
+	s.stop = make(chan struct{})
+	s.wg.Add(1)
+	go s.run()
+}
+
+func (s *SyncLeaseData) Stop() {
+	s.mux.Lock()
+	close(s.stop)
+	s.mux.Unlock()
+	log.DebugLog(log.DebugLevelInfo, "sync lease data stop, waiting")
+	s.wg.Wait()
+	log.DebugLog(log.DebugLevelInfo, "sync lease data stop done")
+	s.mux.Lock()
+	s.stop = nil
+	s.mux.Unlock()
+}
+
+func (s *SyncLeaseData) run() {
+	done := false
+	errc := make(chan error, 1)
+
+	for !done {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func(ctx context.Context) {
+			err := s.syncData()
+			if err == nil {
+				// This call blocks until:
+				// - underlying keep alive fails
+				// - we cancel context
+				// Note that if underlying keep alive fails,
+				// context is also marked as cancelled (Done).
+				err = s.sync.store.KeepAlive(ctx, s.leaseID)
+			}
+			errc <- err
+		}(ctx)
+		// wait for sync to be stopped either intentionally or by failure
+		select {
+		case <-s.stop:
+			done = true
+		case err := <-errc:
+			span := log.StartSpan(log.DebugLevelInfo, "Sync Lease Data recovery")
+			ctx := log.ContextWithSpan(context.Background(), span)
+			log.SpanLog(ctx, log.DebugLevelInfo, "Sync Lease Data failed", "err", err, "retry-in", syncLeaseDataRetry.String())
+			span.Finish()
+		}
+		cancel()
+		// wait before retrying to avoid spinning
+		select {
+		case <-s.stop:
+			done = true
+		case <-time.After(syncLeaseDataRetry):
+		}
+	}
+	s.wg.Done()
+	log.DebugLog(log.DebugLevelInfo, "sync lease data stopped")
+}
+
+func (s *SyncLeaseData) syncData() error {
+	span := log.StartSpan(log.DebugLevelInfo, "Sync Lease Data")
+	ctx := log.ContextWithSpan(context.Background(), span)
+	defer span.Finish()
+
+	// get lease
+	leaseID, err := s.sync.store.Grant(ctx, leaseTimeoutSec)
+	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelInfo, "grant lease failed", "err", err)
+		return err
+	}
+	s.mux.Lock()
+	s.leaseID = leaseID
+	s.mux.Unlock()
+
+	err = controllerApi.registerController(ctx, leaseID)
+	log.SpanLog(ctx, log.DebugLevelInfo, "registered controller", "hostname", cloudcommon.Hostname(), "err", err)
+	if err != nil {
+		return err
+	}
+	err = alertApi.syncSourceData(ctx, leaseID)
+	log.SpanLog(ctx, log.DebugLevelInfo, "synced alerts", "err", err)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *SyncLeaseData) LeaseID() int64 {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	return s.leaseID
+}
+
+func ControllerAliveLease() int64 {
+	return syncLeaseData.LeaseID()
+}

--- a/edgeproto/appinst.pb.go
+++ b/edgeproto/appinst.pb.go
@@ -3612,11 +3612,21 @@ func (c *AppInstCache) UpdateModFunc(ctx context.Context, key *AppInstKey, modRe
 }
 
 func (c *AppInstCache) Delete(ctx context.Context, in *AppInst, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *AppInst) bool {
+		return true
+	})
+}
+
+func (c *AppInstCache) DeleteCondFunc(ctx context.Context, in *AppInst, modRev int64, condFunc func(old *AppInst) bool) {
 	c.Mux.Lock()
 	var old *AppInst
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")
@@ -4814,11 +4824,21 @@ func (c *AppInstInfoCache) UpdateModFunc(ctx context.Context, key *AppInstKey, m
 }
 
 func (c *AppInstInfoCache) Delete(ctx context.Context, in *AppInstInfo, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *AppInstInfo) bool {
+		return true
+	})
+}
+
+func (c *AppInstInfoCache) DeleteCondFunc(ctx context.Context, in *AppInstInfo, modRev int64, condFunc func(old *AppInstInfo) bool) {
 	c.Mux.Lock()
 	var old *AppInstInfo
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")

--- a/edgeproto/autoprovpolicy.pb.go
+++ b/edgeproto/autoprovpolicy.pb.go
@@ -1732,11 +1732,21 @@ func (c *AutoProvPolicyCache) UpdateModFunc(ctx context.Context, key *PolicyKey,
 }
 
 func (c *AutoProvPolicyCache) Delete(ctx context.Context, in *AutoProvPolicy, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *AutoProvPolicy) bool {
+		return true
+	})
+}
+
+func (c *AutoProvPolicyCache) DeleteCondFunc(ctx context.Context, in *AutoProvPolicy, modRev int64, condFunc func(old *AutoProvPolicy) bool) {
 	c.Mux.Lock()
 	var old *AutoProvPolicy
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")
@@ -2850,11 +2860,21 @@ func (c *AutoProvInfoCache) UpdateModFunc(ctx context.Context, key *CloudletKey,
 }
 
 func (c *AutoProvInfoCache) Delete(ctx context.Context, in *AutoProvInfo, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *AutoProvInfo) bool {
+		return true
+	})
+}
+
+func (c *AutoProvInfoCache) DeleteCondFunc(ctx context.Context, in *AutoProvInfo, modRev int64, condFunc func(old *AutoProvInfo) bool) {
 	c.Mux.Lock()
 	var old *AutoProvInfo
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")

--- a/edgeproto/cloudlet.pb.go
+++ b/edgeproto/cloudlet.pb.go
@@ -6261,11 +6261,21 @@ func (c *CloudletCache) UpdateModFunc(ctx context.Context, key *CloudletKey, mod
 }
 
 func (c *CloudletCache) Delete(ctx context.Context, in *Cloudlet, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *Cloudlet) bool {
+		return true
+	})
+}
+
+func (c *CloudletCache) DeleteCondFunc(ctx context.Context, in *Cloudlet, modRev int64, condFunc func(old *Cloudlet) bool) {
 	c.Mux.Lock()
 	var old *Cloudlet
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")
@@ -8423,11 +8433,21 @@ func (c *CloudletInfoCache) UpdateModFunc(ctx context.Context, key *CloudletKey,
 }
 
 func (c *CloudletInfoCache) Delete(ctx context.Context, in *CloudletInfo, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *CloudletInfo) bool {
+		return true
+	})
+}
+
+func (c *CloudletInfoCache) DeleteCondFunc(ctx context.Context, in *CloudletInfo, modRev int64, condFunc func(old *CloudletInfo) bool) {
 	c.Mux.Lock()
 	var old *CloudletInfo
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")

--- a/edgeproto/clusterinst.pb.go
+++ b/edgeproto/clusterinst.pb.go
@@ -2636,11 +2636,21 @@ func (c *ClusterInstCache) UpdateModFunc(ctx context.Context, key *ClusterInstKe
 }
 
 func (c *ClusterInstCache) Delete(ctx context.Context, in *ClusterInst, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *ClusterInst) bool {
+		return true
+	})
+}
+
+func (c *ClusterInstCache) DeleteCondFunc(ctx context.Context, in *ClusterInst, modRev int64, condFunc func(old *ClusterInst) bool) {
 	c.Mux.Lock()
 	var old *ClusterInst
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")
@@ -3826,11 +3836,21 @@ func (c *ClusterInstInfoCache) UpdateModFunc(ctx context.Context, key *ClusterIn
 }
 
 func (c *ClusterInstInfoCache) Delete(ctx context.Context, in *ClusterInstInfo, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *ClusterInstInfo) bool {
+		return true
+	})
+}
+
+func (c *ClusterInstInfoCache) DeleteCondFunc(ctx context.Context, in *ClusterInstInfo, modRev int64, condFunc func(old *ClusterInstInfo) bool) {
 	c.Mux.Lock()
 	var old *ClusterInstInfo
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")

--- a/edgeproto/refs.pb.go
+++ b/edgeproto/refs.pb.go
@@ -1456,11 +1456,21 @@ func (c *CloudletRefsCache) UpdateModFunc(ctx context.Context, key *CloudletKey,
 }
 
 func (c *CloudletRefsCache) Delete(ctx context.Context, in *CloudletRefs, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *CloudletRefs) bool {
+		return true
+	})
+}
+
+func (c *CloudletRefsCache) DeleteCondFunc(ctx context.Context, in *CloudletRefs, modRev int64, condFunc func(old *CloudletRefs) bool) {
 	c.Mux.Lock()
 	var old *CloudletRefs
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")
@@ -2091,11 +2101,21 @@ func (c *ClusterRefsCache) UpdateModFunc(ctx context.Context, key *ClusterInstKe
 }
 
 func (c *ClusterRefsCache) Delete(ctx context.Context, in *ClusterRefs, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *ClusterRefs) bool {
+		return true
+	})
+}
+
+func (c *ClusterRefsCache) DeleteCondFunc(ctx context.Context, in *ClusterRefs, modRev int64, condFunc func(old *ClusterRefs) bool) {
 	c.Mux.Lock()
 	var old *ClusterRefs
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")
@@ -2685,11 +2705,21 @@ func (c *AppInstRefsCache) UpdateModFunc(ctx context.Context, key *AppKey, modRe
 }
 
 func (c *AppInstRefsCache) Delete(ctx context.Context, in *AppInstRefs, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *AppInstRefs) bool {
+		return true
+	})
+}
+
+func (c *AppInstRefsCache) DeleteCondFunc(ctx context.Context, in *AppInstRefs, modRev int64, condFunc func(old *AppInstRefs) bool) {
 	c.Mux.Lock()
 	var old *AppInstRefs
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")

--- a/edgeproto/trustpolicy.pb.go
+++ b/edgeproto/trustpolicy.pb.go
@@ -1060,11 +1060,21 @@ func (c *TrustPolicyCache) UpdateModFunc(ctx context.Context, key *PolicyKey, mo
 }
 
 func (c *TrustPolicyCache) Delete(ctx context.Context, in *TrustPolicy, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *TrustPolicy) bool {
+		return true
+	})
+}
+
+func (c *TrustPolicyCache) DeleteCondFunc(ctx context.Context, in *TrustPolicy, modRev int64, condFunc func(old *TrustPolicy) bool) {
 	c.Mux.Lock()
 	var old *TrustPolicy
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")

--- a/edgeproto/vmpool.pb.go
+++ b/edgeproto/vmpool.pb.go
@@ -2301,11 +2301,21 @@ func (c *VMPoolCache) UpdateModFunc(ctx context.Context, key *VMPoolKey, modRev 
 }
 
 func (c *VMPoolCache) Delete(ctx context.Context, in *VMPool, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *VMPool) bool {
+		return true
+	})
+}
+
+func (c *VMPoolCache) DeleteCondFunc(ctx context.Context, in *VMPool, modRev int64, condFunc func(old *VMPool) bool) {
 	c.Mux.Lock()
 	var old *VMPool
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")
@@ -3633,11 +3643,21 @@ func (c *VMPoolInfoCache) UpdateModFunc(ctx context.Context, key *VMPoolKey, mod
 }
 
 func (c *VMPoolInfoCache) Delete(ctx context.Context, in *VMPoolInfo, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *VMPoolInfo) bool {
+		return true
+	})
+}
+
+func (c *VMPoolInfoCache) DeleteCondFunc(ctx context.Context, in *VMPoolInfo, modRev int64, condFunc func(old *VMPoolInfo) bool) {
 	c.Mux.Lock()
 	var old *VMPoolInfo
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")

--- a/objstore/objstore.go
+++ b/objstore/objstore.go
@@ -63,6 +63,8 @@ type KVStore interface {
 	// To avoid that, the KeepAlive call must remain active.
 	// Grant creates a new lease
 	Grant(ctx context.Context, ttl int64) (int64, error)
+	// Revoke a lease
+	Revoke(ctx context.Context, lease int64) error
 	// KeepAlive keeps a lease alive. This call blocks.
 	KeepAlive(ctx context.Context, leaseID int64) error
 }

--- a/protoc-gen-gomex/mexgen/mex.go
+++ b/protoc-gen-gomex/mexgen/mex.go
@@ -1304,11 +1304,21 @@ func (c *{{.Name}}Cache) UpdateModFunc(ctx context.Context, key *{{.KeyType}}, m
 }
 
 func (c *{{.Name}}Cache) Delete(ctx context.Context, in *{{.Name}}, modRev int64) {
+	c.DeleteCondFunc(ctx, in, modRev, func(old *{{.Name}}) bool {
+		return true
+	})
+}
+
+func (c *{{.Name}}Cache) DeleteCondFunc(ctx context.Context, in *{{.Name}}, modRev int64, condFunc func(old *{{.Name}}) bool) {
 	c.Mux.Lock()
 	var old *{{.Name}}
 	oldData, found := c.Objs[in.GetKeyVal()]
 	if found {
 		old = oldData.Obj
+		if !condFunc(old) {
+			c.Mux.Unlock()
+			return
+		}
 	}
 	delete(c.Objs, in.GetKeyVal())
 	log.SpanLog(ctx, log.DebugLevelApi, "cache delete")


### PR DESCRIPTION
There is some data which we push to etcd on a "lease", such that if the controller dies, that data is automatically deleted from etcd, by etcd. This data was: registered controller (used for controllers to talk to each other), cloudletinfo data, alerts data. The lease is maintained by a keep-alive between the Controller and etcd. If the Controller dies, then the CRM will reconnect to either the same or different controller, and repush all the cloudletinfo/alerts data, which ends up repushing it to etcd.

The problem was that etcd was busy due to high cpu on the underlying node. This caused the keep-alive to fail, even though the Controller was still alive. This exposed some flaws in the keep-alive logic, namely that after etcd flushed all the lease data, there was no mechanism to restore it, because there was no CRM reconnect (because the Controller never restarted).

To fix this, the Controller needs to have a restart process to 1) create a new lease if the current one's keep-alive failed, and 2) push back all the leased data. This handles the case where the keep-alive fails but the Controller never actually died.

In order to do 2), we need to keep a cache of all the data to push back. The usual alertCache is a cache of all alerts in etcd. What we need to push back is only the alerts from CRMs connected to the given controller (because alerts pushed by other Controllers for other CRMs were not flushed from etcd). So now the alerts also have a "sourceCache", which caches only what our connected CRM sent us.

We could have done the same for CloudletInfos, but I don't see any need to delete CloudletInfos if the CRM goes away anymore, since we clean them up on DeleteCloudlet. So I've just changed them to not use leases. But for alerts on the other hand, if the CRM is offline, I think we'd get complaints if the alerts were still present.

I also looked into replacing this lease with a Redis db, but it would have been a lot more changes, and the overall scheme (of keeping a source cache) would still apply.