### PR TITLE
add total to continuous query

### DIFF
--- a/controller/influxq_client/influxq_cq.go
+++ b/controller/influxq_client/influxq_cq.go
@@ -119,6 +119,7 @@ var LatencyAggregationFunctions = map[string]string{
 	"100ms":      "sum(\"100ms\")",
 	"min":        "min(\"min\")",
 	"max":        "max(\"max\")",
+	"total":      "sum(\"total\")",
 	"avg":        "sum(\"total\") / sum(\"numsamples\")",
 	"numsamples": "sum(\"numsamples\")",
 }


### PR DESCRIPTION
Add total to latency continuous query functions.

This allows https://github.com/mobiledgex/edge-cloud-infra/pull/1581 to downsample already downsampled data (needed for average)
