### PR TITLE
locationtile is gps coordinates instead of indices, send findcloudlet when appinst is unusable

### DIFF
--- a/d-match-engine/dme-common/edgeevents.go
+++ b/d-match-engine/dme-common/edgeevents.go
@@ -10,8 +10,9 @@ import (
 
 type EdgeEventsHandler interface {
 	GetVersionProperties() map[string]string
-	AddClientKey(ctx context.Context, appInstKey edgeproto.AppInstKey, cookieKey CookieKey, sendFunc func(event *dme.ServerEdgeEvent))
+	AddClientKey(ctx context.Context, appInstKey edgeproto.AppInstKey, cookieKey CookieKey, lastLoc *dme.Loc, carrier string, sendFunc func(event *dme.ServerEdgeEvent))
 	RemoveClientKey(ctx context.Context, appInstKey edgeproto.AppInstKey, cookieKey CookieKey)
+	UpdateClientLastLocation(ctx context.Context, appInstKey edgeproto.AppInstKey, cookieKey CookieKey, lastLoc *dme.Loc)
 	RemoveAppInstKey(ctx context.Context, appInstKey edgeproto.AppInstKey)
 	SendLatencyRequestEdgeEvent(ctx context.Context, appInstKey edgeproto.AppInstKey)
 	ProcessLatencySamples(ctx context.Context, appInstKey edgeproto.AppInstKey, cookieKey CookieKey, samples []*dme.Sample) (*dme.Statistics, error)
@@ -21,13 +22,18 @@ type EdgeEventsHandler interface {
 
 type EmptyEdgeEventsHandler struct{}
 
-func (e *EmptyEdgeEventsHandler) AddClientKey(ctx context.Context, appInstKey edgeproto.AppInstKey, cookieKey CookieKey, sendFunc func(event *dme.ServerEdgeEvent)) {
+func (e *EmptyEdgeEventsHandler) AddClientKey(ctx context.Context, appInstKey edgeproto.AppInstKey, cookieKey CookieKey, lastLoc *dme.Loc, carrier string, sendFunc func(event *dme.ServerEdgeEvent)) {
 	log.DebugLog(log.DebugLevelDmereq, "AddClientKey not implemented for EmptyEdgeEventHandler. Returning")
 	return
 }
 
 func (e *EmptyEdgeEventsHandler) RemoveClientKey(ctx context.Context, appInstKey edgeproto.AppInstKey, cookieKey CookieKey) {
 	log.DebugLog(log.DebugLevelDmereq, "RemoveClientKey not implemented for EmptyEdgeEventHandler. Returning")
+	return
+}
+
+func (e *EmptyEdgeEventsHandler) UpdateClientLastLocation(ctx context.Context, appInstKey edgeproto.AppInstKey, cookieKey CookieKey, lastLoc *dme.Loc) {
+	log.DebugLog(log.DebugLevelDmereq, "UpdateClientLastLocation not implemented for EmptyEdgeEventHandler. Returning")
 	return
 }
 

--- a/d-match-engine/dme-common/gpslocation-stats.go
+++ b/d-match-engine/dme-common/gpslocation-stats.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
 
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 )
@@ -13,21 +12,30 @@ import (
 const kmPerDegLong = 111.32
 const kmPerDegLat = 110.57
 
+type LocationTileInfo struct {
+	Quadrant   int
+	LongIndex  int
+	LatIndex   int
+	TileLength int
+}
+
 func GetLocationTileFromGpsLocation(loc *dme.Loc, locationTileSideLengthKm int) string {
-	var quadrant string
 	// Validate location
 	err := ValidateLocation(loc)
 	if err != nil {
 		return ""
 	}
+	// Create LocationTileInfo
+	locationTileInfo := &LocationTileInfo{}
+	locationTileInfo.TileLength = locationTileSideLengthKm
 	if loc.Latitude >= 0 && loc.Longitude >= 0 {
-		quadrant = "1"
+		locationTileInfo.Quadrant = 1
 	} else if loc.Latitude >= 0 && loc.Longitude < 0 {
-		quadrant = "2"
+		locationTileInfo.Quadrant = 2
 	} else if loc.Latitude < 0 && loc.Longitude < 0 {
-		quadrant = "3"
+		locationTileInfo.Quadrant = 3
 	} else {
-		quadrant = "4"
+		locationTileInfo.Quadrant = 4
 	}
 	// Convert lat, long to positive
 	lat := math.Abs(loc.Latitude)
@@ -36,31 +44,26 @@ func GetLocationTileFromGpsLocation(loc *dme.Loc, locationTileSideLengthKm int) 
 	latKm := lat * kmPerDegLat
 	longKm := long * kmPerDegLong
 	// Calculate number of tiles to get to loc (round down)
-	latIndex := int(latKm / float64(locationTileSideLengthKm))
-	longIndex := int(longKm / float64(locationTileSideLengthKm))
-	// Append lat long to string for metrics
-	pair := strconv.Itoa(latIndex) + "," + strconv.Itoa(longIndex)
+	locationTileInfo.LatIndex = int(latKm / float64(locationTileSideLengthKm))
+	locationTileInfo.LongIndex = int(longKm / float64(locationTileSideLengthKm))
+	// Get the lower and upper gps location ranges
+	locUnder, locOver, err := getGpsLocationRangeFromLocationInfo(locationTileInfo)
+	if err != nil {
+		return ""
+	}
+	// Append long,lat for both locUnder and locOver to string for metrics
+	locUnderStr := fmt.Sprintf("%f,%f", locUnder.Longitude, locUnder.Latitude)
+	locOverStr := fmt.Sprintf("%f,%f", locOver.Longitude, locOver.Latitude)
 	// Append location tile side length for easy conversion
 	sideLengthStr := strconv.Itoa(locationTileSideLengthKm)
-	return quadrant + "-" + pair + "-" + sideLengthStr
+	return locUnderStr + "_" + locOverStr + "_" + sideLengthStr
 }
 
-func GetGpsLocationRangeFromLocationTile(locationTile string) (under *dme.Loc, over *dme.Loc, err error) {
-	s := strings.Split(locationTile, "-")
-	indeces := strings.Split(s[1], ",")
-	quadrant := s[0]
-	latIndex, err := strconv.Atoi(indeces[0])
-	if err != nil {
-		return nil, nil, err
-	}
-	longIndex, err := strconv.Atoi(indeces[1])
-	if err != nil {
-		return nil, nil, err
-	}
-	locationTileSideLengthKm, err := strconv.Atoi(s[2])
-	if err != nil {
-		return nil, nil, err
-	}
+func getGpsLocationRangeFromLocationInfo(locationTileInfo *LocationTileInfo) (under *dme.Loc, over *dme.Loc, err error) {
+	quadrant := locationTileInfo.Quadrant
+	latIndex := locationTileInfo.LatIndex
+	longIndex := locationTileInfo.LongIndex
+	locationTileSideLengthKm := locationTileInfo.TileLength
 
 	latKmUnder := latIndex * locationTileSideLengthKm
 	latKmOver := (latIndex + 1) * locationTileSideLengthKm
@@ -81,17 +84,17 @@ func GetGpsLocationRangeFromLocationTile(locationTile string) (under *dme.Loc, o
 		Longitude: longOver,
 	}
 	switch quadrant {
-	case "1":
+	case 1:
 		// no-op
-	case "2":
+	case 2:
 		under.Longitude *= -1
 		over.Longitude *= -1
-	case "3":
+	case 3:
 		under.Latitude *= -1
 		under.Longitude *= -1
 		over.Latitude *= -1
 		over.Longitude *= -1
-	case "4":
+	case 4:
 		under.Latitude *= -1
 		over.Latitude *= -1
 	default:

--- a/d-match-engine/dme-common/gpslocation-stats_test.go
+++ b/d-match-engine/dme-common/gpslocation-stats_test.go
@@ -2,6 +2,8 @@ package dmecommon
 
 import (
 	"math"
+	"strconv"
+	"strings"
 	"testing"
 
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
@@ -39,71 +41,70 @@ func TestGpsLocation(t *testing.T) {
 
 	// Get location tile for Berlin with location tile length == 1km
 	tile1Berlin := GetLocationTileFromGpsLocation(berlin, tl1)
-	// Get Gps Location ranges for tile generated above
-	under, over, err := GetGpsLocationRangeFromLocationTile(tile1Berlin)
-	assert.Nil(t, err)
 	// Check to make sure lat, long of berlin is within the location ranges generated above
-	checkLocationRange(t, under, over, berlin)
+	checkLocationRange(t, tile1Berlin, berlin)
 
 	// Get location tile for Berlin with location tile length == 2km
 	tile2Berlin := GetLocationTileFromGpsLocation(berlin, tl2)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile2Berlin)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, berlin)
+	checkLocationRange(t, tile2Berlin, berlin)
 
 	// Get location tile for Berlin with location tile length == 5km
 	tile5Berlin := GetLocationTileFromGpsLocation(berlin, tl5)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile5Berlin)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, berlin)
+	checkLocationRange(t, tile5Berlin, berlin)
 
 	tile1SanJose := GetLocationTileFromGpsLocation(sanjose, tl1)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile1SanJose)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, sanjose)
+	checkLocationRange(t, tile1SanJose, sanjose)
 
 	tile2SanJose := GetLocationTileFromGpsLocation(sanjose, tl2)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile2SanJose)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, sanjose)
+	checkLocationRange(t, tile2SanJose, sanjose)
 
 	tile5SanJose := GetLocationTileFromGpsLocation(sanjose, tl5)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile5SanJose)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, sanjose)
