### PR TITLE
validate service type

### DIFF
--- a/cloudcommon/deployment.go
+++ b/cloudcommon/deployment.go
@@ -115,12 +115,12 @@ func IsValidDeploymentManifest(DeploymentType, command, manifest string, ports [
 			if !ok {
 				continue
 			}
+			if ksvc.Spec.Type != v1.ServiceTypeLoadBalancer {
+				// we allow non-LB services such as ClusterIP, but they do not count for validating exposed ports
+				log.DebugLog(log.DebugLevelApi, "skipping non-load balancer service", "type", ksvc.Spec.Type)
+				continue
+			}
 			for _, kp := range ksvc.Spec.Ports {
-				if ksvc.Spec.Type != v1.ServiceTypeLoadBalancer {
-					// we allow non-LB services such as ClusterIP, but they do not count for validating exposed ports
-					log.DebugLog(log.DebugLevelApi, "skipping non-load balancer service", "type", ksvc.Spec.Type)
-					continue
-				}
 				appPort := dme.AppPort{}
 				appPort.Proto, err = edgeproto.GetLProto(string(kp.Protocol))
 				if err != nil {


### PR DESCRIPTION
EDGECLOUD-4897

A developer ran into a situation in which the service they created was not working: no DNS entry and health checks failed.  The reason is that they had defined their service as ClusterIP type.  This service is for internal cluster communication only. 
 As they had no LoadBalancer services defined, the LB was never setup.  Note it is OK to have both ClusterIP and LoadBalancer services in the same manifest, the requirement is just that all access ports be exposed via a LoadBalancer service.

Fix adds validation when checking the required ports are present in the manifest that we only look for LoadBalancer services.