### PR TITLE
Build enhancements to support easier change tracking

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 # (like abc-priv, secrets, grpc-gateway, golang-ssh, etc).
 # Only edge-cloud, edge-cloud-infra, and edge-proto are needed.
 *
+!.git
 !edge-cloud
 !edge-cloud-infra
 !edge-proto

--- a/docker/Dockerfile.edge-cloud
+++ b/docker/Dockerfile.edge-cloud
@@ -40,9 +40,7 @@ WORKDIR /go/src/github.com/mobiledgex/edge-cloud-infra
 RUN go mod download
 
 WORKDIR /go/src/github.com/mobiledgex
-COPY edge-cloud edge-cloud
-COPY edge-cloud-infra edge-cloud-infra
-COPY edge-proto edge-proto
+COPY . .
 WORKDIR /go/src/github.com/mobiledgex/edge-cloud-infra
 ENV CGO_ENABLED=1
 RUN make


### PR DESCRIPTION
Will be adding a monorepo which contains the edge-* repos as git
submodules to track changes across nightly builds better, especially
when branches are involved. The monorepo will be used only for nightly
builds, and will automatically pull in and tag the changes from each of
the submodules.

With a monorepo, we need the top-level ".git" directory to be included
in the docker build context. Hence this change.

Note: The monorepo won't change anything of how people build the
      workspaces manually currently.