+	checkLocationRange(t, tile5SanJose, sanjose)
 
 	tile1Sydney := GetLocationTileFromGpsLocation(sydney, tl1)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile1Sydney)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, sydney)
+	checkLocationRange(t, tile1Sydney, sydney)
 
 	tile2Sydney := GetLocationTileFromGpsLocation(sydney, tl2)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile2Sydney)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, sydney)
+	checkLocationRange(t, tile2Sydney, sydney)
 
 	tile5Sydney := GetLocationTileFromGpsLocation(sydney, tl5)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile5Sydney)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, sydney)
+	checkLocationRange(t, tile5Sydney, sydney)
 
 	tile1Rio := GetLocationTileFromGpsLocation(rio, tl1)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile1Rio)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, rio)
+	checkLocationRange(t, tile1Rio, rio)
 
 	tile2Rio := GetLocationTileFromGpsLocation(rio, tl2)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile2Rio)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, rio)
+	checkLocationRange(t, tile2Rio, rio)
 
 	tile5Rio := GetLocationTileFromGpsLocation(rio, tl5)
-	under, over, err = GetGpsLocationRangeFromLocationTile(tile5Rio)
-	assert.Nil(t, err)
-	checkLocationRange(t, under, over, rio)
+	checkLocationRange(t, tile5Rio, rio)
 }
 
