### PR TITLE
EDGECLOUD-5117: err on invalid kafka inputs

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -491,6 +491,8 @@ func (s *CloudletApi) createCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 	kafkaDetails := node.KafkaCreds{}
 	if (in.KafkaUser != "") != (in.KafkaPassword != "") {
 		return errors.New("Must specify both kafka username and password, or neither")
+	} else if in.KafkaCluster == "" && in.KafkaUser != "" {
+		return errors.New("Must specify a kafka cluster endpoint in addition to kafka credentials")
 	}
 	if in.KafkaCluster != "" {
 		kafkaDetails.Endpoint = in.KafkaCluster


### PR DESCRIPTION
Don't allow someone to input kafka user/pass without also inputting the kafka cluster endpoint