### PR TITLE
EDGECLOUD-3634 fqdn prefix dot to dash

### DIFF
--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -193,7 +193,7 @@ func GetVMAppFQDN(key *edgeproto.AppInstKey, cloudletKey *edgeproto.CloudletKey,
 }
 
 func FqdnPrefix(svcName string) string {
-	return svcName + "."
+	return svcName + "-"
 }
 
 func ServiceFQDN(svcName, baseFQDN string) string {

--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -283,7 +283,7 @@ func TestAppInstApi(t *testing.T) {
 			if lproto == "http" {
 				continue
 			}
-			test_prefix := fmt.Sprintf("%s-%s.", util.DNSSanitize(app_name), lproto)
+			test_prefix := fmt.Sprintf("%s-%s-", util.DNSSanitize(app_name), lproto)
 			require.Equal(t, test_prefix, port.FqdnPrefix, "check port fqdn prefix")
 		}
 	}

--- a/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
+++ b/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
@@ -646,24 +646,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small
@@ -691,24 +691,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
@@ -231,15 +231,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:

--- a/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
@@ -681,7 +681,7 @@ appinstances:
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: autoprovapp10-tcp.
+    fqdnprefix: autoprovapp10-tcp-
   flavor:
     name: x1.small
   runtimeinfo:

--- a/setup-env/e2e-tests/data/appdata_show.yml
+++ b/setup-env/e2e-tests/data/appdata_show.yml
@@ -684,24 +684,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small
@@ -751,24 +751,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small

--- a/setup-env/e2e-tests/data/appdata_show_after_cluster_update.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_cluster_update.yml
@@ -666,24 +666,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small
@@ -753,24 +753,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small

--- a/setup-env/e2e-tests/data/appdata_show_after_refresh.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_refresh.yml
@@ -666,24 +666,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small
@@ -752,24 +752,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small

--- a/setup-env/e2e-tests/data/appdata_show_after_refresh_all.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_refresh_all.yml
@@ -684,24 +684,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small
@@ -752,24 +752,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small

--- a/setup-env/e2e-tests/data/appdata_show_prometheus_30s_interval.yml
+++ b/setup-env/e2e-tests/data/appdata_show_prometheus_30s_interval.yml
@@ -686,24 +686,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small
@@ -754,24 +754,24 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   - proto: LProtoTcp
     internalport: 81
     publicport: 81
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   - proto: LProtoTcp
     internalport: 444
     publicport: 444
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
     tls: true
   flavor:
     name: x1.small

--- a/setup-env/e2e-tests/data/appdata_trusted_show.yml
+++ b/setup-env/e2e-tests/data/appdata_trusted_show.yml
@@ -569,7 +569,7 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: trustedapp10-tcp.
+    fqdnprefix: trustedapp10-tcp-
   flavor:
     name: x1.small
   state: Ready
@@ -604,7 +604,7 @@ appinstances:
   - proto: LProtoTcp
     internalport: 90
     publicport: 90
-    fqdnprefix: nontrustedapp10-tcp.
+    fqdnprefix: nontrustedapp10-tcp-
   flavor:
     name: x1.small
   state: Ready

--- a/setup-env/e2e-tests/data/crm_info.yml
+++ b/setup-env/e2e-tests/data/crm_info.yml
@@ -516,15 +516,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   state: Ready
@@ -610,11 +610,11 @@ appinstances:
   - proto: LProtoTcp
     internalport: 23
     publicport: 23
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10003
     publicport: 10003
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   state: Ready
@@ -646,15 +646,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   state: Ready

--- a/setup-env/e2e-tests/data/find-cloudlet-response-app1any.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-app1any.yml
@@ -4,15 +4,15 @@
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   cloudletlocation:
     latitude: 32
     longitude: -91
@@ -22,15 +22,15 @@
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   cloudletlocation:
     latitude: 35
     longitude: -95
@@ -40,15 +40,15 @@
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   cloudletlocation:
     latitude: 37
     longitude: -99

--- a/setup-env/e2e-tests/data/find-cloudlet-response-azure.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-azure.yml
@@ -4,15 +4,15 @@ ports:
 - proto: LProtoTcp
   internalport: 80
   publicport: 80
-  fqdnprefix: someapplication110-tcp.
+  fqdnprefix: someapplication110-tcp-
 - proto: LProtoTcp
   internalport: 443
   publicport: 443
-  fqdnprefix: someapplication110-tcp.
+  fqdnprefix: someapplication110-tcp-
 - proto: LProtoUdp
   internalport: 10002
   publicport: 10002
-  fqdnprefix: someapplication110-udp.
+  fqdnprefix: someapplication110-udp-
 cloudletlocation:
   latitude: 32
   longitude: -91

--- a/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet1.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet1.yml
@@ -4,15 +4,15 @@ ports:
 - proto: LProtoTcp
   internalport: 80
   publicport: 80
-  fqdnprefix: someapplication110-tcp.
+  fqdnprefix: someapplication110-tcp-
 - proto: LProtoTcp
   internalport: 443
   publicport: 443
