### PR TITLE
Fix kubernetes default namespace name

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -20,7 +20,7 @@ import (
 const WaitDeleted string = "WaitDeleted"
 const WaitRunning string = "WaitRunning"
 
-const DefaultNamespace string = "Default"
+const DefaultNamespace string = "default"
 
 // This is half of the default controller AppInst timeout
 var maxWait = 15 * time.Minute


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5260: K8s pod takes longer(~70s) to be in running state after appinst is created

### Description

* Default namespace `default` name must start with lowercase `d`