### PR TITLE
EDGECLOUD-4727: flavorusage metrics does not display the flavor used by dedicatedrootlb of cluster instances

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -629,7 +629,7 @@ func getCloudletResourceMetric(ctx context.Context, stm concurrency.STM, key *ed
 		flavorMetric.Timestamp = *ts
 		flavorMetric.AddTag("cloudletorg", cloudlet.Key.Organization)
 		flavorMetric.AddTag("cloudlet", cloudlet.Key.Name)
-		flavorMetric.AddStringVal("flavor", fName)
+		flavorMetric.AddTag("flavor", fName)
 		flavorMetric.AddIntVal("count", fCount)
 		metrics = append(metrics, &flavorMetric)
 	}


### PR DESCRIPTION
* Changed value to a tag, as Influx was only considering `timestamp, cloudlet, cloudlet-org` as a unique entry, and hence flavor counts were overwritten. Thanks @levshvarts for helping me out with this
* Have also added some unit tests although not related to this fix