### PR TITLE
InfraFlavorUpdate rework: initial push

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/crm_server_test.go
+++ b/cloud-resource-manager/cmd/crmserver/crm_server_test.go
@@ -236,12 +236,11 @@ func TestCRM(t *testing.T) {
 
 	*cloudletKeyStr = string(bytes)
 	nodeMgr.AccessKeyClient.TestSkipTlsVerify = true
-	defer nodeMgr.Finish()
 
 	*platformName = "PLATFORM_TYPE_FAKE"
 	err = startServices()
-	require.Nil(t, err, "start crm")
 	defer stopServices()
+	require.Nil(t, err, "start crm")
 
 	notifyClient.WaitForConnect(1)
 	stats := notify.Stats{}

--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -84,14 +84,12 @@ func main() {
 
 	err := startServices()
 	if err != nil {
-		fmt.Printf("\n\n CRM MAIN error returned from startServices: %s\n\n", err.Error())
 		stopServices()
 		log.FatalLog(err.Error())
 	}
 	defer stopServices()
 	sig := <-sigChan
 	fmt.Println(sig)
-	fmt.Printf("\n\nCRM Main completed\n\n")
 }
 
 func startServices() error {
@@ -106,7 +104,6 @@ func startServices() error {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	standalone := false
-	fmt.Printf("\n\nMain: Parsing cloudletKeyStr is : %s\n\n", *cloudletKeyStr)
 
 	cloudcommon.ParseMyCloudletKey(standalone, cloudletKeyStr, &myCloudletInfo.Key)
 	myCloudletInfo.CompatibilityVersion = cloudcommon.GetCRMCompatibilityVersion()
@@ -344,7 +341,6 @@ func startServices() error {
 				return "triggered refresh of rootlb certs"
 			})
 		}
-		fmt.Printf("\n\tMAIN platform init thread complete cloudlet: %+v\n\n", myCloudletInfo.Key)
 		tlsSpan.Finish()
 	}()
 
