### PR TITLE
Add node debug cmd vmspec_matcher verbose

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/tls"
 	"github.com/mobiledgex/edge-cloud/util"
 	"github.com/mobiledgex/edge-cloud/vault"
+	"github.com/mobiledgex/edge-cloud/vmspec"
 	"google.golang.org/grpc"
 )
 
@@ -178,6 +179,7 @@ func startServices() error {
 	if err != nil {
 		return err
 	}
+	initDebug(ctx, &nodeMgr)
 	defer span.Finish()
 	vaultConfig = nodeMgr.VaultConfig
 
@@ -665,4 +667,15 @@ func (c *ControllerMetricsReceiver) RecvMetric(ctx context.Context, metric *edge
 	} else {
 		c.metricsInflux.AddMetric(metric)
 	}
+}
+
+const (
+	ToggleFlavorMatchVerbose = "toggle-flavormatch-verbose"
+)
+
+func initDebug(ctx context.Context, nodeMgr *node.NodeMgr) {
+	nodeMgr.Debug.AddDebugFunc(ToggleFlavorMatchVerbose,
+		func(ctx context.Context, req *edgeproto.DebugRequest) string {
+			return vmspec.ToggleFlavorMatchVerbose()
+		})
 }

--- a/vmspec/vmspec_matcher.go
+++ b/vmspec/vmspec_matcher.go
@@ -25,6 +25,15 @@ type VMCreationSpec struct {
 
 var verbose bool = false
 
+func ToggleFlavorMatchVerbose() string {
+	if verbose == true {
+		verbose = false
+	} else {
+		verbose = true
+	}
+	return strconv.FormatBool(verbose)
+}
+
 // Routines supporting the mapping used in GetVMSpec
 //
 


### PR DESCRIPTION
Add new nodedebug cmd to toggle the verbose flag in the flavor matching code. Primarily supporting the FindFlavorMatch cli command, only supported on controller nodes. 