### PR TITLE
EDGECLOUD-3546: Failed AppInst Deploy with Autocluster doesn't clean cluster stack

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -831,7 +831,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		defer func() {
 			if reterr != nil && !cctx.Undo {
 				cb.Send(&edgeproto.Result{Message: "Deleting auto-ClusterInst due to failure"})
-				undoErr := clusterInstApi.deleteClusterInstInternal(cctxauto, &clusterInst, cb)
+				undoErr := clusterInstApi.deleteClusterInstInternal(cctxauto.WithUndo().WithCRMUndo(), &clusterInst, cb)
 				if undoErr != nil {
 					log.SpanLog(ctx, log.DebugLevelApi,
 						"Undo create auto-ClusterInst failed",

--- a/controller/callcontext.go
+++ b/controller/callcontext.go
@@ -6,6 +6,7 @@ import "github.com/mobiledgex/edge-cloud/edgeproto"
 
 type CallContext struct {
 	Undo        bool
+	CRMUndo     bool
 	Override    edgeproto.CRMOverride
 	AutoCluster bool
 }
@@ -17,6 +18,19 @@ func DefCallContext() *CallContext {
 func (c *CallContext) WithUndo() *CallContext {
 	cc := *c
 	cc.Undo = true
+	return &cc
+}
+
+// Normally, the CRM change is the last change in the API call,
+// and if it fails, CRM will clean up after itself. Thus the
+// undo function should skip any CRM changes. However, in some
+// cases (like autocluster), the CRM change is not the last
+// change, and we may hit other failures after the CRM change succeeds.
+// In that case, we need to have the undo function apply the
+// CRM changes.
+func (c *CallContext) WithCRMUndo() *CallContext {
+	cc := *c
+	cc.CRMUndo = true
 	return &cc
 }
 

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -1292,7 +1292,7 @@ func ignoreTransient(cctx *CallContext, state edgeproto.TrackedState) bool {
 }
 
 func ignoreCRM(cctx *CallContext) bool {
-	if cctx.Undo || cctx.Override == edgeproto.CRMOverride_IGNORE_CRM ||
+	if (cctx.Undo && !cctx.CRMUndo) || cctx.Override == edgeproto.CRMOverride_IGNORE_CRM ||
 		cctx.Override == edgeproto.CRMOverride_IGNORE_CRM_AND_TRANSIENT_STATE {
 		return true
 	}


### PR DESCRIPTION
If appInst creation fails on clusterInst, then we shouldn't set `undo` flag while deleting clusterInst. As `undo` will not perform CRM cleanup of the clusterInst VMs. If ClusterInst was created successfully, then we should perform CRM side cleanup.