@@ -368,7 +364,6 @@ func startServices() error {
 
 func stopServices() {
 
-	fmt.Printf("\n\tstopServices main shutting down gracefully\n\n")
 	if services.flavorRefreshRunning {
 		controllerData.FinishFlavorRefreshThread()
 		services.flavorRefreshRunning = false

--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -1399,7 +1399,7 @@ func (cd *ControllerData) FinishInfraResourceRefreshThread() {
 func (cd *ControllerData) StartFlavorUpdateThread(cloudletInfo *edgeproto.CloudletInfo, testmode bool) {
 	cd.finishFlavorRefreshThread = make(chan struct{})
 	if testmode {
-		cd.settings.FlavorRefreshThreadInterval = edgeproto.Duration(time.Second * 10)
+		cd.settings.FlavorRefreshThreadInterval = edgeproto.Duration(time.Second * 1)
 	}
 	go func() {
 		done := false

--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -246,13 +246,11 @@ func ParseMyCloudletKey(standalone bool, keystr *string, mykey *edgeproto.Cloudl
 	if *keystr == "" {
 		log.FatalLog("cloudletKey not specified")
 	}
-	fmt.Printf("\n\nParseMyCloudletKey string: %s\n", *keystr)
 	err := json.Unmarshal([]byte(*keystr), mykey)
 	if err != nil {
 		err = yaml.Unmarshal([]byte(*keystr), mykey)
 	}
 	if err != nil {
-		fmt.Printf("\n\nParseMyCloudletKey-E-cloudletKey cant parse: %s fatal \n\n", err.Error())
 		log.FatalLog("Failed to parse cloudletKey", "err", err)
 	}
 

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -1768,7 +1768,6 @@ func getDefaultMTClustKey(cloudletKey edgeproto.CloudletKey) *edgeproto.ClusterI
 	}
 }
 
-// don't need to pass any flavor, we'll look at 'em all
 func (s *ClusterInstApi) cleanupDeletedInfraFlavorAlerts(ctx context.Context, clusterInst *edgeproto.ClusterInst) {
 	workerKey := HandleFlavorAlertWorkerKey{
 		cloudletKey: edgeproto.CloudletKey{

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -160,7 +160,6 @@ func startServices() error {
 	if *externalApiAddr == "" {
 		*externalApiAddr, err = util.GetExternalApiAddr(*apiAddr)
 		if err != nil {
-			fmt.Printf("\n\tstartServices-E-error on GetExternalApiAddr: %s\n", err.Error())
 			return err
 		}
 	}
@@ -174,13 +173,11 @@ func startServices() error {
 	// etcd is per-region.
 	objstore.InitRegion(uint32(1))
 	if !util.ValidRegion(*region) {
-		fmt.Printf("\n\tstartServices-E-error invalid region name\n")
 		return fmt.Errorf("invalid region name")
 	}
 
 	ctx, span, err := nodeMgr.Init(node.NodeTypeController, node.CertIssuerRegional, node.WithName(ControllerId), node.WithContainerVersion(*versionTag), node.WithRegion(*region))
 	if err != nil {
-		fmt.Printf("\n\tstartServices-E-error nodemgr.Init %s\n", err.Error())
 		return err
 	}
 	initDebug(ctx, &nodeMgr)
@@ -190,10 +187,8 @@ func startServices() error {
 	log.SpanLog(ctx, log.DebugLevelInfo, "Start up", "rootDir", *rootDir, "apiAddr", *apiAddr, "externalApiAddr", *externalApiAddr)
 	err = validateFields(ctx)
 	if err != nil {
-		fmt.Printf("\n\tstartServices-E-error validateFields %s\n", err.Error())
 		return err
 	}
-	fmt.Printf("\n\tstartServices fininsh validate Fields\n")
 	if *localEtcd {
 		opts := []process.StartOp{}
 		if *initLocalEtcd {
@@ -201,25 +196,19 @@ func startServices() error {
 		}
 		etcdLocal, err := StartLocalEtcdServer(opts...)
 		if err != nil {
-			fmt.Printf("\n\tstartServices-E-error startLocalEtcdServer  %s\n", err.Error())
 			return fmt.Errorf("starting local etcd server failed: %v", err)
 		}
 		services.etcdLocal = etcdLocal
 		etcdUrls = &etcdLocal.ClientAddrs
 	}
-	fmt.Printf("\n\tstartServices: etcd started\n")
 	objStore, err := GetEtcdClientBasic(*etcdUrls)
 	if err != nil {
-		fmt.Printf("\n\tstartServices-E-error init object store  %s\n", err.Error())
 		return fmt.Errorf("Failed to initialize Object Store, %v", err)
 	}
-	fmt.Printf("\n\tstartSErvices created etcd client are we connected?\n")
 	err = objStore.CheckConnected(50, 20*time.Millisecond)
 	if err != nil {
-		fmt.Printf("\n\tstartServices-E-error connect to etcd s %s\n", err.Error())
 		return fmt.Errorf("Failed to connect to etcd servers, %v", err)
 	}
-	fmt.Printf("\n\tstartServices: etcd connected...\n")
 	// We might need to upgrade the stored objects
 	if !*skipVersionCheck {
 		// First off - check version of the objectStore we are running
@@ -228,17 +217,14 @@ func startServices() error {
 			err = edgeproto.UpgradeToLatest(version, objStore)
 
 			if err != nil {
-				fmt.Printf("\n\tstartServices-E-error upgrade to latest  %s\n", err.Error())
 				return fmt.Errorf("Failed to ugprade data model: %v", err)
 			}
 		} else if err != nil {
-			fmt.Printf("\n\tstartServices-version mismatch  %s\n", err.Error())
 			return fmt.Errorf("Running version doesn't match the version of etcd, %v", err)
 		}
 	}
 	lis, err := net.Listen("tcp", *apiAddr)
 	if err != nil {
-		fmt.Printf("\n\tstartServices listen failed:  %s\n", err)
 		return fmt.Errorf("Failed to listen on address %s, %v", *apiAddr, err)
 	}
 	services.listeners = append(services.listeners, lis)
@@ -257,7 +243,6 @@ func startServices() error {
 
 	err = settingsApi.initDefaults(ctx)
 	if err != nil {
-		fmt.Printf("\n\tstartServices-version init settings failed  %s\n", err.Error())
 		return fmt.Errorf("Failed to init settings, %v", err)
 	}
 	// cleanup thread must start after settings are loaded


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5433 Detect deleted platform (infra) flavors.

### Description
Add periodic tast to crm to GatherCloudletInfo, and after the subsequent CloudleInfo.Update(), fixup any flavors that were deleted while in use. Emit events for updated, deleted, or added infra flavors. Emit Alert on any flavors deleted while in use. 
Clear these alerts if 1) the flavor is recreated by the op, or 2) all instances using the deprecated flavor are deleted. 

