### PR TITLE
Switch to debug images for component docker images

### DIFF
--- a/docker/Dockerfile.alertmgr-sidecar
+++ b/docker/Dockerfile.alertmgr-sidecar
@@ -1,6 +1,6 @@
 ARG ALLINONE=default
 FROM $ALLINONE as allinone
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian10:debug
 
 COPY --from=allinone /usr/local/bin/alertmgr-sidecar /usr/local/bin/alertmgr-sidecar

--- a/docker/Dockerfile.autoprov
+++ b/docker/Dockerfile.autoprov
@@ -1,6 +1,6 @@
 ARG ALLINONE=default
 FROM $ALLINONE as allinone
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian10:debug
 
 COPY --from=allinone /usr/local/bin/autoprov /usr/local/bin/autoprov

--- a/docker/Dockerfile.cluster-svc
+++ b/docker/Dockerfile.cluster-svc
@@ -1,6 +1,6 @@
 ARG ALLINONE=default
 FROM $ALLINONE as allinone
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian10:debug
 
 COPY --from=allinone /usr/local/bin/cluster-svc /usr/local/bin/cluster-svc

--- a/docker/Dockerfile.dme
+++ b/docker/Dockerfile.dme
@@ -1,7 +1,7 @@
 ARG ALLINONE=default
 FROM $ALLINONE as allinone
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian10:debug
 
 COPY --from=allinone /usr/local/bin/dme-server /usr/local/bin/dme-server
 COPY --from=allinone \

--- a/docker/Dockerfile.edgeturn
+++ b/docker/Dockerfile.edgeturn
@@ -1,6 +1,6 @@
 ARG ALLINONE=default
 FROM $ALLINONE as allinone
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian10:debug
 
 COPY --from=allinone /usr/local/bin/edgeturn /usr/local/bin/edgeturn

--- a/docker/Dockerfile.mc
+++ b/docker/Dockerfile.mc
@@ -1,7 +1,7 @@
 ARG ALLINONE=default
 FROM $ALLINONE as allinone
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian10:debug
 
 COPY --from=allinone /usr/local/bin/mc /usr/local/bin/mc
 COPY --from=allinone /MobiledgeX_Logo.png /MobiledgeX_Logo.png

--- a/docker/Dockerfile.notifyroot
+++ b/docker/Dockerfile.notifyroot
@@ -1,6 +1,6 @@
 ARG ALLINONE=default
 FROM $ALLINONE as allinone
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian10:debug
 
 COPY --from=allinone /usr/local/bin/notifyroot /usr/local/bin/notifyroot


### PR DESCRIPTION
Pure distroless images do not include a shell, making it difficult to debug
live issues.  Switching to "debug" image which include busybox.
https://github.com/GoogleContainerTools/distroless#debug-images

Note that `kubectl exec` will need to use plain `sh` instead of `bash`:
```
kubectl exec -it dme-597cdcc4bc-hkfm6 -- sh
```