### PR TITLE
use wildcard certs

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -301,8 +301,7 @@ func main() {
 
 		// setup rootlb certs
 		tlsSpan := log.StartSpan(log.DebugLevelInfo, "tls certs thread", opentracing.ChildOf(log.SpanFromContext(ctx).Context()))
-		commonName := cloudcommon.GetRootLBFQDN(&myCloudletInfo.Key, *appDNSRoot)
-		dedicatedCommonName := "*." + commonName // wildcard so dont have to generate certs every time a dedicated cluster is started
+		wildcardName := cloudcommon.GetRootLBFQDNWildcard(&myCloudletInfo.Key, *appDNSRoot)
 		rootlb, err := platform.GetClusterPlatformClient(
 			ctx,
 			&edgeproto.ClusterInst{
@@ -314,7 +313,7 @@ func main() {
 			log.SpanLog(ctx, log.DebugLevelInfra, "Get rootLB certs", "key", myCloudletInfo.Key)
 			proxycerts.Init(ctx, platform, accessapi.NewControllerClient(nodeMgr.AccessApiClient))
 			pfType := pf.GetType(cloudlet.PlatformType.String())
-			proxycerts.GetRootLbCerts(ctx, &myCloudletInfo.Key, commonName, dedicatedCommonName, &nodeMgr, pfType, rootlb, *commercialCerts)
+			proxycerts.GetRootLbCerts(ctx, &myCloudletInfo.Key, wildcardName, &nodeMgr, pfType, rootlb, *commercialCerts)
 			// setup debug func to trigger refresh of rootlb certs
 			nodeMgr.Debug.AddDebugFunc(crmutil.RefreshRootLBCerts, func(ctx context.Context, req *edgeproto.DebugRequest) string {
 				proxycerts.TriggerRootLBCertsRefresh()

--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -177,6 +177,11 @@ func GetRootLBFQDNOld(key *edgeproto.CloudletKey, domain string) string {
 	return GetCloudletBaseFQDN(key, domain)
 }
 
+// Wildcard cert for all LBs both shared and dedicated
+func GetRootLBFQDNWildcard(key *edgeproto.CloudletKey, domain string) string {
+	return "*." + GetCloudletBaseFQDN(key, domain)
+}
+
 // GetDedicatedLBFQDN gets the cluster-specific Load Balancer's Fully Qualified Domain Name
 // for clusters using "dedicated" IP access.
 func GetDedicatedLBFQDN(cloudletKey *edgeproto.CloudletKey, clusterKey *edgeproto.ClusterKey, domain string) string {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5571 TLS certs are for wrong common name in 3.0

### Description

The FQDNs for the LBs changed in 3.0 and now we have certs for the following:

*.shared.hamburg-main.tdg.mobiledgex.net
shared.hamburg-main.tdg.mobiledgex.net

They should be just:
*.hamburg-main.tdg.mobiledgex.net

We no longer need different certs for dedicated vs shared so this makes wildcard certs for all LBs