### PR TITLE
EDGECLOUD-5630: After updating a k8s appinst the runcommand tries to fetch the old pod name

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -442,6 +442,9 @@ func GetAppInstRuntime(ctx context.Context, client ssh.Client, names *KubeNames,
 				namespace = DefaultNamespace
 			}
 		}
+
+		// Returns list of pods and its containers in the format: "<Namespace>/<PodName>/<ContainerName>"
+
 		// Get list of all running pods.
 		// NOTE: Parsing status from json output doesn't give correct value as observed with kubectl version 1.18
 		//       Hence, look at table output and then get list of running pods and use this to fetch container names
@@ -454,11 +457,10 @@ func GetAppInstRuntime(ctx context.Context, client ssh.Client, names *KubeNames,
 		}
 		podNames := strings.Split(out, "\n")
 		for _, podName := range podNames {
-			podName := strings.TrimSpace(podName)
+			podName = strings.TrimSpace(podName)
 			if podName == "" {
 				continue
 			}
-			// Returns list of pods and its containers in the format: "<PodName>/<ContainerName>"
 			cmd = fmt.Sprintf("%s kubectl get pod %s -n %s -o json | jq -r '.spec.containers[] | .name'",
 				names.KconfEnv, podName, namespace)
 			out, err = client.Output(cmd)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5630: After updating a k8s appinst the runcommand tries to fetch the old pod name

### Description

* As part of `RefreshAppInst`, we call `kubectl apply` to apply the updated deployment manifest. This can lead to the re-creation of pods. `kubectl apply` brings up new pods, but it doesn't wait for the cleanup of the old pod. We then use `kubectl get pods` to get the list of pods and containers and update it as part of `runtime` field. This delay in the deletion of pods ends up showing two entries as part of `runtime` output, one for the old pod & another for the newly created pod
* The fix is to use `Running` pods for RunCommand. But JSON output doesn't give the correct status value. Sometimes we see that `kubectl get pods` shows status as `Terminating`, but `kubectl get pods -o json` shows status as `Running`. Hence, the code now relies on table output to figure pod status and then uses this list of running pods to get container names