### PR TITLE
EDGECLOUD-5556: Sidecar app creation fails when controller is on R3.0 and CRM is on R2.4.x

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -1037,8 +1037,11 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			}
 		}
 		if app.InternalPorts || len(ports) == 0 {
-			// no external access to AppInst, no need for URI
-			in.Uri = ""
+			// older CRMs require app URI regardless of external access to AppInst
+			if cloudletCompatibilityVersion >= cloudcommon.CRMCompatibilitySharedRootLBFQDN {
+				// no external access to AppInst, no need for URI
+				in.Uri = ""
+			}
 		}
 		if err := cloudcommon.CheckFQDNLengths("", in.Uri); err != nil {
 			return err

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -206,6 +206,7 @@ var AppData = []edgeproto.App{
 			Vcpus: 0.2,
 			Ram:   10,
 		},
+		InternalPorts: true,
 	},
 	edgeproto.App{ // 10
 		Key: edgeproto.AppKey{


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5556: Sidecar app creation fails when controller is on R3.0 and CRM is on R2.4.x

### Description
* In R2.4.x,
  - Controller sets App URI for sidecar apps (apps with internalports set to true)
  - CRM will error out if any App’s URI is empty. Refer this code: https://github.com/mobiledgex/edge-cloud-infra/blob/r2.4.1-hf/infracommon/dns.go#L46
* In R3.0,
  - Controller will not set App URI for sidecar apps (apps with internalports set to true)
  - CRM will not error out if sidecar App's URI is empty. Refer this code: https://github.com/mobiledgex/edge-cloud-infra/blob/master/infracommon/dns.go#L92
* If Controller is on R3.0 & CRM is on R2.4.x, then Controller will NOT set App URI and hence CRM will ERROR out appinst creation as it is expecting App URI
* Fixed the code to check the compatibility version before setting app URI to empty
