### PR TITLE
EDGECLOUD-5596 mcctl audit operation bad args causes mcctl crash

### DIFF
--- a/cli/input.go
+++ b/cli/input.go
@@ -393,6 +393,9 @@ func GetFieldTaggedName(sf reflect.StructField, ns FieldNamespace) string {
 
 func FindHierField(t reflect.Type, hierName string, ns FieldNamespace) (reflect.StructField, bool) {
 	sf := reflect.StructField{}
+	if t == nil {
+		return sf, false
+	}
 	found := false
 	for _, name := range strings.Split(hierName, ".") {
 		if t.Kind() == reflect.Ptr {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5596 mcctl audit operation with unnecessary args causes SIGSEGV

### Description

Small fix for mcctl crash when input arg is nil (none) and bad args were specified.

After fix:
> mcctl audit operations help=help
Error: parsing arg "help=help" failed: invalid argument: key "help" not found