### PR TITLE
EDGECLOUD-5623 DME rate limiting not working with Global apiname

### DIFF
--- a/cloudcommon/ratelimit/apiendpoint-limiter.go
+++ b/cloudcommon/ratelimit/apiendpoint-limiter.go
@@ -335,6 +335,27 @@ func (a *apiEndpointLimiter) doesLimitByAllRequests() bool {
 	return a.apiEndpointRateLimitSettings.AllRequestsRateLimitSettings != nil
 }
 
+func (a *apiEndpointLimiter) isEmpty() bool {
+	settings := a.apiEndpointRateLimitSettings
+	if settings == nil {
+		return true
+	}
+	numSettings := 0
+	if settings.AllRequestsRateLimitSettings != nil {
+		numSettings += len(settings.AllRequestsRateLimitSettings.FlowSettings)
+		numSettings += len(settings.AllRequestsRateLimitSettings.MaxReqsSettings)
+	}
+	if settings.PerIpRateLimitSettings != nil {
+		numSettings += len(settings.PerIpRateLimitSettings.FlowSettings)
+		numSettings += len(settings.PerIpRateLimitSettings.MaxReqsSettings)
+	}
+	if settings.PerUserRateLimitSettings != nil {
+		numSettings += len(settings.PerUserRateLimitSettings.FlowSettings)
+		numSettings += len(settings.PerUserRateLimitSettings.MaxReqsSettings)
+	}
+	return numSettings == 0
+}
+
 // Helper function that creates slice of Limiters to be passed into NewCompositeLimiter
 func getLimitersFromRateLimitSettings(settings *edgeproto.RateLimitSettings) []Limiter {
 	limiters := make([]Limiter, 0)

--- a/cloudcommon/ratelimit/conversion.go
+++ b/cloudcommon/ratelimit/conversion.go
@@ -1,0 +1,74 @@
+package ratelimit
+
+import "github.com/mobiledgex/edge-cloud/edgeproto"
+
+// Convert db-based objects to user-based objects
+func DbToUserSettings(fsettings []*edgeproto.FlowRateLimitSettings, msettings []*edgeproto.MaxReqsRateLimitSettings) []*edgeproto.RateLimitSettings {
+	settingsmap := make(map[edgeproto.RateLimitSettingsKey]*edgeproto.RateLimitSettings)
+
+	for _, fsetting := range fsettings {
+		key := fsetting.Key.RateLimitKey
+		ratelimitsetting, ok := settingsmap[key]
+		if !ok || ratelimitsetting == nil {
+			ratelimitsetting = &edgeproto.RateLimitSettings{
+				Key: key,
+			}
+			settingsmap[key] = ratelimitsetting
+		}
+		if ratelimitsetting.FlowSettings == nil {
+			ratelimitsetting.FlowSettings = make(map[string]*edgeproto.FlowSettings)
+		}
+		ratelimitsetting.FlowSettings[fsetting.Key.FlowSettingsName] = &fsetting.Settings
+	}
+
+	for _, msetting := range msettings {
+		key := msetting.Key.RateLimitKey
+		ratelimitsetting, ok := settingsmap[key]
+		if !ok || ratelimitsetting == nil {
+			ratelimitsetting = &edgeproto.RateLimitSettings{
+				Key: key,
+			}
+			settingsmap[key] = ratelimitsetting
+		}
+		if ratelimitsetting.MaxReqsSettings == nil {
+			ratelimitsetting.MaxReqsSettings = make(map[string]*edgeproto.MaxReqsSettings)
+		}
+		ratelimitsetting.MaxReqsSettings[msetting.Key.MaxReqsSettingsName] = &msetting.Settings
+	}
+
+	ratelimitsettings := make([]*edgeproto.RateLimitSettings, 0)
+	for _, settings := range settingsmap {
+		ratelimitsettings = append(ratelimitsettings, settings)
+	}
+	return ratelimitsettings
+}
+
+// Convert user-based objects to db-based objects
+func UserToDbSettings(settings []*edgeproto.RateLimitSettings) ([]*edgeproto.FlowRateLimitSettings, []*edgeproto.MaxReqsRateLimitSettings) {
+	fsettings := []*edgeproto.FlowRateLimitSettings{}
+	msettings := []*edgeproto.MaxReqsRateLimitSettings{}
+
+	for _, s := range settings {
+		for name, flowSettings := range s.FlowSettings {
+			frset := edgeproto.FlowRateLimitSettings{
+				Key: edgeproto.FlowRateLimitSettingsKey{
+					FlowSettingsName: name,
+					RateLimitKey:     s.Key,
+				},
+				Settings: *flowSettings,
+			}
+			fsettings = append(fsettings, &frset)
+		}
+		for name, maxSettings := range s.MaxReqsSettings {
+			mrset := edgeproto.MaxReqsRateLimitSettings{
+				Key: edgeproto.MaxReqsRateLimitSettingsKey{
+					MaxReqsSettingsName: name,
+					RateLimitKey:        s.Key,
+				},
+				Settings: *maxSettings,
+			}
+			msettings = append(msettings, &mrset)
+		}
+	}
+	return fsettings, msettings
+}

--- a/cloudcommon/ratelimit/conversion_test.go
+++ b/cloudcommon/ratelimit/conversion_test.go
@@ -1,0 +1,202 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/stretchr/testify/require"
+)
+
+var flowSettings0 = edgeproto.FlowSettings{
+	FlowAlgorithm: edgeproto.FlowRateLimitAlgorithm_TOKEN_BUCKET_ALGORITHM,
+	ReqsPerSecond: 25000,
+	BurstSize:     250,
+}
+
+var flowSettings1 = edgeproto.FlowSettings{
+	FlowAlgorithm: edgeproto.FlowRateLimitAlgorithm_TOKEN_BUCKET_ALGORITHM,
+	ReqsPerSecond: 5000,
+	BurstSize:     50,
+}
+
+var flowSettings2 = edgeproto.FlowSettings{
+	FlowAlgorithm: edgeproto.FlowRateLimitAlgorithm_TOKEN_BUCKET_ALGORITHM,
+	ReqsPerSecond: 10000,
+	BurstSize:     1000,
+}
+
+var flowSettings3 = edgeproto.FlowSettings{
+	FlowAlgorithm: edgeproto.FlowRateLimitAlgorithm_LEAKY_BUCKET_ALGORITHM,
+	ReqsPerSecond: 20000,
+	BurstSize:     2000,
+}
+
+var flowSettings4 = edgeproto.FlowSettings{
+	FlowAlgorithm: edgeproto.FlowRateLimitAlgorithm_TOKEN_BUCKET_ALGORITHM,
+	ReqsPerSecond: 1000,
+	BurstSize:     25,
+}
+
+var maxSettings0 = edgeproto.MaxReqsSettings{
+	MaxReqsAlgorithm: edgeproto.MaxReqsRateLimitAlgorithm_FIXED_WINDOW_ALGORITHM,
+	MaxRequests:      10000,
+	Interval:         edgeproto.Duration(time.Second),
+}
+
+var maxSettings1 = edgeproto.MaxReqsSettings{
+	MaxReqsAlgorithm: edgeproto.MaxReqsRateLimitAlgorithm_FIXED_WINDOW_ALGORITHM,
+	MaxRequests:      20000,
+	Interval:         edgeproto.Duration(time.Second),
+}
+
+// Create copies so global values will not be modified by tests.
+func newFlowSettingsX(ii int) *edgeproto.FlowSettings {
+	f := edgeproto.FlowSettings{}
+	switch ii {
+	case 0:
+		f = flowSettings0
+	case 1:
+		f = flowSettings1
+	case 2:
+		f = flowSettings2
+	case 3:
+		f = flowSettings3
+	case 4:
+		f = flowSettings4
+	}
+	return &f
+}
+
+// Create copies so global values will not be modified by tests.
+func newMaxSettingsX(ii int) *edgeproto.MaxReqsSettings {
+	m := edgeproto.MaxReqsSettings{}
+	switch ii {
+	case 0:
+		m = maxSettings0
+	case 1:
+		m = maxSettings1
+	}
+	return &m
+}
+
+var userSettings = []*edgeproto.RateLimitSettings{
+	&edgeproto.RateLimitSettings{
+		Key: edgeproto.RateLimitSettingsKey{
+			ApiEndpointType: edgeproto.ApiEndpointType_DME,
+			RateLimitTarget: edgeproto.RateLimitTarget_ALL_REQUESTS,
+			ApiName:         edgeproto.GlobalApiName,
+		},
+		FlowSettings: map[string]*edgeproto.FlowSettings{
+			"dmeglobalallreqs0": newFlowSettingsX(0),
+			"leakyallreqs3":     newFlowSettingsX(3),
+		},
+		MaxReqsSettings: map[string]*edgeproto.MaxReqsSettings{
+			"dmeglobalmax0": newMaxSettingsX(0),
+		},
+	},
+	&edgeproto.RateLimitSettings{
+		Key: edgeproto.RateLimitSettingsKey{
+			ApiEndpointType: edgeproto.ApiEndpointType_DME,
+			RateLimitTarget: edgeproto.RateLimitTarget_ALL_REQUESTS,
+			ApiName:         "VerifyLocation",
+		},
+		FlowSettings: map[string]*edgeproto.FlowSettings{
+			"verifylocalreqs1": newFlowSettingsX(1),
+		},
+	},
+	&edgeproto.RateLimitSettings{
+		Key: edgeproto.RateLimitSettingsKey{
+			ApiEndpointType: edgeproto.ApiEndpointType_DME,
+			RateLimitTarget: edgeproto.RateLimitTarget_PER_IP,
+			ApiName:         edgeproto.GlobalApiName,
+		},
+		FlowSettings: map[string]*edgeproto.FlowSettings{
+			"dmeglobalperip0": newFlowSettingsX(0),
+			"dmeglobalperip2": newFlowSettingsX(2),
+		},
+		MaxReqsSettings: map[string]*edgeproto.MaxReqsSettings{
+			"dmeglobalmax1": newMaxSettingsX(1),
+		},
+	},
+	&edgeproto.RateLimitSettings{
+		Key: edgeproto.RateLimitSettingsKey{
+			ApiEndpointType: edgeproto.ApiEndpointType_DME,
+			RateLimitTarget: edgeproto.RateLimitTarget_PER_IP,
+			ApiName:         "VerifyLocation",
+		},
+		FlowSettings: map[string]*edgeproto.FlowSettings{
+			"verifylocperip4": newFlowSettingsX(4),
+		},
+	},
+}
+
+var dbFlowSettings = []*edgeproto.FlowRateLimitSettings{
+	&edgeproto.FlowRateLimitSettings{
+		Key: edgeproto.FlowRateLimitSettingsKey{
+			FlowSettingsName: "dmeglobalallreqs0",
+			RateLimitKey:     userSettings[0].Key,
+		},
+		Settings: flowSettings0,
+	},
+	&edgeproto.FlowRateLimitSettings{
+		Key: edgeproto.FlowRateLimitSettingsKey{
+			FlowSettingsName: "leakyallreqs3",
+			RateLimitKey:     userSettings[0].Key,
+		},
+		Settings: flowSettings3,
+	},
+	&edgeproto.FlowRateLimitSettings{
+		Key: edgeproto.FlowRateLimitSettingsKey{
+			FlowSettingsName: "verifylocalreqs1",
+			RateLimitKey:     userSettings[1].Key,
+		},
+		Settings: flowSettings1,
+	},
+	&edgeproto.FlowRateLimitSettings{
+		Key: edgeproto.FlowRateLimitSettingsKey{
+			FlowSettingsName: "dmeglobalperip0",
+			RateLimitKey:     userSettings[2].Key,
+		},
+		Settings: flowSettings0,
+	},
+	&edgeproto.FlowRateLimitSettings{
+		Key: edgeproto.FlowRateLimitSettingsKey{
+			FlowSettingsName: "dmeglobalperip2",
+			RateLimitKey:     userSettings[2].Key,
+		},
+		Settings: flowSettings2,
+	},
+	&edgeproto.FlowRateLimitSettings{
+		Key: edgeproto.FlowRateLimitSettingsKey{
+			FlowSettingsName: "verifylocperip4",
+			RateLimitKey:     userSettings[3].Key,
+		},
+		Settings: flowSettings4,
+	},
+}
+
+var dbMaxSettings = []*edgeproto.MaxReqsRateLimitSettings{
+	&edgeproto.MaxReqsRateLimitSettings{
+		Key: edgeproto.MaxReqsRateLimitSettingsKey{
+			MaxReqsSettingsName: "dmeglobalmax0",
+			RateLimitKey:        userSettings[0].Key,
+		},
+		Settings: maxSettings0,
+	},
+	&edgeproto.MaxReqsRateLimitSettings{
+		Key: edgeproto.MaxReqsRateLimitSettingsKey{
+			MaxReqsSettingsName: "dmeglobalmax1",
+			RateLimitKey:        userSettings[2].Key,
+		},
+		Settings: maxSettings1,
+	},
+}
+
+func TestConversion(t *testing.T) {
+	dbf, dbm := UserToDbSettings(userSettings)
+	require.Equal(t, dbFlowSettings, dbf)
+	require.Equal(t, dbMaxSettings, dbm)
+	sets := DbToUserSettings(dbFlowSettings, dbMaxSettings)
+	require.Equal(t, userSettings, sets)
+}

