### PR TITLE
EDGECLOUD-5538  Need configurable cluster-svc app flavor

### DIFF
--- a/cluster-svc/README.md
+++ b/cluster-svc/README.md
@@ -17,8 +17,6 @@ Usage of cluster-svc:
     	address to connect to (default "127.0.0.1:55001")
   -d string
     	comma separated list of [etcd api notify dmedb dmereq locapi mexos metrics upgrade]
-  -flavor string
-    	App flavor for cluster-svc applications (default "x1.medium")
   -notifyAddrs string
     	Comma separated list of controller notify listener addresses (default "127.0.0.1:50001")
   -prometheus-ports string

--- a/cluster-svc/cluster-svc-main.go
+++ b/cluster-svc/cluster-svc-main.go
@@ -35,7 +35,6 @@ var ctrlAddr = flag.String("ctrlAddrs", "127.0.0.1:55001", "address to connect t
 var debugLevels = flag.String("d", "", fmt.Sprintf("comma separated list of %v", log.DebugLevelStrings))
 var externalPorts = flag.String("prometheus-ports", "tcp:9090", "ports to expose in form \"tcp:123,udp:123\"")
 var scrapeInterval = flag.Duration("scrapeInterval", time.Second*15, "Metrics collection interval")
-var appFlavor = flag.String("flavor", "x1.medium", "App flavor for cluster-svc applications")
 var upgradeInstances = flag.Bool("updateAll", false, "Upgrade all Instances of Prometheus operator")
 var pluginRequired = flag.Bool("pluginRequired", false, "Require plugin")
 var hostname = flag.String("hostname", "", "Unique hostname")
@@ -435,7 +434,7 @@ func isClusterPrometheusAlert(alert *edgeproto.AlertPolicy) bool {
 // create an appInst as a cluster-svc
 func createAppInstCommon(ctx context.Context, dialOpts grpc.DialOption, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, platformApp *edgeproto.App) error {
 	//update flavor
-	platformApp.DefaultFlavor = edgeproto.FlavorKey{Name: *appFlavor}
+	platformApp.DefaultFlavor = edgeproto.FlavorKey{Name: clusterInst.Flavor.Name}
 	conn, err := grpc.Dial(*ctrlAddr, dialOpts, grpc.WithBlock(), grpc.WithUnaryInterceptor(log.UnaryClientTraceGrpc), grpc.WithStreamInterceptor(log.StreamClientTraceGrpc))
 	if err != nil {
 		return fmt.Errorf("Connect to server %s failed: %s", *ctrlAddr, err.Error())

--- a/setup-env/e2e-tests/data/appdata-ratelimit_show.yml
+++ b/setup-env/e2e-tests/data/appdata-ratelimit_show.yml
@@ -497,7 +497,7 @@ apps:
   imagepath: https://charts.helm.sh/stable:stable/nfs-client-provisioner
   imagetype: Helm
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=1.2.8
   deployment: helm
   accesstype: LoadBalancer
@@ -535,7 +535,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
+++ b/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
@@ -517,7 +517,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer
@@ -570,7 +570,7 @@ apps:
   imagepath: https://charts.helm.sh/stable:stable/nfs-client-provisioner
   imagetype: Helm
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=1.2.8
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
@@ -178,7 +178,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
@@ -174,7 +174,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
@@ -531,7 +531,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
@@ -530,7 +530,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_show.yml
+++ b/setup-env/e2e-tests/data/appdata_show.yml
@@ -497,7 +497,7 @@ apps:
   imagepath: https://charts.helm.sh/stable:stable/nfs-client-provisioner
   imagetype: Helm
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=1.2.8
   deployment: helm
   accesstype: LoadBalancer
@@ -535,7 +535,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_show_after_cluster_update.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_cluster_update.yml
@@ -498,7 +498,7 @@ apps:
   imagepath: https://charts.helm.sh/stable:stable/nfs-client-provisioner
   imagetype: Helm
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=1.2.8
   deployment: helm
   accesstype: LoadBalancer
@@ -536,7 +536,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_show_after_refresh.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_refresh.yml
@@ -498,7 +498,7 @@ apps:
   imagepath: https://charts.helm.sh/stable:stable/nfs-client-provisioner
   imagetype: Helm
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=1.2.8
   deployment: helm
   accesstype: LoadBalancer
@@ -536,7 +536,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_show_after_refresh_all.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_refresh_all.yml
@@ -514,7 +514,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer
@@ -567,7 +567,7 @@ apps:
   imagepath: https://charts.helm.sh/stable:stable/nfs-client-provisioner
   imagetype: Helm
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=1.2.8
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/appdata_show_prometheus_30s_interval.yml
+++ b/setup-env/e2e-tests/data/appdata_show_prometheus_30s_interval.yml
@@ -514,7 +514,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   configs:
@@ -568,7 +568,7 @@ apps:
   imagepath: https://charts.helm.sh/stable:stable/nfs-client-provisioner
   imagetype: Helm
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=1.2.8
   deployment: helm
   configs:

--- a/setup-env/e2e-tests/data/appdata_trusted_show.yml
+++ b/setup-env/e2e-tests/data/appdata_trusted_show.yml
@@ -320,7 +320,7 @@ apps:
   imagetype: Helm
   accessports: tcp:9090
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   delopt: AutoDelete

--- a/setup-env/e2e-tests/data/appdata_trustpol_incompat_rules_show.yml
+++ b/setup-env/e2e-tests/data/appdata_trustpol_incompat_rules_show.yml
@@ -273,7 +273,7 @@ apps:
   imagetype: Helm
   accessports: tcp:9090
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   delopt: AutoDelete

--- a/setup-env/e2e-tests/data/crm_info.yml
+++ b/setup-env/e2e-tests/data/crm_info.yml
@@ -456,7 +456,7 @@ apps:
   imagetype: Helm
   accessports: tcp:9090
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   delopt: AutoDelete

--- a/setup-env/e2e-tests/data/influx_appdata_show.yml
+++ b/setup-env/e2e-tests/data/influx_appdata_show.yml
@@ -182,7 +182,7 @@ apps:
   imagepath: https://charts.helm.sh/stable:stable/nfs-client-provisioner
   imagetype: Helm
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=1.2.8
   deployment: helm
   configs:
@@ -208,7 +208,7 @@ apps:
   trusted: true
   accesstype: LoadBalancer
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/data/show2.yml
+++ b/setup-env/e2e-tests/data/show2.yml
@@ -247,7 +247,7 @@ apps:
   internalports: true
   trusted: true
   defaultflavor:
-    name: x1.medium
+    name: x1.small
   annotations: version=9.4.10
   deployment: helm
   accesstype: LoadBalancer

--- a/setup-env/e2e-tests/testfiles/get_appinstlist.yml
+++ b/setup-env/e2e-tests/testfiles/get_appinstlist.yml
@@ -4,6 +4,9 @@ description: adds dataset with 10 appinstlist and 2 apps. Does get appinstlist f
 
 tests:
 
+- name: stop cluster-svc instances
+  actions: [stop=cluster-svc1, stop=cluster-svc2]
+
 - name: create and verify provisioning 10 appinstlist 
   actions: [ctrlapi-create,ctrlapi-show]
   apifile: "{{datadir}}/appdata_10.yml"
@@ -52,4 +55,5 @@ tests:
     yaml2: "{{datadir}}/appdata_empty.yml"
     filetype: appdata
 
-
+- name: start cluster-svc instances
+  actions: [start=cluster-svc1, start=cluster-svc2]

--- a/setup-env/e2e-tests/testfiles/get_fqdnlist.yml
+++ b/setup-env/e2e-tests/testfiles/get_fqdnlist.yml
@@ -3,6 +3,9 @@
 
 tests:
 
+- name: stop cluster-svc instances
+  actions: [stop=cluster-svc1, stop=cluster-svc2]
+
 - name: create and verify provisioning for 2 apps, 10 instances
   actions: [ctrlapi-create,ctrlapi-show]
   apifile: "{{datadir}}/appdata_10.yml"
@@ -27,3 +30,6 @@ tests:
     yaml1: "{{outputdir}}/show-commands.yml"
     yaml2: "{{datadir}}/appdata_empty.yml"
     filetype: appdata
+
+- name: start cluster-svc instances
+  actions: [start=cluster-svc1, start=cluster-svc2]


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5538  Need configurable cluster-svc app flavor

### Description

We don't really need to specify default flavor for platform apps, since we will overwrite the flavor when deploying an appInst. Instead just use the flavor that we know already exists. This eliminates a possibility of the flavor not existing before deploying platform apps.