### PR TITLE
EDGECLOUD-5512: Failed to refresh TLS certs as expired SSH certs are used

### DIFF
--- a/cloud-resource-manager/platform/common/xind/xind.go
+++ b/cloud-resource-manager/platform/common/xind/xind.go
@@ -84,6 +84,10 @@ func (s *Xind) GetNodePlatformClient(ctx context.Context, node *edgeproto.Cloudl
 	return s.GetClient(ctx)
 }
 
+func (s *Xind) GetSSHClient(ctx context.Context, addr string) (ssh.Client, error) {
+	return s.GetClient(ctx)
+}
+
 func (s *Xind) GetClient(ctx context.Context) (ssh.Client, error) {
 	// TODO: add support for remote infra
 	return &pc.LocalClient{
@@ -105,6 +109,10 @@ func (s *Xind) GetAccessData(ctx context.Context, cloudlet *edgeproto.Cloudlet, 
 
 func (s *Xind) GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error) {
 	return nil, nil
+}
+
+func (s *Xind) GetRootLBAddrs(ctx context.Context) (string, map[string]string, error) {
+	return "", nil, nil
 }
 
 func (s *Xind) GetVersionProperties() map[string]string {

--- a/cloud-resource-manager/platform/fake/fake.go
+++ b/cloud-resource-manager/platform/fake/fake.go
@@ -489,6 +489,10 @@ func (s *Platform) GetNodePlatformClient(ctx context.Context, node *edgeproto.Cl
 	return &pc.LocalClient{}, nil
 }
 
+func (s *Platform) GetSSHClient(ctx context.Context, addr string) (ssh.Client, error) {
+	return &pc.LocalClient{}, nil
+}
+
 func (s *Platform) ListCloudletMgmtNodes(ctx context.Context, clusterInsts []edgeproto.ClusterInst, vmAppInsts []edgeproto.AppInst) ([]edgeproto.CloudletMgmtNode, error) {
 	return []edgeproto.CloudletMgmtNode{
 		edgeproto.CloudletMgmtNode{
@@ -642,6 +646,10 @@ func (s *Platform) GetRestrictedCloudletStatus(ctx context.Context, cloudlet *ed
 
 func (s *Platform) GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error) {
 	return nil, nil
+}
+
+func (s *Platform) GetRootLBAddrs(ctx context.Context) (string, map[string]string, error) {
+	return "", nil, nil
 }
 
 func (s *Platform) GetVersionProperties() map[string]string {

--- a/cloud-resource-manager/platform/platform.go
+++ b/cloud-resource-manager/platform/platform.go
@@ -143,6 +143,10 @@ type Platform interface {
 	GetRestrictedCloudletStatus(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, accessApi AccessApi, updateCallback edgeproto.CacheUpdateCallback) error
 	// Get ssh clients of all root LBs
 	GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error)
+	// Get addresses of all root LBs
+	GetRootLBAddrs(ctx context.Context) (string, map[string]string, error)
+	// Get ssh client based on addr
+	GetSSHClient(ctx context.Context, addr string) (ssh.Client, error)
 	// Get RootLB Flavor
 	GetRootLBFlavor(ctx context.Context) (*edgeproto.Flavor, error)
 }


### PR DESCRIPTION
### Issues Fixed
* EDGECLOUD-5512: Failed to refresh TLS certs as expired SSH certs are used

### Description
* We refresh public TLS certs on RootLB every 30 days. To SSH into all the RootLBs (shared/dedicated), CRM currently maintains a cache of ssh.Clients. As part of this client, even SSH certs are cached. SSH certs are valid for 72 hours and hence it gets expired when TLS certs are refreshed
* Instead of caching SSH clients, CRM will now cache IP addresses of all the RootLBs (shared/dedicated). CRM will use this to setup SSH client whenever TLS certs are refreshed. We can also use DNS names instead of IP addresses, but it won't make any difference as IP addresses will not change for RootLB VMs
* Added helper functions to get RootLB addresses and SSH client