### PR TITLE
EDGECLOUD-5303 EDGECLOUD-5304 error message mentions edgeproto

### DIFF
--- a/cli/input.go
+++ b/cli/input.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/util"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -183,7 +184,7 @@ func ConvertDecodeErr(err error, reals map[string]string) error {
 			if ne, ok := suberr.(*strconv.NumError); ok {
 				suberr = ne.Err
 			}
-			help := getParseErrorHelp(e.To)
+			help := GetParseHelpKind(e.To)
 			err = fmt.Errorf(`Unable to parse "%s" value "%v" as %v: %v%s`, name, e.Val, e.To, suberr, help)
 		case *mapstructure.OverflowError:
 			name := getDecodeArg(e.Name, reals)
@@ -548,7 +549,7 @@ func (s *Input) setKeyVal(dat map[string]interface{}, obj interface{}, key, val,
 			if len(colonParts) == 2 && colonParts[1] == util.EmptySet {
 				b, err := strconv.ParseBool(val)
 				if err != nil {
-					help := getParseErrorHelp(reflect.Bool)
+					help := GetParseHelpKind(reflect.Bool)
 					return fmt.Errorf("unable to parse %q as bool%s", val, help)
 				}
 				if !b {
@@ -589,7 +590,7 @@ func (s *Input) setKeyVal(dat map[string]interface{}, obj interface{}, key, val,
 			v := reflect.New(sf.Type)
 			_, err := WeakDecode(val, v.Interface(), s.DecodeHook)
 			if err != nil {
-				asType := sf.Type.String()
+				asType, help, surpressErr := GetParseHelp(sf.Type)
 				switch e := err.(type) {
 				case *mapstructure.ParseError:
 					err = e.Err
@@ -607,11 +608,10 @@ func (s *Input) setKeyVal(dat map[string]interface{}, obj interface{}, key, val,
 					if strings.Contains(err.Error(), replace) {
 						err = errors.New(strings.Replace(err.Error(), replace, "", -1))
 					}
+					if surpressErr {
+						err = fmt.Errorf("invalid format")
+					}
 				}
-				if sf.Type == reflect.TypeOf(time.Time{}) || sf.Type == reflect.TypeOf(&time.Time{}) {
-					err = util.NiceTimeParseError(err)
-				}
-				help := getParseErrorHelp(sf.Type.Kind())
 				return fmt.Errorf("unable to parse %q as %s: %v%s", val, asType, err, help)
 			}
 			// elem to dereference it
@@ -632,7 +632,27 @@ func (s *Input) setKeyVal(dat map[string]interface{}, obj interface{}, key, val,
 	return nil
 }
 
-func getParseErrorHelp(k reflect.Kind) string {
+// GetParseHelp gets end-user specific messages for error messages
+// without any golang-specific language.
+// It returns a non-golang specific type name, a help message with valid
+// values, and a bool that represents whether the original error
+// should be suppressed because it is too golang-specific.
+func GetParseHelp(t reflect.Type) (string, string, bool) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	// Specially handled types are typically types with
+	// custom unmarshalers and custom DecodeHooks.
+	if t == reflect.TypeOf(time.Time{}) {
+		return "time", fmt.Sprintf(", valid values are RFC3339 format, i.e. %q", time.RFC3339), true
+	}
+	if t == reflect.TypeOf(time.Duration(0)) || t == reflect.TypeOf(edgeproto.Duration(0)) {
+		return "duration", fmt.Sprintf(", valid values are 300ms, 1s, 1.5h, 2h45m, etc"), true
+	}
+	return t.Kind().String(), GetParseHelpKind(t.Kind()), false
+}
+
+func GetParseHelpKind(k reflect.Kind) string {
 	if k == reflect.Bool {
 		return ", valid values are true, false"
 	}

--- a/cli/input_test.go
+++ b/cli/input_test.go
@@ -79,6 +79,7 @@ func TestParseArgs(t *testing.T) {
 			"key.with.dot": "val.with.dot",
 			"keye":         "val=with=equals",
 			"keyCapital":   "valCapital",
+			"spaces":       "Value with spaces",
 			// key with equals not supported
 			//"key=with=equals": "val=with=equals",
 		},
@@ -94,7 +95,7 @@ func TestParseArgs(t *testing.T) {
 		},
 	}
 
-	args = []string{"inner1.name=name1", "inner1.val=1", "inner2.name=name2", "inner2.val=2", "inner1.mmm=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=keyCapital=valCapital", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4", "inner1.sublist:0.name=sublist0", "inner1.sublist:1.name=sublist1"}
+	args = []string{"inner1.name=name1", "inner1.val=1", "inner2.name=name2", "inner2.val=2", "inner1.mmm=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=keyCapital=valCapital", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", `mmm=spaces="Value with spaces"`, "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4", "inner1.sublist:0.name=sublist0", "inner1.sublist:1.name=sublist1"}
 	testConversion(t, input, &ex, &TestObj{}, &TestObj{}, args)
 
 	// test with alias args
@@ -110,7 +111,7 @@ func TestParseArgs(t *testing.T) {
 			"sublist1:#.name=inner1.sublist:#.name",
 		},
 	}
-	args = []string{"name1=name1", "val1=1", "name2=name2", "val2=2", "mmm1=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", "mmm=keyCapital=valCapital", "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4", "sublist1:0.name=sublist0", "sublist1:1.name=sublist1"}
+	args = []string{"name1=name1", "val1=1", "name2=name2", "val2=2", "mmm1=xkey=xx", "arr=foo", "arr=bar", "arr=baz", "mmm=key1=val1", "mmm=key.with.dot=val.with.dot", "mmm=keye=val=with=equals", "mmm=keyCapital=valCapital", `mmm=spaces="Value with spaces"`, "objarr:0.name=arrin1", "objarr:0.val=3", "objarr:1.name=arrin2", "objarr:1.val=4", "sublist1:0.name=sublist0", "sublist1:1.name=sublist1"}
 	testConversion(t, inputAliased, &ex, &TestObj{}, &TestObj{}, args)
 
 	rf := edgeproto.Flavor{

--- a/cloudcommon/node/events.go
+++ b/cloudcommon/node/events.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
-	"github.com/mobiledgex/edge-cloud/util"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -127,12 +126,12 @@ type EventMatch struct {
 }
 
 type EventSearch struct {
-	Match          EventMatch `json:"match,omitempty"`
-	NotMatch       EventMatch `json:"notmatch,omitempty"`
-	AllowedOrgs    []string   `json:"allowedorgs"` // to enforce rbac
-	util.TimeRange `json:",inline"`
-	From           int `json:"from,omitempty"`  // start document offset
-	Limit          int `json:"limit,omitempty"` // number of documents to return
+	Match               EventMatch `json:"match,omitempty"`
+	NotMatch            EventMatch `json:"notmatch,omitempty"`
+	AllowedOrgs         []string   `json:"allowedorgs"` // to enforce rbac
+	edgeproto.TimeRange `json:",inline"`
+	From                int `json:"from,omitempty"`  // start document offset
+	Limit               int `json:"limit,omitempty"` // number of documents to return
 }
 
 type EventTerms struct {
@@ -551,7 +550,7 @@ func (s *NodeMgr) getQuery(ctx context.Context, searchType string, search *Event
 	return s.getQueryCommon(ctx, searchType, search.TimeRange, search.From, search.Limit, "timestamp", smaps, mustnot, filter)
 }
 
-func (s *NodeMgr) getQueryCommon(ctx context.Context, searchType string, tr util.TimeRange, from, limit int, timeField string, smaps, mustnot, filter []map[string]interface{}) (map[string]interface{}, error) {
+func (s *NodeMgr) getQueryCommon(ctx context.Context, searchType string, tr edgeproto.TimeRange, from, limit int, timeField string, smaps, mustnot, filter []map[string]interface{}) (map[string]interface{}, error) {
 	query := map[string]interface{}{}
 	if searchType == searchTypeFilter {
 		query["query"] = map[string]interface{}{

--- a/cloudcommon/node/events_test.go
+++ b/cloudcommon/node/events_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/integration/process"
 	"github.com/mobiledgex/edge-cloud/log"
-	"github.com/mobiledgex/edge-cloud/util"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
@@ -158,7 +157,7 @@ func TestEvents(t *testing.T) {
 
 	// check terms aggregations over all events
 	search := EventSearch{
-		TimeRange: util.TimeRange{
+		TimeRange: edgeproto.TimeRange{
 			StartTime: starttime,
 			EndTime:   endtime,
 		},
@@ -274,7 +273,7 @@ func TestEvents(t *testing.T) {
 	// ---------------------------------------------------
 	//
 	spansearch := SpanSearch{
-		TimeRange: util.TimeRange{
+		TimeRange: edgeproto.TimeRange{
 			StartTime: starttime,
 			EndTime:   endtime,
 		},
@@ -317,7 +316,7 @@ func TestEvents(t *testing.T) {
 	// limit time range to just our test events.
 	// this avoids the startup event added by nodeMgr.Init().
 	search = EventSearch{
-		TimeRange: util.TimeRange{
+		TimeRange: edgeproto.TimeRange{
 			StartTime: starttime,
 			EndTime:   starttime.Add(time.Hour),
 		},

--- a/cloudcommon/node/jaegersearch.go
+++ b/cloudcommon/node/jaegersearch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
 	"github.com/mitchellh/mapstructure"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/util"
 )
@@ -29,12 +30,12 @@ type SpanMatch struct {
 }
 
 type SpanSearch struct {
-	Match             SpanMatch `json:"match,omitempty"`
-	NotMatch          SpanMatch `json:"notmatch,omitempty"`
-	util.TimeRange    `json:",inline"`
-	From              int  `json:"from,omitempty"`  // start document offset
-	Limit             int  `json:"limit,omitempty"` // number of documents to return
-	SearchByRelevance bool `json:"searchbyrelevance"`
+	Match               SpanMatch `json:"match,omitempty"`
+	NotMatch            SpanMatch `json:"notmatch,omitempty"`
+	edgeproto.TimeRange `json:",inline"`
+	From                int  `json:"from,omitempty"`  // start document offset
+	Limit               int  `json:"limit,omitempty"` // number of documents to return
+	SearchByRelevance   bool `json:"searchbyrelevance"`
 }
 
 type SpanOutCondensed struct {

--- a/d-match-engine/dme-common/match-engine.go
+++ b/d-match-engine/dme-common/match-engine.go
@@ -137,6 +137,7 @@ func SetupMatchEngine(eehandler EdgeEventsHandler) {
 // AppInst state is a superset of the cloudlet state and appInst state
 // Returns if this AppInstance is usable or not
 func IsAppInstUsable(appInst *DmeAppInst) bool {
+	fmt.Printf("IsAppInstUsable: %+v\n", *appInst)
 	if appInst == nil {
 		return false
 	}

--- a/util/time.go
+++ b/util/time.go
@@ -1,0 +1,15 @@
+package util
+
+import "time"
+
+// Get the number of milliseconds since epoch for the time.
+// This is used for ElasticSearch.
+func GetEpochMillis(t time.Time) int64 {
+	return (t.Unix()*1e3 + int64(t.Nanosecond())/1e6)
+}
+
+func TimeFromEpochMicros(us int64) time.Time {
+	sec := us / 1e6
+	ns := (us % 1e6) * 1e3
+	return time.Unix(sec, ns)
+}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5303 error message for updating durations mentions edgeproto
* EDGECLOUD-5304 some error message have a message in the message

### Description

This defines a DurationParseError that can be passed up through json.Unmarshal, to have better error messages. TimeRange is also moved from util to edgeproto, so that we can use edgeproto.Duration instead of time.Duration, which allows us to leverage the DurationParseError when parsing JSON.

Additionally, GetParseHelp also now returns custom types (without 'edgeproto' package prefix) to use in error messages, and it is externally available so we can use it from MC as well as mcctl, to keep object type references and help messages the same in both cases.