### PR TITLE
EDGECLOUD-5656 Report generation fails with error "Missing logo"

### DIFF
--- a/docker/Dockerfile.mc
+++ b/docker/Dockerfile.mc
@@ -4,3 +4,4 @@ FROM $ALLINONE as allinone
 FROM gcr.io/distroless/base-debian10
 
 COPY --from=allinone /usr/local/bin/mc /usr/local/bin/mc
+COPY --from=allinone /MobiledgeX_Logo.png /MobiledgeX_Logo.png


### PR DESCRIPTION
Missed copying the logo from the full edge-cloud image into the MC one.
