### PR TITLE
add const for disk

### DIFF
--- a/cloudcommon/infraresources.go
+++ b/cloudcommon/infraresources.go
@@ -18,6 +18,7 @@ var (
 	ResourceVcpus       = "vCPUs"
 	ResourceGpus        = "GPUs"
 	ResourceExternalIPs = "External IPs"
+	ResourceDisk        = "Disk"
 
 	// Platform specific resources
 	ResourceInstances   = "Instances"


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5582 VCD does not show infra disk usage

### Description

This is just to create the constant that VCD needs to report infra disk usage. See infra PR for more details