### PR TITLE
EDGECLOUD-5255 better MC json unmarshal errors

### DIFF
--- a/cli/input.go
+++ b/cli/input.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/mobiledgex/edge-cloud/util"
@@ -601,6 +602,9 @@ func (s *Input) setKeyVal(dat map[string]interface{}, obj interface{}, key, val,
 					if strings.Contains(err.Error(), replace) {
 						err = errors.New(strings.Replace(err.Error(), replace, "", -1))
 					}
+				}
+				if sf.Type == reflect.TypeOf(time.Time{}) || sf.Type == reflect.TypeOf(&time.Time{}) {
+					err = util.NiceTimeParseError(err)
 				}
 				help := getParseErrorHelp(sf.Type.Kind())
 				return fmt.Errorf("unable to parse %q as %s: %v%s", val, asType, err, help)

--- a/d-match-engine/dme-proto/app-client.pb.go
+++ b/d-match-engine/dme-proto/app-client.pb.go
@@ -8707,12 +8707,21 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 		if en, ok := LProto_CamelValue[util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
+		if en, ok := LProto_CamelValue["LProto"+util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
 	case reflect.TypeOf(HealthCheck(0)):
 		if en, ok := HealthCheck_CamelValue[util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
+		if en, ok := HealthCheck_CamelValue["HealthCheck"+util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
 	case reflect.TypeOf(CloudletState(0)):
 		if en, ok := CloudletState_CamelValue[util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
+		if en, ok := CloudletState_CamelValue["CloudletState"+util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
 	case reflect.TypeOf(MaintenanceState(0)):
@@ -8725,6 +8734,9 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 		}
 	case reflect.TypeOf(ReplyStatus(0)):
 		if en, ok := ReplyStatus_CamelValue[util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
+		if en, ok := ReplyStatus_CamelValue["Rs"+util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
 	}

--- a/edgeproto/alert.pb.go
+++ b/edgeproto/alert.pb.go
@@ -1100,12 +1100,21 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 		if en, ok := Liveness_CamelValue[util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
+		if en, ok := Liveness_CamelValue["Liveness"+util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
 	case reflect.TypeOf(IpSupport(0)):
 		if en, ok := IpSupport_CamelValue[util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
+		if en, ok := IpSupport_CamelValue["IpSupport"+util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
 	case reflect.TypeOf(IpAccess(0)):
 		if en, ok := IpAccess_CamelValue[util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
+		if en, ok := IpAccess_CamelValue["IpAccess"+util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
 	case reflect.TypeOf(TrackedState(0)):
@@ -1120,8 +1129,14 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 		if en, ok := ImageType_CamelValue[util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
+		if en, ok := ImageType_CamelValue["ImageType"+util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
 	case reflect.TypeOf(VmAppOsType(0)):
 		if en, ok := VmAppOsType_CamelValue[util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
+		if en, ok := VmAppOsType_CamelValue["VmAppOs"+util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
 	case reflect.TypeOf(DeleteType(0)):
@@ -1132,8 +1147,14 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 		if en, ok := AccessType_CamelValue[util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
+		if en, ok := AccessType_CamelValue["AccessType"+util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
 	case reflect.TypeOf(PlatformType(0)):
 		if en, ok := PlatformType_CamelValue[util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
+		if en, ok := PlatformType_CamelValue["PlatformType"+util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
 	case reflect.TypeOf(InfraApiAccess(0)):
@@ -1152,8 +1173,14 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 		if en, ok := VMState_CamelValue[util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
+		if en, ok := VMState_CamelValue["Vm"+util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
 	case reflect.TypeOf(VMAction(0)):
 		if en, ok := VMAction_CamelValue[util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
+		if en, ok := VMAction_CamelValue["VmAction"+util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
 	case reflect.TypeOf(PowerState(0)):
@@ -1168,8 +1195,14 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 		if en, ok := StreamState_CamelValue[util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
+		if en, ok := StreamState_CamelValue["Stream"+util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
 	case reflect.TypeOf(VersionHash(0)):
 		if en, ok := VersionHash_CamelValue[util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
+		if en, ok := VersionHash_CamelValue["Hash"+util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
 	}

--- a/protoc-gen-gomex/mexgen/mex.go
+++ b/protoc-gen-gomex/mexgen/mex.go
@@ -2546,6 +2546,12 @@ func (m *mex) generateEnumDecodeHook() {
 			m.P("if en, ok := ", en.Name, "_CamelValue[util.CamelCase(data.(string))]; ok {")
 			m.P("return en, nil")
 			m.P("}")
+			commonPrefix := gensupport.GetEnumCommonPrefix(en)
+			if commonPrefix != "" {
+				m.P("if en, ok := ", en.Name, "_CamelValue[\"", commonPrefix, "\"+util.CamelCase(data.(string))]; ok {")
+				m.P("return en, nil")
+				m.P("}")
+			}
 		}
 	}
 	m.P("}")

--- a/testgen/sample.pb.go
+++ b/testgen/sample.pb.go
@@ -3367,6 +3367,9 @@ func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error
 		if en, ok := OuterEnum_CamelValue[util.CamelCase(data.(string))]; ok {
 			return en, nil
 		}
+		if en, ok := OuterEnum_CamelValue["Outer"+util.CamelCase(data.(string))]; ok {
+			return en, nil
+		}
 	}
 	return data, nil
 }

--- a/util/timerange.go
+++ b/util/timerange.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -57,4 +58,15 @@ func TimeFromEpochMicros(us int64) time.Time {
 	sec := us / 1e6
 	ns := (us % 1e6) * 1e3
 	return time.Unix(sec, ns)
+}
+
+// Change the time.ParseError into something more user-friendly to read.
+func NiceTimeParseError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), time.RFC3339) {
+		err = fmt.Errorf("%s into RFC3339 format failed. Example: \"%s\"", strings.Split(err.Error(), " as")[0], time.RFC3339)
+	}
+	return err
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5255 invalid limit/numsamples/startage/endage for clientapiusage/clientappusage/clientcloudletusage needs better error handling

### Description

Changes for common time.Parse error message for infra PR.

Also I broke the args parsing for enums when switching to WeakDecode in https://github.com/mobiledgex/edge-cloud/pull/1410, because the EnumDecodeHook wasn't handling the new short string version of enums. So fixed that here.