### PR TITLE
EDGECLOUD-5448  alertpolicy tirigger-time needs to limit value of input

### DIFF
--- a/controller/alertpolicy_api_test.go
+++ b/controller/alertpolicy_api_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
@@ -76,6 +77,12 @@ func TestAlertPolicyApi(t *testing.T) {
 	userAlert.TriggerTime = 0
 	_, err = userAlertApi.CreateAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err, "Trigger Time should be at least 30s")
+
+	// Create user alert with trigger time, that's invalid
+	userAlert = testutil.AlertPolicyData[0]
+	userAlert.TriggerTime = edgeproto.Duration(80 * time.Hour)
+	_, err = userAlertApi.CreateAlertPolicy(ctx, &userAlert)
+	require.NotNil(t, err, "Trigger Time cannot exceed 3 days")
 
 	// Delete non-existent user alert
 	userAlert = testutil.AlertPolicyData[0]

--- a/edgeproto/alertpolicy.pb.go
+++ b/edgeproto/alertpolicy.pb.go
@@ -90,7 +90,7 @@ type AlertPolicy struct {
 	ActiveConnLimit uint32 `protobuf:"varint,6,opt,name=active_conn_limit,json=activeConnLimit,proto3" json:"active_conn_limit,omitempty"`
 	// Alert severity level - one of "info", "warning", "error"
 	Severity string `protobuf:"bytes,7,opt,name=severity,proto3" json:"severity,omitempty"`
-	// Duration for which alert interval is active
+	// Duration for which alert interval is active(max 72 hours)
 	TriggerTime Duration `protobuf:"varint,8,opt,name=trigger_time,json=triggerTime,proto3,casttype=Duration" json:"trigger_time,omitempty"`
 	// Additional Labels
 	Labels map[string]string `protobuf:"bytes,9,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`

--- a/edgeproto/alertpolicy.proto
+++ b/edgeproto/alertpolicy.proto
@@ -36,7 +36,7 @@ message AlertPolicy {
   uint32 active_conn_limit = 6;
   // Alert severity level - one of "info", "warning", "error"
   string severity = 7;
-  // Duration for which alert interval is active
+  // Duration for which alert interval is active(max 72 hours)
   int64 trigger_time = 8 [(gogoproto.casttype) = "Duration"];
   // Additional Labels
   map <string, string> labels = 9;

--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -1242,6 +1242,10 @@ func (a *AlertPolicy) Validate(fields map[string]struct{}) error {
 	if a.DiskUtilizationLimit > 100 {
 		return errors.New("Disk utilization limit is percent. Valid values 1-100%")
 	}
+	// reasonable max trigger time check - should not be >24h
+	if a.TriggerTime > Duration(72*time.Hour) {
+		return errors.New("Trigger duration should not exceed 72 hours")
+	}
 	return nil
 }
 

--- a/gencmd/alertpolicy.cmd.go
+++ b/gencmd/alertpolicy.cmd.go
@@ -325,7 +325,7 @@ var AlertPolicyComments = map[string]string{
 	"disk-utilization":   "container or pod disk utilization rate(percentage) across all nodes. Valid values 1-100",
 	"active-connections": "Active Connections alert threshold. Valid values 1-4294967295",
 	"severity":           "Alert severity level - one of info, warning, error",
-	"trigger-time":       "Duration for which alert interval is active",
+	"trigger-time":       "Duration for which alert interval is active(max 72 hours)",
 	"labels":             "Additional Labels, specify labels:empty=true to clear",
 	"annotations":        "Additional Annotations for extra information about the alert, specify annotations:empty=true to clear",
 	"description":        "Description of the alert policy",

--- a/gencmd/alldata.cmd.go
+++ b/gencmd/alldata.cmd.go
@@ -1162,7 +1162,7 @@ var AllDataComments = map[string]string{
 	"alertpolicies:#.diskutilizationlimit":                                          "container or pod disk utilization rate(percentage) across all nodes. Valid values 1-100",
 	"alertpolicies:#.activeconnlimit":                                               "Active Connections alert threshold. Valid values 1-4294967295",
 	"alertpolicies:#.severity":                                                      "Alert severity level - one of info, warning, error",
-	"alertpolicies:#.triggertime":                                                   "Duration for which alert interval is active",
+	"alertpolicies:#.triggertime":                                                   "Duration for which alert interval is active(max 72 hours)",
 	"alertpolicies:#.labels":                                                        "Additional Labels",
 	"alertpolicies:#.annotations":                                                   "Additional Annotations for extra information about the alert",
 	"alertpolicies:#.description":                                                   "Description of the alert policy",


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5448  alertpolicy tirigger-time needs to limit value of input

### Description

Add a max trigger time for alert policies. Set it to 72hours, as this seems like a reasonable interval.