### PR TITLE
EDGECLOUD-2583: PlatformFindCloudlet with bad client_token returns wrong status code

### DIFF
--- a/d-match-engine/dme-common/dme-stats.go
+++ b/d-match-engine/dme-common/dme-stats.go
@@ -313,6 +313,11 @@ func (s *DmeStats) UnaryStatsInterceptor(ctx context.Context, req interface{}, i
 		if token != "" {
 			tokdata, tokerr := GetClientDataFromToken(token)
 			if tokerr != nil {
+				if err != nil {
+					// err and tokerr will have the same cause, because GetClientDataFromToken is also called from PlatformFindCloudlet
+					// err has the correct status code
+					tokerr = err
+				}
 				return resp, tokerr
 			}
 			call.Key.AppKey = tokdata.AppKey


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-2583: PlatformFindCloudlet with bad client_token returns wrong status code

### Description

Return the error with the correct status for platform find cloudlet