### PR TITLE
fix e2e-tests deployment tag strict setup

### DIFF
--- a/cloudcommon/services.go
+++ b/cloudcommon/services.go
@@ -90,12 +90,17 @@ func getCrmProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig
 			Hostname: cloudlet.Key.Name,
 			EnvVars:  envVars,
 		},
-		TLS: process.TLSCerts{
-			ServerCert: tlsCertFile,
-			ServerKey:  tlsKeyFile,
-			CACert:     tlsCAFile,
+		NodeCommon: process.NodeCommon{
+			TLS: process.TLSCerts{
+				ServerCert: tlsCertFile,
+				ServerKey:  tlsKeyFile,
+				CACert:     tlsCAFile,
+			},
+			VaultAddr:     vaultAddr,
+			UseVaultPki:   useVaultPki,
+			DeploymentTag: deploymentTag,
+			AccessApiAddr: accessApiAddr,
 		},
-		VaultAddr:           vaultAddr,
 		PhysicalName:        cloudlet.PhysicalName,
 		TestMode:            testMode,
 		Span:                span,
@@ -104,11 +109,8 @@ func getCrmProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig
 		CloudletVMImagePath: cloudletVMImagePath,
 		Region:              region,
 		CommercialCerts:     commercialCerts,
-		UseVaultPki:         useVaultPki,
 		AppDNSRoot:          appDNSRoot,
 		ChefServerPath:      chefServerPath,
-		DeploymentTag:       deploymentTag,
-		AccessApiAddr:       accessApiAddr,
 	}, opts, nil
 }
 

--- a/integration/process/process.go
+++ b/integration/process/process.go
@@ -58,6 +58,36 @@ func (c *Common) GetEnv() []string {
 	return envs
 }
 
