### PR TITLE
EDGECLOUD-5609 ShowFlavorsFor API Optional Arg to Filter By Operator

### DIFF
--- a/notify/dummy_notify.go
+++ b/notify/dummy_notify.go
@@ -295,7 +295,7 @@ func (s *DummyHandler) WaitForCloudletState(key *edgeproto.CloudletKey, state dm
 			}
 			lastState = cloudletInfo.State
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(30 * time.Millisecond)
 	}
 
 	return fmt.Errorf("Unable to get desired cloudletInfo state, actual state %s, desired state %s", lastState, state)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5609 ShowFlavorsFor API Optional Arg to Filter By Operator

### Description

Allows the input CloudletKey for ShowFlavorsForCloudlet to specify only the operator (or only the name) and gets flavors across all matching cloudlets. Previously the API only allowed a single cloudlet to be specified.