### PR TITLE
EDGECLOUD-5653: US Controller keeps crashing during regression run

### DIFF
--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -534,7 +534,10 @@ func (p *Crm) StopLocal() {
 }
 
 func (p *Crm) Wait() error {
-	return p.cmd.Wait()
+	if p.cmd != nil {
+		return p.cmd.Wait()
+	}
+	return nil
 }
 
 func (p *Crm) GetExeName() string { return "crmserver" }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5653: US Controller keeps crashing during regression run
