### PR TITLE
Fix cloudlet resource usage count after CRM restart

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -286,6 +286,14 @@ func (cd *ControllerData) clusterInstChanged(ctx context.Context, old *edgeproto
 
 	log.SpanLog(ctx, log.DebugLevelInfra, "ClusterInstChange", "key", new.Key, "state", new.State, "old", old)
 
+	// store clusterInstInfo object on CRM bringup, if state is READY
+	if old == nil && new.State == edgeproto.TrackedState_READY {
+		if err := cd.ClusterInstInfoCache.SetState(ctx, &new.Key, new.State); err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfra, "ClusterInst set state failed", "err", err)
+		}
+		return
+	}
+
 	resetStatus := edgeproto.NoResetStatus
 	updateClusterCacheCallback := func(updateType edgeproto.CacheUpdateType, value string) {
 		switch updateType {
@@ -475,6 +483,14 @@ func (cd *ControllerData) appInstChanged(ctx context.Context, old *edgeproto.App
 	var err error
 
 	if old != nil && old.State == new.State {
+		return
+	}
+
+	// store appInstInfo object on CRM bringup, if state is READY
+	if old == nil && new.State == edgeproto.TrackedState_READY {
+		if err := cd.AppInstInfoCache.SetState(ctx, &new.Key, new.State); err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfra, "AppInst set state failed", "err", err)
+		}
 		return
 	}
 


### PR DESCRIPTION
* Encountered this issue on main setup, where resources were getting doubly counted. This was causing further ClusterInst creations to fail
* This issue occurs only when CRM is restarted (which we do during upgrades) with already created ClusterInsts
* CRM relies on `ClusterInstInfo` cache object to get the list of ClusterKeys to send it as part of `CloudletInfo`. But when CRM is restarted, we don't store `ClusterInstInfo` object for already created Clusters (in READY state) and hence those were not sent as part of `CloudletInfo`. This causes resources to be doubly counted by the controller
* Fix is to store `ClusterInstInfo` object for already existing ClusterInsts
* QA regression didn't catch this issue because they always recreate ClusterInsts after CRM upgrade