### PR TITLE
Disable alert policy on multi-tenant clusters.

### DIFF
--- a/cluster-svc/cluster-svc-main.go
+++ b/cluster-svc/cluster-svc-main.go
@@ -243,6 +243,10 @@ func appInstCb(ctx context.Context, old *edgeproto.AppInst, new *edgeproto.AppIn
 				"cluster", new.ClusterInstKey())
 			return
 		}
+		if cluster.MultiTenant {
+			log.SpanLog(ctx, log.DebugLevelNotify, "Alert Policies on multi-tenant clusters are not yet supported")
+			return
+		}
 		if err := createMEXPromInst(ctx, dialOpts, &cluster, &app); err != nil {
 			log.SpanLog(ctx, log.DebugLevelApi, "Prometheus-operator inst create failed", "cluster",
 				cluster, "error", err.Error())


### PR DESCRIPTION
### Description
Disable alert policy on MT clusters - more work needs to be done to support this.