### PR TITLE
EDGECLOUD-5565: R3.0 Orange_Spain MXFUN-EDC99 cloudlet upgrade failed

### DIFF
--- a/util/json_test.go
+++ b/util/json_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type TestObj struct {
-	Field1 CustomJsonNumber `json:"field-1"`
+	Field1 EmptyStringJsonNumber `json:"field-1"`
 }
 
 func TestJson(t *testing.T) {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5565: R3.0 Orange_Spain MXFUN-EDC99 cloudlet upgrade failed

### Description

* Defined custom JSON number type, which is essentially a `json.Number` which ignores empty string.