-  fqdnprefix: someapplication110-tcp.
+  fqdnprefix: someapplication110-tcp-
 - proto: LProtoUdp
   internalport: 10002
   publicport: 10002
-  fqdnprefix: someapplication110-udp.
+  fqdnprefix: someapplication110-udp-
 cloudletlocation:
   latitude: 31
   longitude: -91

--- a/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet2.yml
+++ b/setup-env/e2e-tests/data/find-cloudlet-response-cloudlet2.yml
@@ -4,15 +4,15 @@ ports:
 - proto: LProtoTcp
   internalport: 80
   publicport: 80
-  fqdnprefix: someapplication110-tcp.
+  fqdnprefix: someapplication110-tcp-
 - proto: LProtoTcp
   internalport: 443
   publicport: 443
-  fqdnprefix: someapplication110-tcp.
+  fqdnprefix: someapplication110-tcp-
 - proto: LProtoUdp
   internalport: 10002
   publicport: 10002
-  fqdnprefix: someapplication110-udp.
+  fqdnprefix: someapplication110-udp-
 cloudletlocation:
   latitude: 35
   longitude: -95

--- a/setup-env/e2e-tests/data/get_appinstlist_result_app1.yml
+++ b/setup-env/e2e-tests/data/get_appinstlist_result_app1.yml
@@ -14,15 +14,15 @@ cloudlets:
     - proto: LProtoTcp
       internalport: 80
       publicport: 80
-      fqdnprefix: someapplication110-tcp.
+      fqdnprefix: someapplication110-tcp-
     - proto: LProtoTcp
       internalport: 443
       publicport: 443
-      fqdnprefix: someapplication110-tcp.
+      fqdnprefix: someapplication110-tcp-
     - proto: LProtoUdp
       internalport: 10002
       publicport: 10002
-      fqdnprefix: someapplication110-udp.
+      fqdnprefix: someapplication110-udp-
     orgname: AcmeAppCo
 - carriername: tmus
   cloudletname: tmus-cloud-2
@@ -38,15 +38,15 @@ cloudlets:
     - proto: LProtoTcp
       internalport: 80
       publicport: 80
-      fqdnprefix: someapplication110-tcp.
+      fqdnprefix: someapplication110-tcp-
     - proto: LProtoTcp
       internalport: 443
       publicport: 443
-      fqdnprefix: someapplication110-tcp.
+      fqdnprefix: someapplication110-tcp-
     - proto: LProtoUdp
       internalport: 10002
       publicport: 10002
-      fqdnprefix: someapplication110-udp.
+      fqdnprefix: someapplication110-udp-
     orgname: AcmeAppCo
 - carriername: tmus
   cloudletname: tmus-cloud-3
@@ -62,13 +62,13 @@ cloudlets:
     - proto: LProtoTcp
       internalport: 80
       publicport: 80
-      fqdnprefix: someapplication110-tcp.
+      fqdnprefix: someapplication110-tcp-
     - proto: LProtoTcp
       internalport: 443
       publicport: 443
-      fqdnprefix: someapplication110-tcp.
+      fqdnprefix: someapplication110-tcp-
     - proto: LProtoUdp
       internalport: 10002
       publicport: 10002
-      fqdnprefix: someapplication110-udp.
+      fqdnprefix: someapplication110-udp-
     orgname: AcmeAppCo

--- a/setup-env/e2e-tests/data/influx_appdata_show.yml
+++ b/setup-env/e2e-tests/data/influx_appdata_show.yml
@@ -312,15 +312,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:

--- a/setup-env/e2e-tests/data/show10.yml
+++ b/setup-env/e2e-tests/data/show10.yml
@@ -1196,15 +1196,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1231,15 +1231,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 10000
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 10001
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10000
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1266,15 +1266,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1301,15 +1301,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 10000
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 10001
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10000
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1336,15 +1336,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 10000
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 10001
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10000
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1371,15 +1371,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 10000
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 10001
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10000
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1406,15 +1406,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 10000
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 10001
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10000
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1441,15 +1441,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1476,15 +1476,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1511,15 +1511,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 10000
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 10001
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10000
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1546,15 +1546,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1581,15 +1581,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1616,15 +1616,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1651,15 +1651,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1686,15 +1686,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1721,15 +1721,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1756,15 +1756,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1791,15 +1791,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1826,15 +1826,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 10000
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 10001
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10000
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -1861,15 +1861,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 10000
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 10001
-    fqdnprefix: someapplication210-tcp.
+    fqdnprefix: someapplication210-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10000
-    fqdnprefix: someapplication210-udp.
+    fqdnprefix: someapplication210-udp-
   flavor:
     name: x1.small
   runtimeinfo:

--- a/setup-env/e2e-tests/data/show2.yml
+++ b/setup-env/e2e-tests/data/show2.yml
@@ -327,15 +327,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:
@@ -361,15 +361,15 @@ appinstances:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   flavor:
     name: x1.small
   runtimeinfo:


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-3634 Change fqdn_prefix separator from dot to dash

### Description

Changes fqdn prefix separator from dot to dash to avoid an extra level of hierarchy in the fqdn. See the bug for more details.