### PR TITLE
EDGECLOUD-4755: Fix auto created AppInst cleanup

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -200,7 +200,7 @@ func (s *AppInstApi) AutoDeleteAppInsts(key *edgeproto.ClusterInstKey, crmoverri
 				err = nil
 				break
 			}
-			if err != nil && err.Error() == "AppInst busy, cannot be deleted" {
+			if err != nil && strings.Contains(err.Error(), ObjBusyDeletionMsg) {
 				spinTime = time.Since(start)
 				if spinTime > settingsApi.Get().DeleteAppInstTimeout.TimeDuration() {
 					log.DebugLog(log.DebugLevelApi, "Timeout while waiting for App", "appName", val.Key.AppKey.Name)

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -31,6 +31,7 @@ var clusterInstApi = ClusterInstApi{}
 
 var AutoClusterPrefixErr = fmt.Sprintf("Cluster name prefix \"%s\" is reserved",
 	cloudcommon.AutoClusterPrefix)
+var ObjBusyDeletionMsg = "busy, cannot be deleted"
 
 // Transition states indicate states in which the CRM is still busy.
 var CreateClusterInstTransitions = map[edgeproto.TrackedState]struct{}{
@@ -1082,7 +1083,7 @@ func validateDeleteState(cctx *CallContext, objName string, state edgeproto.Trac
 			return fmt.Errorf("%s busy, already under deletion", objName)
 		}
 		if edgeproto.IsTransientState(state) {
-			return fmt.Errorf("%s busy, cannot be deleted", objName)
+			return fmt.Errorf("%s %s", objName, ObjBusyDeletionMsg)
 		}
 	}
 	if cctx.Override != edgeproto.CRMOverride_IGNORE_CRM_ERRORS {


### PR DESCRIPTION
* One of my earlier changes changed the busy message and hence AppInst cleanup was not being retried
* But this also uncovered another issue where state change was not being saved because `Fields` was not set