### PR TITLE
EDGECLOUD-5191:Address potential race on thread startup with settings…

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -1339,12 +1339,17 @@ func (cd *ControllerData) StartInfraResourceRefreshThread(cloudletInfo *edgeprot
 
 	cd.finishInfraResourceThread = make(chan struct{})
 	var count int
-
+	var sleeptime time.Duration
 	go func() {
 		done := false
 		for !done {
+			// if the settings are not ready yet, use default.
+			sleeptime = cd.settings.ResourceSnapshotThreadInterval.TimeDuration()
+			if sleeptime == 0 {
+				sleeptime = edgeproto.GetDefaultSettings().ResourceSnapshotThreadInterval.TimeDuration()
+			}
 			select {
-			case <-time.After(cd.settings.ResourceSnapshotThreadInterval.TimeDuration()):
+			case <-time.After(sleeptime):
 				span := log.StartSpan(log.DebugLevelApi, "CloudletResourceRefresh thread")
 				ctx := log.ContextWithSpan(context.Background(), span)
 


### PR DESCRIPTION
… value

### Issues Fixed

* EDGECLOUD-5191 : Periodic thread for infra resource snapshot

Address potential race condition on thread start if settings are not yet available, use the default explicity.
