### PR TITLE
EDGECLOUD-5145 fix for parsing nested yaml separator

### DIFF
--- a/cloudcommon/kubemf.go
+++ b/cloudcommon/kubemf.go
@@ -11,8 +11,10 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
+const yamlSeparator = "\n---"
+
 func DecodeK8SYaml(manifest string) ([]runtime.Object, []*schema.GroupVersionKind, error) {
-	files := strings.Split(manifest, "---")
+	files := strings.Split(manifest, yamlSeparator)
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	objs := []runtime.Object{}
 	kinds := []*schema.GroupVersionKind{}

--- a/cloudcommon/kubemf_test.go
+++ b/cloudcommon/kubemf_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestDecodeK8S(t *testing.T) {
 	objs, _, err := DecodeK8SYaml(testKubeManifest)
 	require.Nil(t, err)
-	require.Equal(t, 3, len(objs))
+	require.Equal(t, 4, len(objs))
 	_, ok := objs[0].(*v1.Service)
 	require.True(t, ok)
 	_, ok = objs[1].(*v1.Service)
@@ -97,7 +97,26 @@ spec:
           protocol: TCP
         - containerPort: 27276
           protocol: UDP
-`
+# adding nested 'yaml document separator' inside mqtt_params_robot.yaml below
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mqtt-bridge-cfg-files-configmap
+data:
+  mqtt_params_robot.yaml: |
+    ---
+    mqtt:
+      client:
+        protocol: $(arg mqtt_protocol)      # MQTTv311
+      connection:
+        host: $(arg mqtt_host)
+        port: $(arg mqtt_port)
+        keepalive: $(arg mqtt_keepalive)
+      private_path: device/001
+    serializer: json:dumps
+    deserializer: json:loads
+    `
 
 var testDockerComposeManifest = `version: '3.3'
 


### PR DESCRIPTION
Without fix
=========

bash-3.2$ lmc-login
login successful
token saved to /Users/devdatta/.mctoken

bash-3.2$ mcctl --skipverify --addr https://127.0.0.1:9900 app create region=local appname=DevApp appvers=1.0 app-org=MobiledgeX deployment=kubernetes deploymentmanifest="$(cat embedded-seps.yml)"
Error: Bad Request (400), Invalid deployment manifest, parse kubernetes deployment yaml failed, yaml: line 8: did not find expected key
bash-3.2$

After fix
======

* Unit test
cd cloudcommon/
bash-3.2$ go test -run TestDecodeK8S
PASS
ok  github.com/mobiledgex/edge-cloud/cloudcommon 1.081s
bash-3.2$

* On local set up
The input manifest file is the one from the defect EDGECLOUD-5145.
bash-3.2$ lmc-login
login successful
token saved to /Users/devdatta/.mctoken
bash-3.2$ mcctl --skipverify --addr https://127.0.0.1:9900 app create region=local appname=DevApp appvers=1.0 app-org=MobiledgeX deployment=kubernetes deploymentmanifest="$(cat embedded-seps.yml)"
{}
bash-3.2$

bash-3.2$ mcctl  --skipverify --addr https://127.0.0.1:9900 app show  region=local appname=DevApp | grep mqtt | wc -l
     159
bash-3.2$


* Regarding Jon's notes on the defect - Actual code from k8s.io is using  
const yamlSeparator = "\n---"
// splitYAMLDocument is a bufio.SplitFunc for splitting YAML streams into individual documents.

Here is the link for it :
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go#L171
