### PR TITLE
EDGECLOUD-5343 rate limit mc e2e-test ShowApp2 failed

### DIFF
--- a/cloudcommon/ratelimit/interval-limiter.go
+++ b/cloudcommon/ratelimit/interval-limiter.go
@@ -26,7 +26,7 @@ func NewIntervalLimiter(reqLimit int, interval time.Duration) *IntervalLimiter {
 		requestLimit:            reqLimit,
 		currentNumberOfRequests: 0,
 		interval:                interval,
-		intervalStartTime:       time.Now().Truncate(interval),
+		intervalStartTime:       time.Now(),
 	}
 }
 
@@ -36,7 +36,7 @@ func (i *IntervalLimiter) Limit(ctx context.Context, info *CallerInfo) error {
 	defer i.Unlock()
 	// Check start of interval
 	if time.Since(i.intervalStartTime) > i.interval {
-		i.intervalStartTime = time.Now().Truncate(i.interval)
+		i.intervalStartTime = time.Now()
 		i.currentNumberOfRequests = 0
 	}
 	if i.currentNumberOfRequests >= i.requestLimit && i.requestLimit != 0 {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5343 rate limit e2e-test fails intermittently

### Description

Remove truncate because it can move the start time into the past, which makes it hard to deterministically test (since how far back it goes depends on the current time).