### PR TITLE
Fixes for EDGECLOUD 4465, 4884, 3329, 4226, 4838

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -328,6 +328,9 @@ func (s *AppApi) configureApp(ctx context.Context, stm concurrency.STM, in *edge
 		VaultConfig: vaultConfig,
 	}
 	if in.ImageType == edgeproto.ImageType_IMAGE_TYPE_QCOW {
+		if !strings.Contains(in.ImagePath, "://") {
+			in.ImagePath = "https://" + in.ImagePath
+		}
 		err := util.ValidateImagePath(in.ImagePath)
 		if err != nil {
 			return err

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -294,6 +294,11 @@ func validateCloudletInfraResources(ctx context.Context, stm concurrency.STM, cl
 			// this resource is not tracked by controller, skip it
 			continue
 		}
+		if resInfo.QuotaMaxValue > 0 && resInfo.InfraMaxValue > 0 {
+			if resInfo.QuotaMaxValue > resInfo.InfraMaxValue {
+				warnings = append(warnings, fmt.Sprintf("[Quota] Invalid quota set for %s, quota max value %d is more than infra max value %d", resName, resInfo.QuotaMaxValue, resInfo.InfraMaxValue))
+			}
+		}
 		thAvailableResVal := uint64(0)
 		if resInfo.Value > max {
 			warnings = append(warnings, fmt.Sprintf("[Quota] Invalid quota set for %s, quota max value %d is less than used resource value %d", resName, max, resInfo.Value))


### PR DESCRIPTION
EDGECLOUD-4465: Generate Alert if quotamaxvalue is greater than inframaxvalue during CreateCloudlet
EDGECLOUD-4226: CreateApp should work without “https://” prefix in the image path