### PR TITLE
EDGECLOUD-5246 Trust Policy timeout error message fixed

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -1890,7 +1890,7 @@ func (s *CloudletApi) UpdateCloudletsUsingTrustPolicy(ctx context.Context, trust
 		log.DebugLog(log.DebugLevelApi, "cloudletUpdateResult ", "key", k, "error", result.errString)
 		if result.errString == "" {
 			numPassed++
-		} else if strings.Contains(result.errString, "Timed out") {
+		} else if caseInsensitiveContainsTimedOut(result.errString) {
 			cb.Send(&edgeproto.Result{Message: fmt.Sprintf("Update cloudlet is in progress: %s - %s Please use 'cloudlet show' to check current status", k, result.errString)})
 			numInProgress++
 		} else {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5246
Timed out waiting for Trust Policy should not display if work is in progress and timeout is to short

### Description

Fixed the error message.

###  Unit testing
Diffs for unit testing only

diff --git a/cloud-resource-manager/platform/fake/fake.go b/cloud-resource-manager/platform/fake/fake.go
index 0d68c5c1..11c8d1bc 100644
--- a/cloud-resource-manager/platform/fake/fake.go
+++ b/cloud-resource-manager/platform/fake/fake.go
@@ -4,6 +4,7 @@ import (
        "context"
        "errors"
        "fmt"
+       "math/rand"
        "net/http"
        "net/http/httptest"
        "os"
@@ -540,6 +541,8 @@ func (s *Platform) UpdateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud

 func (s *Platform) UpdateTrustPolicy(ctx context.Context, TrustPolicy *edgeproto.TrustPolicy) error {
        log.DebugLog(log.DebugLevelInfra, "fake UpdateTrustPolicy begin", "policy", TrustPolicy)
+       r := rand.Intn(20)
+       time.Sleep(time.Duration(r) * time.Second)
        return nil
 }


Dajgaonkar-MAC:edge-cloud-infra devdatta$ lmc settings show region=local | grep updatetrustpolicytimeout
updatetrustpolicytimeout: 5s

lmc trustpolicy create  region=local cloudlet-org=tmus name=tp1

lmc settings update updatetrustpolicytimeout=0.01s region=local

lmc settings show region=local | grep updatetrustpolicytimeout
updatetrustpolicytimeout: 10ms


Dajgaonkar-MAC:edge-cloud-infra devdatta$ lmc cloudlet create region=local cloudlet-org=tmus cloudlet=tmus-cloud-tp numdynamicips=254 location.latitude=1 location.longitude=2 trustpolicy=tp1
message: Setting physicalname to match cloudlet name
message: Creating Cloudlet
message: Starting CRMServer
message: Initializing platform
message: Done intializing fake platform
message: Gathering Cloudlet Info
message: Created Cloudlet successfully


Dajgaonkar-MAC:edge-cloud-infra devdatta$ lmc trustpolicy update region=local cloudlet-org=tmus name=tp1 outboundsecurityrules:0.protocol=tcp outboundsecurityrules:0.remotecidr=0.0.0.0/0 outboundsecurityrules:0.portrangemin=2222 outboundsecurityrules:0.portrangemax=2222 outboundsecurityrules:1.protocol=tcp outboundsecurityrules:1.remotecidr=0.0.0.0/0 outboundsecurityrules:1.portrangemin=2016 outboundsecurityrules:1.portrangemax=2016 outboundsecurityrules:2.protocol=udp outboundsecurityrules:2.remotecidr=0.0.0.0/0 outboundsecurityrules:2.portrangemin=2015 outboundsecurityrules:2.portrangemax=2015 outboundsecurityrules:3.protocol=tcp outboundsecurityrules:3.remotecidr=0.0.0.0/0 outboundsecurityrules:3.portrangemin=3389 outboundsecurityrules:3.portrangemax=3389 outboundsecurityrules:4.protocol=tcp outboundsecurityrules:4.remotecidr=0.0.0.0/0 outboundsecurityrules:4.portrangemin=8085 outboundsecurityrules:4.portrangemax=8085 outboundsecurityrules:5.protocol=tcp outboundsecurityrules:5.remotecidr=0.0.0.0/0 outboundsecurityrules:5.portrangemin=8066 outboundsecurityrules:5.portrangemax=8069

message: 'Doing TrustPolicy: tp1 Update for Cloudlet: organization:"tmus" name:"tmus-cloud-tp" '
message: 'In progress TrustPolicy: tp1 Update for Cloudlet: organization:"tmus" name:"tmus-cloud-tp"  --
  Timed out waiting for Trust Policy'
message: 'Update cloudlet is in progress: {tmus tmus-cloud-tp} - Timed out waiting
  for Trust Policy Please use ''cloudlet show'' to check current status'
message: 'Processed: 1 Cloudlets.  Passed: 0 InProgress: 1 Failed: 0'

Dajgaonkar-MAC:edge-cloud-infra devdatta$ lmc trustpolicy show region=local
- key:
    organization: tmus
    name: pol1
- key:
    organization: tmus
    name: tp1
  outboundsecurityrules:
  - protocol: tcp
    portrangemin: 2222
    portrangemax: 2222
    remotecidr: 0.0.0.0/0
  - protocol: tcp
    portrangemin: 2016
    portrangemax: 2016
    remotecidr: 0.0.0.0/0
  - protocol: udp
    portrangemin: 2015
    portrangemax: 2015
    remotecidr: 0.0.0.0/0
  - protocol: tcp
    portrangemin: 3389
    portrangemax: 3389
    remotecidr: 0.0.0.0/0
  - protocol: tcp
    portrangemin: 8085
    portrangemax: 8085
    remotecidr: 0.0.0.0/0
  - protocol: tcp
    portrangemin: 8066
    portrangemax: 8069
    remotecidr: 0.0.0.0/0
