### PR TITLE
allow trust policy update

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -488,7 +488,6 @@ func (s *AppApi) UpdateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 		edgeproto.AppFieldDeploymentGenerator,
 	}
 	canAlwaysUpdate := map[string]bool{
-
 		edgeproto.AppFieldTrusted: true,
 	}
 


### PR DESCRIPTION
EDGECLOUD-4880

Update is disallowed for all VM App fields when there are instances deployed.  This is a problem because it means operators cannot add trust policy to any cloudlets which have VM App instances.