### PR TITLE
Change resource titles in Operator PDF reports

### DIFF
--- a/cloud-resource-manager/platform/fake/fake.go
+++ b/cloud-resource-manager/platform/fake/fake.go
@@ -28,8 +28,6 @@ var (
 	ResourceAdd    = true
 	ResourceRemove = false
 
-	ResourceExternalIps = "External IPs"
-
 	FakeRamUsed         = uint64(0)
 	FakeVcpusUsed       = uint64(0)
 	FakeDiskUsed        = uint64(0)
@@ -357,7 +355,7 @@ func (s *Platform) GetCloudletInfraResources(ctx context.Context) (*edgeproto.In
 			InfraMaxValue: FakeVcpusMax,
 		},
 		edgeproto.InfraResource{
-			Name:          ResourceExternalIps,
+			Name:          cloudcommon.ResourceExternalIPs,
 			Value:         FakeExternalIpsUsed,
 			InfraMaxValue: FakeExternalIpsMax,
 		},
@@ -370,7 +368,7 @@ func (s *Platform) GetCloudletInfraResources(ctx context.Context) (*edgeproto.In
 func (s *Platform) GetClusterAdditionalResources(ctx context.Context, cloudlet *edgeproto.Cloudlet, vmResources []edgeproto.VMResource, infraResMap map[string]edgeproto.InfraResource) map[string]edgeproto.InfraResource {
 	// resource name -> resource units
 	cloudletRes := map[string]string{
-		ResourceExternalIps: "",
+		cloudcommon.ResourceExternalIPs: "",
 	}
 	resInfo := make(map[string]edgeproto.InfraResource)
 	for resName, resUnits := range cloudletRes {
@@ -387,10 +385,10 @@ func (s *Platform) GetClusterAdditionalResources(ctx context.Context, cloudlet *
 
 	for _, vmRes := range vmResources {
 		if vmRes.Type == cloudcommon.VMTypeRootLB {
-			out, ok := resInfo[ResourceExternalIps]
+			out, ok := resInfo[cloudcommon.ResourceExternalIPs]
 			if ok {
 				out.Value += 1
-				resInfo[ResourceExternalIps] = out
+				resInfo[cloudcommon.ResourceExternalIPs] = out
 			}
 		}
 	}
@@ -401,8 +399,8 @@ func (s *Platform) GetCloudletResourceQuotaProps(ctx context.Context) (*edgeprot
 	return &edgeproto.CloudletResourceQuotaProps{
 		Properties: []edgeproto.InfraResource{
 			edgeproto.InfraResource{
-				Name:        ResourceExternalIps,
-				Description: "Limit on external IPs available",
+				Name:        cloudcommon.ResourceExternalIPs,
+				Description: cloudcommon.ResourceQuotaDesc[cloudcommon.ResourceExternalIPs],
 			},
 		},
 	}, nil
@@ -416,7 +414,7 @@ func (s *Platform) GetClusterAdditionalResourceMetric(ctx context.Context, cloud
 		}
 	}
 
-	resMetric.AddIntVal("externalIpsUsed", externalIpsUsed)
+	resMetric.AddIntVal(cloudcommon.ResourceMetricExternalIPs, externalIpsUsed)
 	return nil
 }
 

--- a/cloudcommon/infraresources.go
+++ b/cloudcommon/infraresources.go
@@ -17,8 +17,23 @@ var (
 	ResourceVcpus = "vCPUs"
 	ResourceGpus  = "GPUs"
 
+	// Platform specific resources
+	ResourceInstances   = "Instances"
+	ResourceFloatingIPs = "Floating IPs"
+	ResourceExternalIPs = "External IPs"
+
+	// Resource units
 	ResourceRamUnits = "MB"
 
+	// Resource metrics
+	ResourceMetricRamMB       = "ramUsed"
+	ResourceMetricVcpus       = "vcpusUsed"
+	ResourceMetricsGpus       = "gpusUsed"
+	ResourceMetricInstances   = "instancesUsed"
+	ResourceMetricExternalIPs = "externalIpsUsed"
+	ResourceMetricFloatingIPs = "floatingIpsUsed"
+
+	// Common cloudlet resources
 	CloudletResources = []edgeproto.InfraResource{
 		edgeproto.InfraResource{
 			Name:        ResourceRamMb,
@@ -32,6 +47,21 @@ var (
 			Name:        ResourceGpus,
 			Description: "Limit on GPUs available",
 		},
+	}
+
+	ResourceQuotaDesc = map[string]string{
+		ResourceInstances:   "Limit on number of instances that can be provisioned",
+		ResourceFloatingIPs: "Limit on number of floating IPs that can be created",
+		ResourceExternalIPs: "Limit on how many external IPs are available",
+	}
+
+	ResourceMetricsDesc = map[string]string{
+		ResourceMetricRamMB:       "RAM Usage (MB)",
+		ResourceMetricVcpus:       "vCPU Usage",
+		ResourceMetricsGpus:       "GPU Usage",
+		ResourceMetricInstances:   "VM Instance Usage",
+		ResourceMetricExternalIPs: "External IP Usage",
+		ResourceMetricFloatingIPs: "Floating IP Usage",
 	}
 )
 

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -590,8 +590,8 @@ func getCloudletResourceMetric(ctx context.Context, stm concurrency.STM, key *ed
 	resMetric.Name = cloudcommon.GetCloudletResourceUsageMeasurement(pfType)
 	resMetric.AddTag("cloudletorg", key.Organization)
 	resMetric.AddTag("cloudlet", key.Name)
-	resMetric.AddIntVal("ramUsed", ramUsed)
-	resMetric.AddIntVal("vcpusUsed", vcpusUsed)
+	resMetric.AddIntVal(cloudcommon.ResourceMetricRamMB, ramUsed)
+	resMetric.AddIntVal(cloudcommon.ResourceMetricVcpus, vcpusUsed)
 
 	// get additional infra specific metric
 	err = cloudletPlatform.GetClusterAdditionalResourceMetric(ctx, &cloudlet, &resMetric, allResources)
@@ -614,7 +614,7 @@ func getCloudletResourceMetric(ctx context.Context, stm concurrency.STM, key *ed
 			}
 		}
 	}
-	resMetric.AddIntVal("gpusUsed", gpusUsed)
+	resMetric.AddIntVal(cloudcommon.ResourceMetricsGpus, gpusUsed)
 	metrics := []*edgeproto.Metric{}
 	metrics = append(metrics, &resMetric)
 


### PR DESCRIPTION
* Updated code to define all resource names and metric names as part of cloudcommon code. This way we can ensure that consistent name is used across different platforms and all the descriptions for those are defined in one place