### PR TITLE
EDGECLOUD-5623 spew-rate-limit-mgr

### DIFF
--- a/d-match-engine/dme-server/dme-debug.go
+++ b/d-match-engine/dme-server/dme-debug.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/mobiledgex/edge-cloud/cloudcommon/node"
 	dmecommon "github.com/mobiledgex/edge-cloud/d-match-engine/dme-common"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -12,6 +13,7 @@ import (
 
 func InitDebug(nodeMgr *node.NodeMgr) {
 	nodeMgr.Debug.AddDebugFunc(dmecommon.RequestAppInstLatency, requestAppInstLatency)
+	nodeMgr.Debug.AddDebugFunc("spew-rate-limit-mgr", spewRateLimitMgr)
 }
 
 func requestAppInstLatency(ctx context.Context, req *edgeproto.DebugRequest) string {
@@ -37,4 +39,13 @@ func createAppInstKeyFromRequest(req *edgeproto.DebugRequest) (*edgeproto.AppIns
 	}
 
 	return &appInstKey, nil
+}
+
+func spewRateLimitMgr(ctx context.Context, req *edgeproto.DebugRequest) string {
+	if dmecommon.RateLimitMgr == nil {
+		return "nil"
+	}
+	dmecommon.RateLimitMgr.Lock()
+	defer dmecommon.RateLimitMgr.Unlock()
+	return spew.Sdump(dmecommon.RateLimitMgr)
 }

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/creack/pty v1.1.10
+	github.com/davecgh/go-spew v1.1.1
 	github.com/daviddengcn/go-colortext v0.0.0-20171126034257-17e75f6184bc
 	github.com/denisenkom/go-mssqldb v0.0.0-20190905012053-7920e8ef8898 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5623 DME rate limiting not working with Global apiname

### Description

Add a debug command to help debug why the rate limiter is not working. This command will dump the contents of the DME's rate limit manager, so we can see if it's been properly configured or not, and what state it is in.

This is not a fix for the bug above, it's just debug to help determine the root cause.

Example output:
```
> edgectl controller RunDebug cmd=spew-rate-limit-mgr type=dme
- node:
    name: Jon-Mex.lan
    type: dme
    cloudletkey:
      organization: TDG
      name: jon-berlin
    region: local
  output: |
    (*ratelimit.RateLimitManager)(0xc000362810)({
     Mutex: (util.Mutex) {
      mux: (sync.Mutex) {
       state: (int32) 1,
       sema: (uint32) 0
      }
     },
     limitsPerApi: (map[string]*ratelimit.apiEndpointLimiter) (len=2) {
      (string) (len=14) "VerifyLocation": (*ratelimit.apiEndpointLimiter)(0xc000207580)({
       apiName: (string) (len=14) "VerifyLocation",
       apiEndpointRateLimitSettings: (*ratelimit.apiEndpointRateLimitSettings)(0xc0005abf60)({
        AllRequestsRateLimitSettings: (*edgeproto.RateLimitSettings)(0xc000362f00)(key:<api_name:"VerifyLocation" api_endpoint_type:DME rate_limit_target:ALL_REQUESTS > flow_settings:<key:"verifylocallreqs1" value:<flow_algorithm:TOKEN_BUCKET_ALGORITHM reqs_per_second:5000 burst_size:50 > > ),
        PerIpRateLimitSettings: (*edgeproto.RateLimitSettings)(0xc000362fc0)(key:<api_name:"VerifyLocation" api_endpoint_type:DME rate_limit_target:PER_IP > flow_settings:<key:"verifylocperip1" value:<flow_algorithm:TOKEN_BUCKET_ALGORITHM reqs_per_second:1000 burst_size:25 > > ),
        PerUserRateLimitSettings: (*edgeproto.RateLimitSettings)(<nil>)
       }),
       limitAllRequests: (*ratelimit.CompositeLimiter)(0xc0005074a0)({
        limiters: ([]ratelimit.Limiter) (len=1 cap=1) {
         (*ratelimit.TokenBucketLimiter)(0xc000507460)({
          limiter: (*rate.Limiter)(0xc000228280)({
           mu: (sync.Mutex) {
            state: (int32) 0,
            sema: (uint32) 0
           },
           limit: (rate.Limit) 5000,
           burst: (int) 50,
           tokens: (float64) 0,
           last: (time.Time) 0001-01-01 00:00:00 +0000 UTC,
           lastEvent: (time.Time) 0001-01-01 00:00:00 +0000 UTC
          }),
          tokensPerSecond: (float64) 5000,
          bucketSize: (int) 50
         })
        }
       }),
       limitsPerIp: (map[string]*ratelimit.CompositeLimiter) {
       },
       limitsPerUser: (map[string]*ratelimit.CompositeLimiter) {
       },
       maxNumIps: (int) 10000,
       maxNumUsers: (int) 10000
      }),
      (string) (len=6) "Global": (*ratelimit.apiEndpointLimiter)(0xc000207540)({
       apiName: (string) (len=6) "Global",
       apiEndpointRateLimitSettings: (*ratelimit.apiEndpointRateLimitSettings)(0xc0005abf00)({
        AllRequestsRateLimitSettings: (*edgeproto.RateLimitSettings)(0xc000362c00)(key:<api_name:"Global" api_endpoint_type:DME rate_limit_target:ALL_REQUESTS > flow_settings:<key:"andyr" value:<flow_algorithm:TOKEN_BUCKET_ALGORITHM reqs_per_second:5 burst_size:1 > > flow_settings:<key:"dmeglobalallreqs1" value:<flow_algorithm:TOKEN_BUCKET_ALGORITHM reqs_per_second:25000 burst_size:250 > > ),
        PerIpRateLimitSettings: (*edgeproto.RateLimitSettings)(0xc000362cc0)(key:<api_name:"Global" api_endpoint_type:DME rate_limit_target:PER_IP > flow_settings:<key:"dmeglobalperip1" value:<flow_algorithm:TOKEN_BUCKET_ALGORITHM reqs_per_second:10000 burst_size:100 > > ),
        PerUserRateLimitSettings: (*edgeproto.RateLimitSettings)(<nil>)
       }),
       limitAllRequests: (*ratelimit.CompositeLimiter)(0xc0004d43a0)({
        limiters: ([]ratelimit.Limiter) (len=2 cap=2) {
         (*ratelimit.TokenBucketLimiter)(0xc0004d4320)({
          limiter: (*rate.Limiter)(0xc0002dcc30)({
           mu: (sync.Mutex) {
            state: (int32) 0,
            sema: (uint32) 0
           },
           limit: (rate.Limit) 25000,
           burst: (int) 250,
           tokens: (float64) 0,
           last: (time.Time) 0001-01-01 00:00:00 +0000 UTC,
           lastEvent: (time.Time) 0001-01-01 00:00:00 +0000 UTC
          }),
          tokensPerSecond: (float64) 25000,
          bucketSize: (int) 250
         }),
         (*ratelimit.TokenBucketLimiter)(0xc0004d4340)({
          limiter: (*rate.Limiter)(0xc0002dcc80)({
           mu: (sync.Mutex) {
            state: (int32) 0,
            sema: (uint32) 0
           },
           limit: (rate.Limit) 5,
           burst: (int) 1,
           tokens: (float64) 0,
           last: (time.Time) 0001-01-01 00:00:00 +0000 UTC,
           lastEvent: (time.Time) 0001-01-01 00:00:00 +0000 UTC
          }),
          tokensPerSecond: (float64) 5,
          bucketSize: (int) 1
         })
        }
       }),
       limitsPerIp: (map[string]*ratelimit.CompositeLimiter) {
       },
       limitsPerUser: (map[string]*ratelimit.CompositeLimiter) {
       },
       maxNumIps: (int) 10000,
       maxNumUsers: (int) 10000
      })
     },
     disableRateLimit: (bool) false,
     maxNumPerIpRateLimiters: (int) 10000,
     maxNumPerUserRateLimiters: (int) 0
    })
```