### PR TITLE
fix resources calc when no native flavors exist

### DIFF
--- a/cloudcommon/infraresources.go
+++ b/cloudcommon/infraresources.go
@@ -65,36 +65,11 @@ var (
 	}
 )
 
-func GetClusterInstVMRequirements(ctx context.Context, clusterInst *edgeproto.ClusterInst, pfFlavorList []*edgeproto.FlavorInfo, rootLBFlavor *edgeproto.FlavorInfo) ([]edgeproto.VMResource, error) {
-	log.SpanLog(ctx, log.DebugLevelApi, "GetClusterInstVMResources", "clusterinst key", clusterInst.Key, "platform flavors", pfFlavorList, "root lb flavor", rootLBFlavor)
+// GetClusterInstVMRequirements uses the nodeFlavor and masterNodeFlavor if it cannot find a platform flavor
+func GetClusterInstVMRequirements(ctx context.Context, clusterInst *edgeproto.ClusterInst, nodeFlavor, masterNodeFlavor, rootLBFlavor *edgeproto.FlavorInfo) ([]edgeproto.VMResource, error) {
+	log.SpanLog(ctx, log.DebugLevelApi, "GetClusterInstVMResources", "clusterinst key", clusterInst.Key, "nodeFlavor", nodeFlavor.Name, "masterNodeFlavor", masterNodeFlavor.Name, "root lb flavor", rootLBFlavor)
 	vmResources := []edgeproto.VMResource{}
-	nodeFlavor := &edgeproto.FlavorInfo{}
-	masterNodeFlavor := &edgeproto.FlavorInfo{}
-	nodeFlavorFound := false
-	masterNodeFlavorFound := false
-	for _, flavor := range pfFlavorList {
-		if flavor.Name == clusterInst.NodeFlavor {
-			nodeFlavor = flavor
-			nodeFlavorFound = true
-		}
-		if flavor.Name == clusterInst.MasterNodeFlavor {
-			masterNodeFlavor = flavor
-			masterNodeFlavorFound = true
-		}
-	}
-	// platforms with no native flavor support return zero len flavor lists and use our meta flavors only
-	if len(pfFlavorList) == 0 {
-		log.SpanLog(ctx, log.DebugLevelApi, "GetClusterInstVMResources empty flavor list", "clusterinst key", clusterInst.Key, "platform flavors", pfFlavorList, "root lb flavor", rootLBFlavor)
-		nodeFlavorFound = true
-		masterNodeFlavorFound = true
-	}
 
-	if !nodeFlavorFound {
-		return nil, fmt.Errorf("Node flavor %s does not exist", clusterInst.NodeFlavor)
-	}
-	if clusterInst.MasterNodeFlavor != "" && !masterNodeFlavorFound {
-		return nil, fmt.Errorf("Master node flavor %s does not exist", clusterInst.MasterNodeFlavor)
-	}
 	if clusterInst.Deployment == DeploymentTypeDocker {
 		vmResources = append(vmResources, edgeproto.VMResource{
 			Key:      clusterInst.Key,

--- a/controller/clusterinst_api_test.go
+++ b/controller/clusterinst_api_test.go
@@ -745,7 +745,9 @@ func testClusterInstResourceUsage(t *testing.T, ctx context.Context) {
 		clusterInst.IpAccess = edgeproto.IpAccess_IP_ACCESS_DEDICATED
 		clusterInst.Flavor = testutil.FlavorData[4].Key
 		clusterInst.NodeFlavor = "flavor.large"
-		ciResources, err := cloudcommon.GetClusterInstVMRequirements(ctx, &clusterInst, cloudletInfo.Flavors, lbFlavor)
+		nodeFlavorInfo, masterFlavorInfo, err := getClusterFlavorInfo(ctx, stm, cloudletInfo.Flavors, &clusterInst)
+		require.Nil(t, err, "get cluster flavor info")
+		ciResources, err := cloudcommon.GetClusterInstVMRequirements(ctx, &clusterInst, nodeFlavorInfo, masterFlavorInfo, lbFlavor)
 		require.Nil(t, err, "get cluster inst vm requirements")
 		// number of vm resources = num_nodes + num_masters + num_of_rootLBs
 		require.Equal(t, 5, len(ciResources), "matches number of vm resources")


### PR DESCRIPTION
EDGECLOUD-5164

When a cloudlet has no "native" flavors, as is the case with VCD, the clusterinst resource usage does not get calculated because currently only the platform flavors are used.  I did some minor refactoring to separate the flavor retrieval from the resource calculation so  I could access flavorApi.

