### PR TITLE
EDGECLOUD-5512: Add debug command to trigger refresh of RootLB certs

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -315,6 +315,11 @@ func main() {
 			proxycerts.Init(ctx, platform, accessapi.NewControllerClient(nodeMgr.AccessApiClient))
 			pfType := pf.GetType(cloudlet.PlatformType.String())
 			proxycerts.GetRootLbCerts(ctx, &myCloudletInfo.Key, commonName, dedicatedCommonName, &nodeMgr, pfType, rootlb, *commercialCerts)
+			// setup debug func to trigger refresh of rootlb certs
+			nodeMgr.Debug.AddDebugFunc(crmutil.RefreshRootLBCerts, func(ctx context.Context, req *edgeproto.DebugRequest) string {
+				proxycerts.TriggerRootLBCertsRefresh()
+				return "triggered refresh of rootlb certs"
+			})
 		}
 		tlsSpan.Finish()
 	}()

--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -114,7 +114,7 @@ func NewControllerData(pf platform.Platform, key *edgeproto.CloudletKey, nodeMgr
 	cd.settings = *edgeproto.GetDefaultSettings()
 
 	// debug functions
-	nodeMgr.Debug.AddDebugFunc("envoyversioncmd", cd.GetClusterEnvoyVersion)
+	nodeMgr.Debug.AddDebugFunc(GetEnvoyVersionCmd, cd.GetClusterEnvoyVersion)
 
 	return cd
 }

--- a/cloud-resource-manager/crmutil/crm-debug.go
+++ b/cloud-resource-manager/crmutil/crm-debug.go
@@ -11,8 +11,14 @@ import (
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 )
 
+const (
+	GetEnvoyVersionCmd = "get-cluster-envoy-version"
+	RefreshRootLBCerts = "refresh-rootlb-certs"
+	CRMCmd             = "crmcmd"
+)
+
 func InitDebug(nodeMgr *node.NodeMgr) {
-	nodeMgr.Debug.AddDebugFunc("crmcmd", runCrmCmd)
+	nodeMgr.Debug.AddDebugFunc(CRMCmd, runCrmCmd)
 }
 
 func runCrmCmd(ctx context.Context, req *edgeproto.DebugRequest) string {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5512: Add debug command to trigger a refresh of RootLB certs

### Description

* Added debug command to trigger a refresh of RootLB certs. This is required for QA testing.