### PR TITLE
fix race condition when doing multiple updates

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -359,10 +359,8 @@ func (cd *ControllerData) clusterInstChanged(ctx context.Context, old *edgeproto
 				//XXX seems clusterInstInfoError is overloaded with status for flavor and clustinst.
 				return
 			}
-
-			log.SpanLog(ctx, log.DebugLevelInfra, "cluster state ready", "ClusterInst", *new)
-			cd.clusterInstInfoState(ctx, &new.Key, edgeproto.TrackedState_READY, updateClusterCacheCallback)
 			// Get cluster resources and report to controller.
+			updateClusterCacheCallback(edgeproto.UpdateTask, "Getting Cluster Infra Resources")
 			resources, err := cd.platform.GetClusterInfraResources(ctx, &new.Key)
 			if err != nil {
 				log.SpanLog(ctx, log.DebugLevelInfra, "error getting infra resources", "err", err)
@@ -373,6 +371,8 @@ func (cd *ControllerData) clusterInstChanged(ctx context.Context, old *edgeproto
 					log.SpanLog(ctx, log.DebugLevelInfra, "failed to set cluster inst resources", "err", err)
 				}
 			}
+			log.SpanLog(ctx, log.DebugLevelInfra, "cluster state ready", "ClusterInst", *new)
+			cd.clusterInstInfoState(ctx, &new.Key, edgeproto.TrackedState_READY, updateClusterCacheCallback)
 		}()
 	} else if new.State == edgeproto.TrackedState_UPDATE_REQUESTED {
 		// Marks start of clusterinst change and hence increases ref count
@@ -414,10 +414,8 @@ func (cd *ControllerData) clusterInstChanged(ctx context.Context, old *edgeproto
 			}
 			return nil
 		})
-
-		log.SpanLog(ctx, log.DebugLevelInfra, "cluster state ready", "ClusterInst", *new)
-		cd.clusterInstInfoState(ctx, &new.Key, edgeproto.TrackedState_READY, updateClusterCacheCallback)
 		// Get cluster resources and report to controller.
+		updateClusterCacheCallback(edgeproto.UpdateTask, "Getting Cluster Infra Resources")
 		resources, err := cd.platform.GetClusterInfraResources(ctx, &new.Key)
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelInfra, "error getting infra resources", "err", err)
@@ -428,6 +426,8 @@ func (cd *ControllerData) clusterInstChanged(ctx context.Context, old *edgeproto
 				log.SpanLog(ctx, log.DebugLevelInfra, "failed to set cluster inst resources", "err", err)
 			}
 		}
+		log.SpanLog(ctx, log.DebugLevelInfra, "cluster state ready", "ClusterInst", *new)
+		cd.clusterInstInfoState(ctx, &new.Key, edgeproto.TrackedState_READY, updateClusterCacheCallback)
 	} else if new.State == edgeproto.TrackedState_DELETE_REQUESTED {
 		// Marks start of clusterinst change and hence increases ref count
 		cd.vmResourceActionBegin()


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5504 UpdateClusterInst race condition

### Description

When doing multiple UpdateClusterInst operations separated by only a few seconds, the second one returns very quickly with a repeated set of steps from the first update. Eventually the 2nd update does properly work, but there is no further feedback to the user and so it is confusing.

The reason is that when the CRM does Create or Update ClusterInst, it sets the state to READY but then keeps working to collect infra resources for the cluster.  If the second create happens while this infra resource collection is happening, the controller gets a state update that it thinks means that the second create is done.

We intentionally had the GetClusterInfraResources happen after the state transitions Ready to save a little time on Create and Update, but it causes some race conditions. And arguably it is better to have the resource values accurately reflect the real usage before this occurs.