### PR TITLE
Harbor docker registry

### DIFF
--- a/Makedefs
+++ b/Makedefs
@@ -1,3 +1,4 @@
 LINUX_XCOMPILE_ENV = CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 
-TAG ?= latest
+TAG ?= $(shell echo $$USER | tr -cd 'a-zA-Z' )-$(shell date +'%Y-%m-%d' )
+REGISTRY ?= harbor.mobiledgex.net/mobiledgex-dev

--- a/Makefile
+++ b/Makefile
@@ -42,15 +42,16 @@ build-linux:
 build-docker:
 	rsync --checksum .dockerignore ../.dockerignore
 	docker build --build-arg BUILD_TAG="$(shell git describe --always --dirty=+), $(shell date +'%Y-%m-%d'), ${TAG}" \
-		-t mobiledgex/edge-cloud:${TAG} -f docker/Dockerfile.edge-cloud ..
-	docker tag mobiledgex/edge-cloud:${TAG} registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
-	docker push registry.mobiledgex.net:5000/mobiledgex/edge-cloud:${TAG}
-	docker tag mobiledgex/edge-cloud:${TAG} registry.mobiledgex.net:5000/mobiledgex/edge-cloud:latest
-	docker push registry.mobiledgex.net:5000/mobiledgex/edge-cloud:latest
-	for ADDLTAG in ${ADDLTAGS}; do \
-		docker tag mobiledgex/edge-cloud:${TAG} $$ADDLTAG; \
-		docker push $$ADDLTAG; \
-	done
+		-t mobiledgex/edge-cloud:$(TAG) -f docker/Dockerfile.edge-cloud ..
+	docker tag mobiledgex/edge-cloud:$(TAG) $(REGISTRY)/edge-cloud:${TAG}
+	docker push $(REGISTRY)/edge-cloud:$(TAG)
+	docker tag mobiledgex/edge-cloud:$(TAG) $(REGISTRY)/edge-cloud:latest
+	docker push $(REGISTRY)/edge-cloud:latest
+
+build-nightly: REGISTRY = harbor.mobiledgex.net/mobiledgex
+build-nightly: build-docker
+	docker tag mobiledgex/edge-cloud:$(TAG) $(REGISTRY)/edge-cloud:nightly
+	docker push $(REGISTRY)/edge-cloud:nightly
 
 install:
 	go install ./...


### PR DESCRIPTION
Publish to the new docker registry at harbor.mobiledgex.net. See [edge-cloud PR](https://github.com/mobiledgex/edge-cloud-infra/pull/1481) for more details.

Regular docker builds will publish to `harbor.mobiledgex.net/mobiledgex-dev/edge-cloud`, and official Jenkins builds will publish to `harbor.mobiledgex.net/mobiledgex/edge-cloud`. Jenkins will also publish a "nightly" tag. So, if you need the latest official build available, it will always be: `harbor.mobiledgex.net/mobiledgex/edge-cloud:nightly`