### PR TITLE
EDGECLOUD-4732 nas not yet supported, vgpu not a toplevel resource

### DIFF
--- a/controller/restagtable_api.go
+++ b/controller/restagtable_api.go
@@ -281,7 +281,7 @@ func (s *ResTagTableApi) ValidateOptResMapValues(resmap map[string]string) (bool
 	var err error
 	var count string
 	for k, v := range resmap {
-		if k == "gpu" || k == "vgpu" || k == "nas" {
+		if k == "gpu" {
 			values := strings.Split(v, ":")
 			if len(values) == 1 {
 				return false, fmt.Errorf("Missing manditory resource count, ex: optresmap=gpu=gpu:1")


### PR DESCRIPTION
nas is not yet supported in the backed, removed. vgpu is not a toplevel resource, rather a variant of resource type gpu. Modify optrestable entry of CreateFlavor accordingly.
