### PR TITLE
master taint on update

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -1050,13 +1050,6 @@ func (s *ClusterInstApi) updateClusterInstInternal(cctx *CallContext, in *edgepr
 			if inbuf.Deployment != cloudcommon.DeploymentTypeKubernetes {
 				return fmt.Errorf("Cannot add auto scale policy to non-kubernetes ClusterInst")
 			}
-			if inbuf.NumNodes == 0 {
-				// this restriction is because we do not adjust
-				// the taints when switching from 1master/0nodes
-				// to 1master/Xnodes. This check can be removed
-				// if we fix the tainting.
-				return fmt.Errorf("Cannot add auto scale policy to master-only ClusterInst")
-			}
 		}
 
 		if err := checkCloudletReady(cctx, stm, &in.Key.CloudletKey, cloudcommon.Update); err != nil {

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -659,11 +659,6 @@ func (s *AutoScalePolicy) Validate(fields map[string]struct{}) error {
 	if s.MaxNodes > AutoScaleMaxNodes {
 		return fmt.Errorf("Max nodes cannot exceed %d", AutoScaleMaxNodes)
 	}
-	if s.MinNodes < 1 {
-		// Taint on master is not updated during UpdateClusterInst
-		// when going up/down from 0, so min supported is 1.
-		return errors.New("Min nodes cannot be less than 1")
-	}
 	if s.HasV0Config() && s.HasV1Config() {
 		return errors.New("The new target cpu/mem/active-connections can only be used once the old cpu threshold settings have been disabled (set to 0)")
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5215 Taints are not adjusted when adding nodes to master-only k8s cluster

### Description

Currently for 0-node clusters we disable the no-schedule taint on the master to allow pods to run there.  But we never change this when updating, either to add the taint when adding nodes or to remove the taint when removing all the nodes.  This addresses that.   See also infra fix.