### PR TITLE
e2e-tests ramdisk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201010224723-4f7140c49acb
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 	google.golang.org/api v0.14.0
 	google.golang.org/genproto v0.0.0-20200305110556-506484158171 // indirect
 	google.golang.org/grpc v1.29.1

--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -16,6 +16,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -64,8 +66,47 @@ type LocalAuth struct {
 var InfluxCredsFile = "/tmp/influx.json"
 
 // EtcdLocal
+var EtcdRamDiskSizeVar = "ETCD_RAMDISK_SIZEG"
+var RamDisk = "ramdisk"
+var MaxRamDiskSizeG = 3.0
 
 func (p *Etcd) StartLocal(logfile string, opts ...StartOp) error {
+	etcdRamDiskSizeG := os.Getenv(EtcdRamDiskSizeVar)
+	if runtime.GOOS == "darwin" && etcdRamDiskSizeG != "" {
+		// macos specific
+		dir := "/Volumes/" + RamDisk
+		_, err := os.Stat(dir)
+		if os.IsNotExist(err) {
+			// create ram disk
+			size, err := strconv.ParseFloat(etcdRamDiskSizeG, 32)
+			if err != nil {
+				return fmt.Errorf("Failed to convert %s value %s to float: %v", EtcdRamDiskSizeVar, etcdRamDiskSizeG, err)
+			}
+			// prevent the user from killing their machine
+			if size > MaxRamDiskSizeG {
+				return fmt.Errorf("RAM disk sizes larger than %fG not allowed to avoid killing your machine", MaxRamDiskSizeG)
+			}
+			// create device
+			args := []string{"hdiutil", "attach", "-nomount",
+				fmt.Sprintf("ram://%d", uint(size*2097152))}
+			log.Printf("Creating ramdisk: %s\n", strings.Join(args, " "))
+			out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("Failed to create ramdisk: %s: %s, %v", strings.Join(args, " "), string(out), err)
+			}
+			diskID := string(out)
+			eraseCmd := fmt.Sprintf("diskutil erasevolume HFS+ %s %s", RamDisk, diskID)
+			log.Printf("Formatting ramdisk: %s\n", eraseCmd)
+			out, err = exec.Command("bash", "-c", eraseCmd).CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("Failed to clear ramdisk: %s: %s, %v", strings.Join(args, " "), string(out), err)
+			}
+		}
+		base := filepath.Base(p.DataDir)
+		p.DataDir = dir + "/" + base
+		log.Printf("Using ramdisk for etcd %s storage: %s\n", p.Name, p.DataDir)
+	}
+
 	options := StartOptions{}
 	options.ApplyStartOptions(opts...)
 	if options.CleanStartup {
@@ -91,6 +132,41 @@ func (p *Etcd) LookupArgs() string { return "--name " + p.Name }
 
 func (p *Etcd) ResetData() error {
 	return os.RemoveAll(p.DataDir)
+}
+
+// This should be called after etcd processes are stopped
+func CleanupEtcdRamDisk() error {
+	if runtime.GOOS == "darwin" {
+		dir := "/Volumes/" + RamDisk
+		_, err := os.Stat(dir)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		log.Printf("Cleaning up RAM disk. Getting device ID...\n")
+		args := []string{"bash", "-c", "diskutil list " + RamDisk}
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Failed to get device ID for RAM disk: %s: %s, %v", strings.Join(args, " "), string(out), err)
+		}
+		outFields := strings.Fields(string(out))
+		if len(outFields) < 1 {
+			return fmt.Errorf("diskutil output device ID not found: %s", string(out))
+		}
+		diskID := outFields[0]
+		log.Printf("Unmounting RAM disk %s\n", diskID)
+		args = []string{"umount", "-f", diskID}
+		out, err = exec.Command(args[0], args[1:]...).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("unmount etcd RAM disk failed: %s: %s, %v", strings.Join(args, " "), string(out), err)
+		}
+		log.Printf("Ejecting RAM disk %s\n", diskID)
+		args = []string{"hdiutil", "detach", diskID}
+		out, err = exec.Command(args[0], args[1:]...).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("delete etcd RAM disk failed: %s: %s, %v", strings.Join(args, " "), string(out), err)
+		}
+	}
+	return nil
 }
 
 // ControllerLocal

--- a/setup-env/setup-mex/setup-mex.go
+++ b/setup-env/setup-mex/setup-mex.go
@@ -606,6 +606,10 @@ func Cleanup(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	err = process.CleanupEtcdRamDisk()
+	if err != nil {
+		return err
+	}
 	return CleanupLocalProxies()
 }
 


### PR DESCRIPTION
This creates a RAM disk for etcd in e2e-tests. I found this reduced e2e-test run time by 1/3 to 1/2. But, it does eat up a fair amount of RAM, so it's disabled by default. To enable, set the env var ETCD_RAMDISK_SIZEG=1.2 when running e2e-tests. 1.2 means a 1.2GB ramdisk, which seems to work (there are 6 etcd instances in the infra test, each can use up to 150MB or so). As part of cleanup, e2e-tests will delete the RAM disk.