### PR TITLE
EDGECLOUD-4911  App config - Deployment manifest is deleted on updating the app config

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -577,7 +577,7 @@ func (s *AppApi) UpdateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 				// No generator means the user previously provided a manifest.  Force them to do so again when changing ports so
 				// that they do not accidentally lose their provided manifest details
 				return fmt.Errorf("kubernetes manifest which was previously specified must be provided again when changing access ports")
-			} else if cur.Deployment != cloudcommon.DeploymentTypeDocker {
+			} else if cur.Deployment == cloudcommon.DeploymentTypeKubernetes {
 				// force regeneration of manifest for k8s
 				cur.DeploymentManifest = ""
 			}


### PR DESCRIPTION
We clear the deployment manifest in case accessPorts are updated to prevent manifests containing incorrect set of ports; however we should only do that for k8s deployments. Fixed the check and added unit-tests to prevent this in the future.