### PR TITLE
EDGECLOUD-5561 debug: appinstlatency request failing with deadline exceeded

### DIFF
--- a/cloudcommon/node/debugnode.go
+++ b/cloudcommon/node/debugnode.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -30,6 +31,7 @@ const (
 	DisableSampleLog     = "disable-sample-logging"
 	EnableSampleLog      = "enable-sample-logging"
 	DumpCloudletPools    = "dump-cloudlet-pools"
+	DumpStackTrace       = "dump-stack-trace"
 )
 
 type DebugNode struct {
@@ -82,6 +84,14 @@ func (s *DebugNode) Init(mgr *NodeMgr) {
 				return err.Error()
 			}
 			return string(out)
+		})
+	s.AddDebugFunc(DumpStackTrace,
+		func(ctx context.Context, req *edgeproto.DebugRequest) string {
+			buf := make([]byte, 8192)
+			runtime.Stack(buf, true)
+			// dump to log file in case notify-send is broken.
+			fmt.Println(string(buf))
+			return string(buf)
 		})
 }
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5561 appinstlatency request failing with deadline exceeded

### Description

The notify stream from DME to Controller seems to get stuck. I killed the DME to get a stack trace, and it looks like it's stuck because the send buffer is full. Unfortunately killing the DME was the only way to get a stack trace, and it cleans up the connection on the Controller side.

To debug this, I've added a debug command to dump a stack trace of all threads. Then when it happens again I can run this on both the DME and Controller side. This is not a fix, just a way to help debug.