### PR TITLE
e2e-test fix for converting yaml map keys to mcctl args

### DIFF
--- a/cli/input.go
+++ b/cli/input.go
@@ -614,11 +614,11 @@ func MarshalArgs(obj interface{}, ignore []string, aliases []string) ([]string, 
 
 func MapToArgs(prefix []string, dat map[string]interface{}, ignore map[string]struct{}, specialArgs map[string]string, aliases map[string]string) []string {
 	args := []string{}
-	for k, v := range dat {
+	for kK, v := range dat {
 		if v == nil {
 			continue
 		}
-		k = strings.ToLower(k)
+		k := strings.ToLower(kK)
 		if sub, ok := v.(map[string]interface{}); ok {
 			subargs := MapToArgs(append(prefix, k), sub, ignore, specialArgs, aliases)
 			args = append(args, subargs...)
@@ -657,7 +657,7 @@ func MapToArgs(prefix []string, dat map[string]interface{}, ignore map[string]st
 		}
 		var arg string
 		if sparg == "StringToString" {
-			arg = fmt.Sprintf("%s=%s=%s", name, k, val)
+			arg = fmt.Sprintf("%s=%s=%s", name, kK, val)
 		} else {
 			arg = fmt.Sprintf("%s=%s", name, val)
 		}

--- a/cli/input_test.go
+++ b/cli/input_test.go
@@ -75,6 +75,7 @@ func TestParseArgs(t *testing.T) {
 			"key1":         "val1",
 			"key.with.dot": "val.with.dot",
 			"keye":         "val=with=equals",
+			"keyCapital":   "valCapital",
 			// key with equals not supported
 			//"key=with=equals": "val=with=equals",
 		},
@@ -90,7 +91,7 @@ func TestParseArgs(t *testing.T) {
 		},
 	}
 
-	args = []string{"inner1.name=name1", "inner1.val=1", "inner2.name=name2", "inner2.val=2", "inner1.mmm=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4", "inner1.sublist:0.name=sublist0", "inner1.sublist:1.name=sublist1"}
+	args = []string{"inner1.name=name1", "inner1.val=1", "inner2.name=name2", "inner2.val=2", "inner1.mmm=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=keyCapital=valCapital", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4", "inner1.sublist:0.name=sublist0", "inner1.sublist:1.name=sublist1"}
 	testConversion(t, input, &ex, &TestObj{}, &TestObj{}, args)
 
 	// test with alias args
@@ -106,7 +107,7 @@ func TestParseArgs(t *testing.T) {
 			"sublist1:#.name=inner1.sublist:#.name",
 		},
 	}
-	args = []string{"name1=name1", "val1=1", "name2=name2", "val2=2", "mmm1=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4", "sublist1:0.name=sublist0", "sublist1:1.name=sublist1"}
+	args = []string{"name1=name1", "val1=1", "name2=name2", "val2=2", "mmm1=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", "mmm=keyCapital=valCapital", "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4", "sublist1:0.name=sublist0", "sublist1:1.name=sublist1"}
 	testConversion(t, inputAliased, &ex, &TestObj{}, &TestObj{}, args)
 
 	rf := edgeproto.Flavor{


### PR DESCRIPTION
E2e-test fix only. Fixes a case where map keys from yaml are converted to mcctl args, and are lower cased incorrectly. This causes env var names like FAKE_RAM_MAX to get incorrectly converted to fake_ram_max when testing mcctl. There are no instances of this right now, but it's affecting some new e2e-tests I'm working on.

This change has no affect on anything outside of e2e-tests.