--- a/cloudcommon/ratelimit/ratelimitmgr.go
+++ b/cloudcommon/ratelimit/ratelimitmgr.go
@@ -74,6 +74,9 @@ func (r *RateLimitManager) RemoveFlowRateLimitSettings(key edgeproto.FlowRateLim
 		return
 	}
 	limiter.removeFlowRateLimitSettings(key.RateLimitKey.RateLimitTarget, key.FlowSettingsName)
+	if limiter.isEmpty() {
+		delete(r.limitsPerApi, api)
+	}
 }
 
 // Update the maxreqs rate limit settings for API that use the rate limit settings associated with the specified RateLimitSettingsKey
@@ -100,14 +103,20 @@ func (r *RateLimitManager) RemoveMaxReqsRateLimitSettings(key edgeproto.MaxReqsR
 		return
 	}
 	limiter.removeMaxReqsRateLimitSettings(key.RateLimitKey.RateLimitTarget, key.MaxReqsSettingsName)
+	if limiter.isEmpty() {
+		delete(r.limitsPerApi, api)
+	}
 }
 
 // Remove FlowRateLimitSettings whose keys are not in the keys map
 func (r *RateLimitManager) PruneFlowRateLimitSettings(keys map[edgeproto.FlowRateLimitSettingsKey]struct{}) {
 	r.Lock()
 	defer r.Unlock()
-	for _, limiter := range r.limitsPerApi {
+	for api, limiter := range r.limitsPerApi {
 		limiter.pruneFlowRateLimitSettings(keys)
+		if limiter.isEmpty() {
+			delete(r.limitsPerApi, api)
+		}
 	}
 }
 
@@ -115,8 +124,11 @@ func (r *RateLimitManager) PruneFlowRateLimitSettings(keys map[edgeproto.FlowRat
 func (r *RateLimitManager) PruneMaxReqsRateLimitSettings(keys map[edgeproto.MaxReqsRateLimitSettingsKey]struct{}) {
 	r.Lock()
 	defer r.Unlock()
-	for _, limiter := range r.limitsPerApi {
+	for api, limiter := range r.limitsPerApi {
 		limiter.pruneMaxReqsRateLimitSettings(keys)
+		if limiter.isEmpty() {
+			delete(r.limitsPerApi, api)
+		}
 	}
 }
 

--- a/cloudcommon/ratelimit/ratelimitmgr_test.go
+++ b/cloudcommon/ratelimit/ratelimitmgr_test.go
@@ -1,0 +1,71 @@
+package ratelimit
+
+import (
+	"testing"
+
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/stretchr/testify/require"
+)
+
+func checkNumSettings(t *testing.T, lenFlowSettings, lenMaxSettings int, settings *edgeproto.RateLimitSettings) {
+	if lenFlowSettings == 0 && lenMaxSettings == 0 && settings == nil {
+		// this is ok
+		return
+	}
+	require.Equal(t, lenFlowSettings, len(settings.FlowSettings))
+	require.Equal(t, lenMaxSettings, len(settings.MaxReqsSettings))
+}
+
+func TestUpdates(t *testing.T) {
+	mgr := NewRateLimitManager(false, 100, 100)
+	// add settings
+	for _, fset := range dbFlowSettings {
+		mgr.UpdateFlowRateLimitSettings(fset)
+	}
+	for _, mset := range dbMaxSettings {
+		mgr.UpdateMaxReqsRateLimitSettings(mset)
+	}
+	// check that data was populated
+	require.NotNil(t, mgr.limitsPerApi)
+	require.Equal(t, 2, len(mgr.limitsPerApi))
+
+	global := mgr.limitsPerApi[edgeproto.GlobalApiName]
+	require.NotNil(t, global)
+	checkNumSettings(t, 2, 1, global.apiEndpointRateLimitSettings.AllRequestsRateLimitSettings)
+	checkNumSettings(t, 2, 1, global.apiEndpointRateLimitSettings.PerIpRateLimitSettings)
+	require.Nil(t, global.apiEndpointRateLimitSettings.PerUserRateLimitSettings)
+	require.Equal(t, 3, len(global.limitAllRequests.limiters))
+	require.Equal(t, 0, len(global.limitsPerIp))
+	require.Equal(t, 0, len(global.limitsPerUser))
+
+	verifyLoc := mgr.limitsPerApi["VerifyLocation"]
+	require.NotNil(t, verifyLoc)
+	checkNumSettings(t, 1, 0, verifyLoc.apiEndpointRateLimitSettings.AllRequestsRateLimitSettings)
+	checkNumSettings(t, 1, 0, verifyLoc.apiEndpointRateLimitSettings.PerIpRateLimitSettings)
+	require.Nil(t, verifyLoc.apiEndpointRateLimitSettings.PerUserRateLimitSettings)
+	require.Equal(t, 1, len(verifyLoc.limitAllRequests.limiters))
+	require.Equal(t, 0, len(verifyLoc.limitsPerIp))
+	require.Equal(t, 0, len(verifyLoc.limitsPerUser))
+
+	// remove flow settings
+	for _, fset := range dbFlowSettings {
+		mgr.RemoveFlowRateLimitSettings(fset.Key)
+	}
+	global = mgr.limitsPerApi[edgeproto.GlobalApiName]
+	require.NotNil(t, global)
+	checkNumSettings(t, 0, 1, global.apiEndpointRateLimitSettings.AllRequestsRateLimitSettings)
+	checkNumSettings(t, 0, 1, global.apiEndpointRateLimitSettings.PerIpRateLimitSettings)
+	require.Nil(t, global.apiEndpointRateLimitSettings.PerUserRateLimitSettings)
+
+	require.Equal(t, 1, len(global.limitAllRequests.limiters))
+	require.Equal(t, 0, len(global.limitsPerIp))
+	require.Equal(t, 0, len(global.limitsPerUser))
+	verifyLoc = mgr.limitsPerApi["VerifyLocation"]
+	require.Nil(t, verifyLoc)
+
+	// remove max settings
+	for _, mset := range dbMaxSettings {
+		mgr.RemoveMaxReqsRateLimitSettings(mset.Key)
+	}
+	require.Equal(t, 0, len(mgr.limitsPerApi))
+}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5623 DME rate limiting not working with Global apiname

### Description

Rate limiting was not working because a rate limiter for "RegisterClient" was added and then removed, but the RateLimitMgr still had an apiEndpointRateLimiter for "RegisterClient" because the removal code was not cleaning up an apiEndpointRateLimit that had no settings left. This caused the RateLimitMgr to limit RegisterClient requests against an empty apiEndpointRateLimiter instead of the default global one.

I moved the conversion function from controller to the ratelimit package, and added the reverse conversion function. And added a bunch of unit tests to make sure the conversion from User to DB structs was not a problem. Added a unit test to make sure removal of settings from the RateLimitMgr cleaned up properly.