### PR TITLE
EDGECLOUD-5279 cli arg:empty with invalid val should err

### DIFF
--- a/cli/input.go
+++ b/cli/input.go
@@ -546,7 +546,12 @@ func (s *Input) setKeyVal(dat map[string]interface{}, obj interface{}, key, val,
 			// special case to specify empty list/map for update
 			colonParts := strings.Split(part, ":")
 			if len(colonParts) == 2 && colonParts[1] == util.EmptySet {
-				if !valIsTrue(val) {
+				b, err := strconv.ParseBool(val)
+				if err != nil {
+					help := getParseErrorHelp(reflect.Bool)
+					return fmt.Errorf("unable to parse %q as bool%s", val, help)
+				}
+				if !b {
 					continue
 				}
 				// get the hier name without the :empty
@@ -632,24 +637,6 @@ func getParseErrorHelp(k reflect.Kind) string {
 		return ", valid values are true, false"
 	}
 	return ""
-}
-
-func valIsTrue(val interface{}) bool {
-	b := false
-	switch v := val.(type) {
-	case string:
-		e, err := strconv.ParseBool(v)
-		if err == nil {
-			b = e
-		}
-	case bool:
-		b = v
-	case int:
-		if v == 1 {
-			b = true
-		}
-	}
-	return b
 }
 
 // Get empty list or map value based on field type.

--- a/cli/input_test.go
+++ b/cli/input_test.go
@@ -184,6 +184,13 @@ func TestParseArgs(t *testing.T) {
 	}
 	fields := []string{"1.1", "1.3", "1.4", "4", "6", "7", "7.1", "7.4"}
 	testConversionEmptyFields(t, input, &emptySets, &TestObj{}, args, fields)
+
+	// test parse empty invalid value
+	args = []string{"arr:empty=ttrue"}
+	buf := TestObj{}
+	_, err = input.ParseArgs(args, &buf)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), `parsing arg "arr:empty=ttrue" failed: unable to parse "ttrue" as bool, valid values are true, false`)
 }
 
 func testConversionEmptyFields(t *testing.T, input *cli.Input, obj, buf interface{}, args []string, expectedFields []string) {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5279 app update with autoprovpolicies:empty and invalid value should give an error

### Description

Return failure if failed to parse empty bool arg. Previously value was ignored if improper.