-func checkLocationRange(t *testing.T, under, over, actual *dme.Loc) {
+func checkLocationRange(t *testing.T, locationTile string, actual *dme.Loc) {
+	s := strings.Split(locationTile, "_")
+	// Pull out underLoc values
+	underStr := s[0]
+	underLongLat := strings.Split(underStr, ",")
+	underLong, err := strconv.ParseFloat(underLongLat[0], 64)
+	assert.Nil(t, err)
+	underLat, err := strconv.ParseFloat(underLongLat[1], 64)
+	assert.Nil(t, err)
+	under := &dme.Loc{
+		Longitude: underLong,
+		Latitude:  underLat,
+	}
+	// Pull out overLoc values
+	overStr := s[1]
+	overLongLat := strings.Split(overStr, ",")
+	overLong, err := strconv.ParseFloat(overLongLat[0], 64)
+	assert.Nil(t, err)
+	overLat, err := strconv.ParseFloat(overLongLat[1], 64)
+	assert.Nil(t, err)
+	over := &dme.Loc{
+		Longitude: overLong,
+		Latitude:  overLat,
+	}
+
 	assert.True(t, math.Abs(actual.Latitude) < math.Abs(over.Latitude))
 	assert.True(t, math.Abs(actual.Latitude) >= math.Abs(under.Latitude))
 

--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -395,11 +395,11 @@ func initEdgeEventsPlugin(ctx context.Context, operatorName string) (dmecommon.E
 	if err != nil {
 		log.FatalLog("plugin does not have GetEdgeEventsHandler symbol", "plugin", *eesolib)
 	}
-	getEdgeEventsHandlerFunc, ok := sym.(func(ctx context.Context) (dmecommon.EdgeEventsHandler, error))
+	getEdgeEventsHandlerFunc, ok := sym.(func(ctx context.Context, edgeEventsCookieExpiration time.Duration) (dmecommon.EdgeEventsHandler, error))
 	if !ok {
-		log.FatalLog("plugin GetEdgeEventsHandler symbol does not implement func(ctx context.Context) (dmecommon.EdgeEventsHandler, error)", "plugin", *eesolib)
+		log.FatalLog("plugin GetEdgeEventsHandler symbol does not implement func(ctx context.Context, edgeEventsCookieExpiration time.Duration) (dmecommon.EdgeEventsHandler, error)", "plugin", *eesolib)
 	}
-	eehandler, err := getEdgeEventsHandlerFunc(ctx)
+	eehandler, err := getEdgeEventsHandlerFunc(ctx, *edgeEventsCookieExpiration)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Couple of EdgeEvents updates:

1. Add UpdateClientLastLocation function to EdgeEventsHandler that is called each time a client's location changes. This is used by the infra plugin to call FindCloudlet and provide a new cloudlet to the client when an appinst is unusable
2. Add lastLoc and carrier parameters to AddClientKey in EdgeEventsHandler. These are also used to be able to call FindCloudlet from the infra plugin
3. Modified locationtile. Previously locationtile contained long/lat indices, which forced whoever was consuming stats to calculate actual gps coordinates of the locationtile. Now, I'm just doing the indices->long/lat conversions for them and storing the long/lats of the corners of the tile in the locationtile string. 

- The format of the locationtile is: Longitude1,Latitude1_Longitude2,Latitude2_LocationTileLength
- The first Long/Lat are the coordinates of the corner closest to (0,0)
- The second Long/Lat are the coordinates of the corner farthest from (0,0)
- And example locationtile is: -90.998922,30.984896_-91.016888,31.002985_2 (a client at (-90.0, 30.0) will be in this tile)