+// Common args for all nodeMgr processes
+type NodeCommon struct {
+	TLS           TLSCerts
+	VaultAddr     string
+	UseVaultPki   bool
+	DeploymentTag string
+	AccessApiAddr string
+	AccessKeyFile string
+}
+
+func (p *NodeCommon) GetNodeMgrArgs() []string {
+	args := []string{}
+	if p.VaultAddr != "" {
+		args = append(args, "--vaultAddr", p.VaultAddr)
+	}
+	if p.UseVaultPki {
+		args = append(args, "--useVaultPki")
+	}
+	if p.DeploymentTag != "" {
+		args = append(args, "--deploymentTag", p.DeploymentTag)
+	}
+	if p.AccessApiAddr != "" {
+		args = append(args, "--accessApiAddr", p.AccessApiAddr)
+	}
+	if p.AccessKeyFile != "" {
+		args = append(args, "--accessKeyFile", p.AccessKeyFile)
+	}
+	return p.TLS.AddInternalPkiArgs(args)
+}
+
 // options
 
 type StartOptions struct {

--- a/integration/process/process_defs.go
+++ b/integration/process/process_defs.go
@@ -24,63 +24,52 @@ type Etcd struct {
 	cmd            *exec.Cmd
 }
 type Controller struct {
-	Common                 `yaml:",inline"`
-	EtcdAddrs              string
-	ApiAddr                string
-	HttpAddr               string
-	NotifyAddr             string
-	NotifyRootAddrs        string
-	NotifyParentAddrs      string
-	EdgeTurnAddr           string
-	VaultAddr              string
-	InfluxAddr             string
-	Region                 string
-	TLS                    TLSCerts
-	UseVaultPki            bool
-	cmd                    *exec.Cmd
-	TestMode               bool
-	RegistryFQDN           string
-	ArtifactoryFQDN        string
-	CloudletRegistryPath   string
-	VersionTag             string
-	CloudletVMImagePath    string
-	CheckpointInterval     string
-	AppDNSRoot             string
-	DeploymentTag          string
-	ChefServerPath         string
-	AccessApiAddr          string
-	RequireNotifyAccessKey bool
+	Common               `yaml:",inline"`
+	NodeCommon           `yaml:",inline"`
+	EtcdAddrs            string
+	ApiAddr              string
+	HttpAddr             string
+	NotifyAddr           string
+	NotifyRootAddrs      string
+	NotifyParentAddrs    string
+	EdgeTurnAddr         string
+	InfluxAddr           string
+	Region               string
+	cmd                  *exec.Cmd
+	TestMode             bool
+	RegistryFQDN         string
+	ArtifactoryFQDN      string
+	CloudletRegistryPath string
+	VersionTag           string
+	CloudletVMImagePath  string
+	CheckpointInterval   string
+	AppDNSRoot           string
+	ChefServerPath       string
 }
 type Dme struct {
-	Common        `yaml:",inline"`
-	ApiAddr       string
-	HttpAddr      string
-	NotifyAddrs   string
-	LocVerUrl     string
-	TokSrvUrl     string
-	QosPosUrl     string
-	Carrier       string
-	CloudletKey   string
-	VaultAddr     string
-	CookieExpr    string
-	Region        string
-	TLS           TLSCerts
-	UseVaultPki   bool
-	cmd           *exec.Cmd
-	AccessKeyFile string
-	AccessApiAddr string
+	Common      `yaml:",inline"`
+	NodeCommon  `yaml:",inline"`
+	ApiAddr     string
+	HttpAddr    string
+	NotifyAddrs string
+	LocVerUrl   string
+	TokSrvUrl   string
+	QosPosUrl   string
+	Carrier     string
+	CloudletKey string
+	CookieExpr  string
+	Region      string
+	cmd         *exec.Cmd
 }
 type Crm struct {
 	Common              `yaml:",inline"`
+	NodeCommon          `yaml:",inline"`
 	NotifyAddrs         string
 	NotifySrvAddr       string
 	CloudletKey         string
 	Platform            string
 	Plugin              string
-	TLS                 TLSCerts
-	UseVaultPki         bool
 	cmd                 *exec.Cmd
-	VaultAddr           string
 	PhysicalName        string
 	TestMode            bool
 	Span                string
@@ -91,9 +80,6 @@ type Crm struct {
 	CommercialCerts     bool
 	AppDNSRoot          string
 	ChefServerPath      string
-	DeploymentTag       string
-	AccessKeyFile       string
-	AccessApiAddr       string
 }
 type LocApiSim struct {
 	Common  `yaml:",inline"`
@@ -129,16 +115,14 @@ type Influx struct {
 }
 type ClusterSvc struct {
 	Common         `yaml:",inline"`
+	NodeCommon     `yaml:",inline"`
 	NotifyAddrs    string
 	CtrlAddrs      string
 	PromPorts      string
 	InfluxDB       string
 	Interval       string
 	Region         string
-	VaultAddr      string
 	PluginRequired bool
-	UseVaultPki    bool
-	TLS            TLSCerts
 	cmd            *exec.Cmd
 }
 type DockerGeneric struct {
@@ -161,20 +145,16 @@ type Traefik struct {
 	cmd    *exec.Cmd
 }
 type NotifyRoot struct {
-	Common      `yaml:",inline"`
-	VaultAddr   string
-	TLS         TLSCerts
-	UseVaultPki bool
-	cmd         *exec.Cmd
+	Common     `yaml:",inline"`
+	NodeCommon `yaml:",inline"`
+	cmd        *exec.Cmd
 }
 type EdgeTurn struct {
-	Common      `yaml:",inline"`
-	TLS         TLSCerts
-	cmd         *exec.Cmd
-	UseVaultPki bool
-	VaultAddr   string
-	ListenAddr  string
-	ProxyAddr   string
-	Region      string
-	TestMode    bool
+	Common     `yaml:",inline"`
+	NodeCommon `yaml:",inline"`
+	cmd        *exec.Cmd
+	ListenAddr string
+	ProxyAddr  string
+	Region     string
+	TestMode   bool
 }

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -97,6 +97,7 @@ func (p *Etcd) ResetData() error {
 
 func (p *Controller) StartLocal(logfile string, opts ...StartOp) error {
 	args := []string{"--etcdUrls", p.EtcdAddrs, "--notifyAddr", p.NotifyAddr}
+	args = append(args, p.GetNodeMgrArgs()...)
 	if p.ApiAddr != "" {
 		args = append(args, "--apiAddr")
 		args = append(args, p.ApiAddr)
@@ -105,14 +106,9 @@ func (p *Controller) StartLocal(logfile string, opts ...StartOp) error {
 		args = append(args, "--httpAddr")
 		args = append(args, p.HttpAddr)
 	}
-	args = p.TLS.AddInternalPkiArgs(args)
 	if p.InfluxAddr != "" {
 		args = append(args, "--influxAddr")
 		args = append(args, p.InfluxAddr)
-	}
-	if p.VaultAddr != "" {
-		args = append(args, "--vaultAddr")
-		args = append(args, p.VaultAddr)
 	}
 	if p.RegistryFQDN != "" {
 		args = append(args, "--registryFQDN")
@@ -141,9 +137,6 @@ func (p *Controller) StartLocal(logfile string, opts ...StartOp) error {
 	if p.Region != "" {
 		args = append(args, "--region", p.Region)
 	}
-	if p.UseVaultPki {
-		args = append(args, "--useVaultPki")
-	}
 	if p.EdgeTurnAddr != "" {
 		args = append(args, "--edgeTurnAddr")
 		args = append(args, p.EdgeTurnAddr)
@@ -169,19 +162,9 @@ func (p *Controller) StartLocal(logfile string, opts ...StartOp) error {
 		args = append(args, "--checkpointInterval")
 		args = append(args, p.CheckpointInterval)
 	}
-	if p.DeploymentTag != "" {
-		args = append(args, "--deploymentTag")
-		args = append(args, p.DeploymentTag)
-	}
 	if p.ChefServerPath != "" {
 		args = append(args, "--chefServerPath")
 		args = append(args, p.ChefServerPath)
-	}
-	if p.AccessApiAddr != "" {
-		args = append(args, "--accessApiAddr", p.AccessApiAddr)
-	}
-	if p.RequireNotifyAccessKey {
-		args = append(args, "--requireNotifyAccessKey")
 	}
 
 	envs := p.GetEnv()
@@ -279,6 +262,7 @@ func (p *Controller) ConnectAPI(timeout time.Duration) (*grpc.ClientConn, error)
 
 func (p *Dme) StartLocal(logfile string, opts ...StartOp) error {
 	args := []string{"--notifyAddrs", p.NotifyAddrs}
+	args = append(args, p.GetNodeMgrArgs()...)
 	if p.ApiAddr != "" {
 		args = append(args, "--apiAddr")
 		args = append(args, p.ApiAddr)
@@ -307,14 +291,6 @@ func (p *Dme) StartLocal(logfile string, opts ...StartOp) error {
 		args = append(args, "--cloudletKey")
 		args = append(args, p.CloudletKey)
 	}
-	args = p.TLS.AddInternalPkiArgs(args)
-	if p.VaultAddr != "" {
-		args = append(args, "--vaultAddr")
-		args = append(args, p.VaultAddr)
-	}
-	if p.UseVaultPki {
-		args = append(args, "--useVaultPki")
-	}
 	if p.CookieExpr != "" {
 		args = append(args, "--cookieExpiration")
 		args = append(args, p.CookieExpr)
@@ -322,12 +298,7 @@ func (p *Dme) StartLocal(logfile string, opts ...StartOp) error {
 	if p.Region != "" {
 		args = append(args, "--region", p.Region)
 	}
-	if p.AccessKeyFile != "" {
-		args = append(args, "--accessKeyFile", p.AccessKeyFile)
-	}
-	if p.AccessApiAddr != "" {
-		args = append(args, "--accessApiAddr", p.AccessApiAddr)
-	}
+
 	options := StartOptions{}
 	options.ApplyStartOptions(opts...)
 	if options.Debug != "" {
@@ -401,6 +372,7 @@ func (p *Dme) getTlsConfig(addr string) *tls.Config {
 
 func (p *Crm) GetArgs(opts ...StartOp) []string {
 	args := []string{"--notifyAddrs", p.NotifyAddrs}
+	args = append(args, p.GetNodeMgrArgs()...)
 	if p.NotifySrvAddr != "" {
 		args = append(args, "--notifySrvAddr")
 		args = append(args, p.NotifySrvAddr)
@@ -409,7 +381,6 @@ func (p *Crm) GetArgs(opts ...StartOp) []string {
 		args = append(args, "--cloudletKey")
 		args = append(args, p.CloudletKey)
 	}
-	args = p.TLS.AddInternalPkiArgs(args)
 	if p.Name != "" {
 		args = append(args, "--hostname")
 		args = append(args, p.Name)
@@ -421,10 +392,6 @@ func (p *Crm) GetArgs(opts ...StartOp) []string {
 	if p.Plugin != "" {
 		args = append(args, "--plugin")
 		args = append(args, p.Plugin)
-	}
-	if p.VaultAddr != "" {
-		args = append(args, "--vaultAddr")
-		args = append(args, p.VaultAddr)
 	}
 	if p.PhysicalName != "" {
 		args = append(args, "--physicalName")
@@ -453,9 +420,6 @@ func (p *Crm) GetArgs(opts ...StartOp) []string {
 		args = append(args, "--region")
 		args = append(args, p.Region)
 	}
-	if p.UseVaultPki {
-		args = append(args, "--useVaultPki")
-	}
 	if p.AppDNSRoot != "" {
 		args = append(args, "--appDNSRoot")
 		args = append(args, p.AppDNSRoot)
@@ -464,16 +428,7 @@ func (p *Crm) GetArgs(opts ...StartOp) []string {
 		args = append(args, "--chefServerPath")
 		args = append(args, p.ChefServerPath)
 	}
-	if p.DeploymentTag != "" {
-		args = append(args, "--deploymentTag")
-		args = append(args, p.DeploymentTag)
-	}
-	if p.AccessKeyFile != "" {
-		args = append(args, "--accessKeyFile", p.AccessKeyFile)
-	}
-	if p.AccessApiAddr != "" {
-		args = append(args, "--accessApiAddr", p.AccessApiAddr)
-	}
+
 	options := StartOptions{}
 	options.ApplyStartOptions(opts...)
 	if options.Debug != "" {
@@ -622,11 +577,11 @@ func (p *Influx) GetClient() (influxclient.Client, error) {
 
 func (p *ClusterSvc) StartLocal(logfile string, opts ...StartOp) error {
 	args := []string{"--notifyAddrs", p.NotifyAddrs}
+	args = append(args, p.GetNodeMgrArgs()...)
 	if p.CtrlAddrs != "" {
 		args = append(args, "--ctrlAddrs")
 		args = append(args, p.CtrlAddrs)
 	}
-	args = p.TLS.AddInternalPkiArgs(args)
 	if p.PromPorts != "" {
 		args = append(args, "--prometheus-ports")
 		args = append(args, p.PromPorts)
@@ -641,13 +596,6 @@ func (p *ClusterSvc) StartLocal(logfile string, opts ...StartOp) error {
 	}
 	if p.PluginRequired {
 		args = append(args, "--pluginRequired")
-	}
-	if p.VaultAddr != "" {
-		args = append(args, "--vaultAddr")
-		args = append(args, p.VaultAddr)
-	}
-	if p.UseVaultPki {
-		args = append(args, "--useVaultPki")
 	}
 	if p.Region != "" {
 		args = append(args, "--region", p.Region)
@@ -1356,15 +1304,8 @@ http {
 `
 
 func (p *NotifyRoot) StartLocal(logfile string, opts ...StartOp) error {
-	args := []string{}
-	if p.VaultAddr != "" {
-		args = append(args, "--vaultAddr")
-		args = append(args, p.VaultAddr)
-	}
-	args = p.TLS.AddInternalPkiArgs(args)
-	if p.UseVaultPki {
-		args = append(args, "--useVaultPki")
-	}
+	args := p.GetNodeMgrArgs()
+
 	options := StartOptions{}
 	options.ApplyStartOptions(opts...)
 	if options.Debug != "" {
@@ -1402,7 +1343,7 @@ func (p *NotifyRoot) GetExeName() string { return "notifyroot" }
 func (p *NotifyRoot) LookupArgs() string { return "" }
 
 func (p *EdgeTurn) StartLocal(logfile string, opts ...StartOp) error {
-	args := []string{}
+	args := p.GetNodeMgrArgs()
 	if p.ListenAddr != "" {
 		args = append(args, "--listenAddr")
 		args = append(args, p.ListenAddr)
@@ -1411,19 +1352,11 @@ func (p *EdgeTurn) StartLocal(logfile string, opts ...StartOp) error {
 		args = append(args, "--proxyAddr")
 		args = append(args, p.ProxyAddr)
 	}
-	args = p.TLS.AddInternalPkiArgs(args)
 	if p.Region != "" {
 		args = append(args, "--region", p.Region)
 	}
 	if p.TestMode {
 		args = append(args, "--testMode")
-	}
-	if p.UseVaultPki {
-		args = append(args, "--useVaultPki")
-	}
-	if p.VaultAddr != "" {
-		args = append(args, "--vaultAddr")
-		args = append(args, p.VaultAddr)
 	}
 	options := StartOptions{}
 	options.ApplyStartOptions(opts...)

--- a/setup-env/setup-mex/setup-mex.go
+++ b/setup-env/setup-mex/setup-mex.go
@@ -167,7 +167,7 @@ func ReadSetupFile(setupfile string, deployment interface{}, vars map[string]str
 	setupdir := filepath.Dir(setupfile)
 	vars["setupdir"] = setupdir
 
-	util.ReadYamlFile(setupfile, &setupVars)
+	util.ReadYamlFile(setupfile, &setupVars, util.WithStrict())
 
 	for _, repl := range setupVars.Vars {
 		for varname, value := range repl {

--- a/setup-env/util/util.go
+++ b/setup-env/util/util.go
@@ -405,6 +405,7 @@ func CreateOutputDir(useTimestamp bool, outputDir string, logFileName string) st
 type ReadYamlOptions struct {
 	vars                 map[string]string
 	validateReplacedVars bool
+	strict               bool
 }
 
 type ReadYamlOp func(opts *ReadYamlOptions)
@@ -448,7 +449,11 @@ func ReadYamlFile(filename string, iface interface{}, ops ...ReadYamlOp) error {
 		}
 	}
 
-	err = yaml.Unmarshal(yamlFile, iface)
+	if opts.strict {
+		err = yaml.UnmarshalStrict(yamlFile, iface)
+	} else {
+		err = yaml.Unmarshal(yamlFile, iface)
+	}
 	if err != nil {
 		return err
 	}
@@ -464,6 +469,12 @@ func WithVars(vars map[string]string) ReadYamlOp {
 func ValidateReplacedVars() ReadYamlOp {
 	return func(opts *ReadYamlOptions) {
 		opts.validateReplacedVars = true
+	}
+}
+
+func WithStrict() ReadYamlOp {
+	return func(opts *ReadYamlOptions) {
+		opts.strict = true
 	}
 }
 


### PR DESCRIPTION
Groups nodeMgr command args under a common "NodeCommon" struct for e2e processes, rather than duplicating them across multiple process types. The autoprov process was missing the deploymentTag field.

Changes the yaml unmarshal of the setup file to strict, so that invalid fields cause it to fail. The e2e tests were failing in infra because a deploymentTag field was specified on the autoprov process, but the process definition didn't have such a field, and it was being silently ignored.