### PR TITLE
EDGECLOUD-4755  Deletion of k8s cluster instances failed due to helm error

### DIFF
--- a/cloud-resource-manager/k8smgmt/helm.go
+++ b/cloud-resource-manager/k8smgmt/helm.go
@@ -202,7 +202,11 @@ func DeleteHelmAppInst(ctx context.Context, client ssh.Client, names *KubeNames,
 	cmd := fmt.Sprintf("%s helm delete --purge %s", names.KconfEnv, names.HelmAppName)
 	out, err := client.Output(cmd)
 	if err != nil {
-		return fmt.Errorf("error deleting helm chart, %s, %s, %v", cmd, out, err)
+		if !strings.Contains(out, "not found") {
+			return fmt.Errorf("error deleting helm chart, %s, %s, %v", cmd, out, err)
+		}
+		log.SpanLog(ctx, log.DebugLevelInfra, "Unable to find the chart, continue", "cmd", cmd,
+			"out", out, "err", err)
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "removed helm chart")
 	return nil


### PR DESCRIPTION
The root cause was that the helm version is outdated on the shared rootLb and it tries to delete prometheus chart, which actually failed to be deployed in first place. However this failure, when the tarted chart is not there should not result in a deletion error.
