### PR TITLE
EDGECLOUD-5487 EDGECLOUD-5481 EDGECLOUD-5480 ratelimit err msg fixes

### DIFF
--- a/controller/ratelimitsettings_api.go
+++ b/controller/ratelimitsettings_api.go
@@ -173,7 +173,7 @@ func (r *RateLimitSettingsApi) UpdateFlowRateLimitSettings(ctx context.Context, 
 	cur := edgeproto.FlowRateLimitSettings{}
 	err = r.sync.ApplySTMWait(ctx, func(stm concurrency.STM) error {
 		if !r.flowstore.STMGet(stm, &in.Key, &cur) {
-			return in.Key.RateLimitKey.NotFoundError()
+			return in.Key.NotFoundError()
 		}
 
 		old := cur

--- a/d-match-engine/dme-proto/app-client.pb.go
+++ b/d-match-engine/dme-proto/app-client.pb.go
@@ -7424,7 +7424,7 @@ func (e *IDTypes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid IDTypes value %q", str)
 	}
 	*e = IDTypes(val)
 	return nil
@@ -7450,7 +7450,7 @@ func (e *IDTypes) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid IDTypes value %q", str)
 		}
 		*e = IDTypes(val)
 		return nil
@@ -7458,10 +7458,14 @@ func (e *IDTypes) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := IDTypes_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid IDTypes value %d", val)
+		}
 		*e = IDTypes(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid IDTypes value %v", b)
 }
 
 /*
@@ -7519,7 +7523,7 @@ func (e *ReplyStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid ReplyStatus value %q", str)
 	}
 	*e = ReplyStatus(val)
 	return nil
@@ -7550,7 +7554,7 @@ func (e *ReplyStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid ReplyStatus value %q", str)
 		}
 		*e = ReplyStatus(val)
 		return nil
@@ -7558,10 +7562,14 @@ func (e *ReplyStatus) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := ReplyStatus_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid ReplyStatus value %d", val)
+		}
 		*e = ReplyStatus(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid ReplyStatus value %v", b)
 }
 
 /*
@@ -7622,7 +7630,7 @@ func (e *FindCloudletReply_FindStatus) UnmarshalYAML(unmarshal func(interface{})
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid FindCloudletReply_FindStatus value %q", str)
 	}
 	*e = FindCloudletReply_FindStatus(val)
 	return nil
@@ -7653,7 +7661,7 @@ func (e *FindCloudletReply_FindStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid FindCloudletReply_FindStatus value %q", str)
 		}
 		*e = FindCloudletReply_FindStatus(val)
 		return nil
@@ -7661,10 +7669,14 @@ func (e *FindCloudletReply_FindStatus) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := FindCloudletReply_FindStatus_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid FindCloudletReply_FindStatus value %d", val)
+		}
 		*e = FindCloudletReply_FindStatus(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid FindCloudletReply_FindStatus value %v", b)
 }
 
 /*
@@ -7721,7 +7733,7 @@ func (e *VerifyLocationReply_TowerStatus) UnmarshalYAML(unmarshal func(interface
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %q", str)
 	}
 	*e = VerifyLocationReply_TowerStatus(val)
 	return nil
@@ -7747,7 +7759,7 @@ func (e *VerifyLocationReply_TowerStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %q", str)
 		}
 		*e = VerifyLocationReply_TowerStatus(val)
 		return nil
@@ -7755,10 +7767,14 @@ func (e *VerifyLocationReply_TowerStatus) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := VerifyLocationReply_TowerStatus_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %d", val)
+		}
 		*e = VerifyLocationReply_TowerStatus(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %v", b)
 }
 
 /*
@@ -7841,7 +7857,7 @@ func (e *VerifyLocationReply_GPSLocationStatus) UnmarshalYAML(unmarshal func(int
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %q", str)
 	}
 	*e = VerifyLocationReply_GPSLocationStatus(val)
 	return nil
@@ -7872,7 +7888,7 @@ func (e *VerifyLocationReply_GPSLocationStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %q", str)
 		}
 		*e = VerifyLocationReply_GPSLocationStatus(val)
 		return nil
@@ -7880,10 +7896,14 @@ func (e *VerifyLocationReply_GPSLocationStatus) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := VerifyLocationReply_GPSLocationStatus_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %d", val)
+		}
 		*e = VerifyLocationReply_GPSLocationStatus(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %v", b)
 }
 
 /*
@@ -7944,7 +7964,7 @@ func (e *GetLocationReply_LocStatus) UnmarshalYAML(unmarshal func(interface{}) e
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid GetLocationReply_LocStatus value %q", str)
 	}
 	*e = GetLocationReply_LocStatus(val)
 	return nil
@@ -7975,7 +7995,7 @@ func (e *GetLocationReply_LocStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid GetLocationReply_LocStatus value %q", str)
 		}
 		*e = GetLocationReply_LocStatus(val)
 		return nil
@@ -7983,10 +8003,14 @@ func (e *GetLocationReply_LocStatus) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := GetLocationReply_LocStatus_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid GetLocationReply_LocStatus value %d", val)
+		}
 		*e = GetLocationReply_LocStatus(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid GetLocationReply_LocStatus value %v", b)
 }
 
 /*
@@ -8047,7 +8071,7 @@ func (e *AppInstListReply_AIStatus) UnmarshalYAML(unmarshal func(interface{}) er
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid AppInstListReply_AIStatus value %q", str)
 	}
 	*e = AppInstListReply_AIStatus(val)
 	return nil
@@ -8078,7 +8102,7 @@ func (e *AppInstListReply_AIStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid AppInstListReply_AIStatus value %q", str)
 		}
 		*e = AppInstListReply_AIStatus(val)
 		return nil
@@ -8086,10 +8110,14 @@ func (e *AppInstListReply_AIStatus) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := AppInstListReply_AIStatus_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid AppInstListReply_AIStatus value %d", val)
+		}
 		*e = AppInstListReply_AIStatus(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid AppInstListReply_AIStatus value %v", b)
 }
 
 /*
@@ -8150,7 +8178,7 @@ func (e *FqdnListReply_FLStatus) UnmarshalYAML(unmarshal func(interface{}) error
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid FqdnListReply_FLStatus value %q", str)
 	}
 	*e = FqdnListReply_FLStatus(val)
 	return nil
@@ -8181,7 +8209,7 @@ func (e *FqdnListReply_FLStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid FqdnListReply_FLStatus value %q", str)
 		}
 		*e = FqdnListReply_FLStatus(val)
 		return nil
@@ -8189,10 +8217,14 @@ func (e *FqdnListReply_FLStatus) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := FqdnListReply_FLStatus_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid FqdnListReply_FLStatus value %d", val)
+		}
 		*e = FqdnListReply_FLStatus(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid FqdnListReply_FLStatus value %v", b)
 }
 
 /*
@@ -8253,7 +8285,7 @@ func (e *AppOfficialFqdnReply_AOFStatus) UnmarshalYAML(unmarshal func(interface{
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %q", str)
 	}
 	*e = AppOfficialFqdnReply_AOFStatus(val)
 	return nil
@@ -8284,7 +8316,7 @@ func (e *AppOfficialFqdnReply_AOFStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %q", str)
 		}
 		*e = AppOfficialFqdnReply_AOFStatus(val)
 		return nil
@@ -8292,10 +8324,14 @@ func (e *AppOfficialFqdnReply_AOFStatus) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := AppOfficialFqdnReply_AOFStatus_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %d", val)
+		}
 		*e = AppOfficialFqdnReply_AOFStatus(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %v", b)
 }
 
 /*
@@ -8356,7 +8392,7 @@ func (e *DynamicLocGroupRequest_DlgCommType) UnmarshalYAML(unmarshal func(interf
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %q", str)
 	}
 	*e = DynamicLocGroupRequest_DlgCommType(val)
 	return nil
@@ -8387,7 +8423,7 @@ func (e *DynamicLocGroupRequest_DlgCommType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %q", str)
 		}
 		*e = DynamicLocGroupRequest_DlgCommType(val)
 		return nil
@@ -8395,10 +8431,14 @@ func (e *DynamicLocGroupRequest_DlgCommType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := DynamicLocGroupRequest_DlgCommType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %d", val)
+		}
 		*e = DynamicLocGroupRequest_DlgCommType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %v", b)
 }
 
 /*
@@ -8474,7 +8514,7 @@ func (e *ClientEdgeEvent_ClientEventType) UnmarshalYAML(unmarshal func(interface
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %q", str)
 	}
 	*e = ClientEdgeEvent_ClientEventType(val)
 	return nil
@@ -8505,7 +8545,7 @@ func (e *ClientEdgeEvent_ClientEventType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %q", str)
 		}
 		*e = ClientEdgeEvent_ClientEventType(val)
 		return nil
@@ -8513,10 +8553,14 @@ func (e *ClientEdgeEvent_ClientEventType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := ClientEdgeEvent_ClientEventType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %d", val)
+		}
 		*e = ClientEdgeEvent_ClientEventType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %v", b)
 }
 
 /*
@@ -8607,7 +8651,7 @@ func (e *ServerEdgeEvent_ServerEventType) UnmarshalYAML(unmarshal func(interface
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %q", str)
 	}
 	*e = ServerEdgeEvent_ServerEventType(val)
 	return nil
@@ -8638,7 +8682,7 @@ func (e *ServerEdgeEvent_ServerEventType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %q", str)
 		}
 		*e = ServerEdgeEvent_ServerEventType(val)
 		return nil
@@ -8646,10 +8690,14 @@ func (e *ServerEdgeEvent_ServerEventType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := ServerEdgeEvent_ServerEventType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %d", val)
+		}
 		*e = ServerEdgeEvent_ServerEventType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %v", b)
 }
 
 /*

--- a/d-match-engine/dme-proto/appcommon.pb.go
+++ b/d-match-engine/dme-proto/appcommon.pb.go
@@ -790,7 +790,7 @@ func (e *LProto) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid LProto value %q", str)
 	}
 	*e = LProto(val)
 	return nil
@@ -821,7 +821,7 @@ func (e *LProto) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid LProto value %q", str)
 		}
 		*e = LProto(val)
 		return nil
@@ -829,10 +829,14 @@ func (e *LProto) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := LProto_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid LProto value %d", val)
+		}
 		*e = LProto(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid LProto value %v", b)
 }
 
 /*
@@ -903,7 +907,7 @@ func (e *HealthCheck) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid HealthCheck value %q", str)
 	}
 	*e = HealthCheck(val)
 	return nil
@@ -934,7 +938,7 @@ func (e *HealthCheck) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid HealthCheck value %q", str)
 		}
 		*e = HealthCheck(val)
 		return nil
@@ -942,10 +946,14 @@ func (e *HealthCheck) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := HealthCheck_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid HealthCheck value %d", val)
+		}
 		*e = HealthCheck(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid HealthCheck value %v", b)
 }
 
 /*
@@ -1031,7 +1039,7 @@ func (e *CloudletState) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid CloudletState value %q", str)
 	}
 	*e = CloudletState(val)
 	return nil
@@ -1062,7 +1070,7 @@ func (e *CloudletState) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid CloudletState value %q", str)
 		}
 		*e = CloudletState(val)
 		return nil
@@ -1070,10 +1078,14 @@ func (e *CloudletState) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := CloudletState_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid CloudletState value %d", val)
+		}
 		*e = CloudletState(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid CloudletState value %v", b)
 }
 
 /*
@@ -1170,7 +1182,7 @@ func (e *MaintenanceState) UnmarshalYAML(unmarshal func(interface{}) error) erro
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid MaintenanceState value %q", str)
 	}
 	*e = MaintenanceState(val)
 	return nil
@@ -1196,7 +1208,7 @@ func (e *MaintenanceState) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid MaintenanceState value %q", str)
 		}
 		*e = MaintenanceState(val)
 		return nil
@@ -1204,10 +1216,14 @@ func (e *MaintenanceState) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := MaintenanceState_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid MaintenanceState value %d", val)
+		}
 		*e = MaintenanceState(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid MaintenanceState value %v", b)
 }
 
 /*

--- a/d-match-engine/dme-proto/dynamic-location-group.pb.go
+++ b/d-match-engine/dme-proto/dynamic-location-group.pb.go
@@ -505,7 +505,7 @@ func (e *DlgMessage_DlgAck) UnmarshalYAML(unmarshal func(interface{}) error) err
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid DlgMessage_DlgAck value %q", str)
 	}
 	*e = DlgMessage_DlgAck(val)
 	return nil
@@ -536,7 +536,7 @@ func (e *DlgMessage_DlgAck) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid DlgMessage_DlgAck value %q", str)
 		}
 		*e = DlgMessage_DlgAck(val)
 		return nil
@@ -544,10 +544,14 @@ func (e *DlgMessage_DlgAck) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := DlgMessage_DlgAck_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid DlgMessage_DlgAck value %d", val)
+		}
 		*e = DlgMessage_DlgAck(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid DlgMessage_DlgAck value %v", b)
 }
 
 /*

--- a/edgeproto/app.pb.go
+++ b/edgeproto/app.pb.go
@@ -4131,7 +4131,7 @@ func (e *ImageType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid ImageType value %q", str)
 	}
 	*e = ImageType(val)
 	return nil
@@ -4162,7 +4162,7 @@ func (e *ImageType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid ImageType value %q", str)
 		}
 		*e = ImageType(val)
 		return nil
@@ -4170,10 +4170,14 @@ func (e *ImageType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := ImageType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid ImageType value %d", val)
+		}
 		*e = ImageType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid ImageType value %v", b)
 }
 
 /*
@@ -4249,7 +4253,7 @@ func (e *VmAppOsType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid VmAppOsType value %q", str)
 	}
 	*e = VmAppOsType(val)
 	return nil
@@ -4280,7 +4284,7 @@ func (e *VmAppOsType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid VmAppOsType value %q", str)
 		}
 		*e = VmAppOsType(val)
 		return nil
@@ -4288,10 +4292,14 @@ func (e *VmAppOsType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := VmAppOsType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid VmAppOsType value %d", val)
+		}
 		*e = VmAppOsType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid VmAppOsType value %v", b)
 }
 
 /*
@@ -4343,7 +4351,7 @@ func (e *DeleteType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid DeleteType value %q", str)
 	}
 	*e = DeleteType(val)
 	return nil
@@ -4369,7 +4377,7 @@ func (e *DeleteType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid DeleteType value %q", str)
 		}
 		*e = DeleteType(val)
 		return nil
@@ -4377,10 +4385,14 @@ func (e *DeleteType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := DeleteType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid DeleteType value %d", val)
+		}
 		*e = DeleteType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid DeleteType value %v", b)
 }
 
 /*
@@ -4438,7 +4450,7 @@ func (e *AccessType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid AccessType value %q", str)
 	}
 	*e = AccessType(val)
 	return nil
@@ -4469,7 +4481,7 @@ func (e *AccessType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid AccessType value %q", str)
 		}
 		*e = AccessType(val)
 		return nil
@@ -4477,10 +4489,14 @@ func (e *AccessType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := AccessType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid AccessType value %d", val)
+		}
 		*e = AccessType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid AccessType value %v", b)
 }
 
 /*

--- a/edgeproto/appinst.pb.go
+++ b/edgeproto/appinst.pb.go
@@ -5697,7 +5697,7 @@ func (e *PowerState) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid PowerState value %q", str)
 	}
 	*e = PowerState(val)
 	return nil
@@ -5723,7 +5723,7 @@ func (e *PowerState) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid PowerState value %q", str)
 		}
 		*e = PowerState(val)
 		return nil
@@ -5731,10 +5731,14 @@ func (e *PowerState) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := PowerState_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid PowerState value %d", val)
+		}
 		*e = PowerState(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid PowerState value %v", b)
 }
 
 /*

--- a/edgeproto/cloudlet.pb.go
+++ b/edgeproto/cloudlet.pb.go
@@ -12752,7 +12752,7 @@ func (e *PlatformType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid PlatformType value %q", str)
 	}
 	*e = PlatformType(val)
 	return nil
@@ -12783,7 +12783,7 @@ func (e *PlatformType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid PlatformType value %q", str)
 		}
 		*e = PlatformType(val)
 		return nil
@@ -12791,10 +12791,14 @@ func (e *PlatformType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := PlatformType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid PlatformType value %d", val)
+		}
 		*e = PlatformType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid PlatformType value %v", b)
 }
 
 /*
@@ -12846,7 +12850,7 @@ func (e *InfraApiAccess) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid InfraApiAccess value %q", str)
 	}
 	*e = InfraApiAccess(val)
 	return nil
@@ -12872,7 +12876,7 @@ func (e *InfraApiAccess) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid InfraApiAccess value %q", str)
 		}
 		*e = InfraApiAccess(val)
 		return nil
@@ -12880,10 +12884,14 @@ func (e *InfraApiAccess) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := InfraApiAccess_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid InfraApiAccess value %d", val)
+		}
 		*e = InfraApiAccess(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid InfraApiAccess value %v", b)
 }
 
 /*
@@ -12937,7 +12945,7 @@ func (e *OSType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid OSType value %q", str)
 	}
 	*e = OSType(val)
 	return nil
@@ -12963,7 +12971,7 @@ func (e *OSType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid OSType value %q", str)
 		}
 		*e = OSType(val)
 		return nil
@@ -12971,10 +12979,14 @@ func (e *OSType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := OSType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid OSType value %d", val)
+		}
 		*e = OSType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid OSType value %v", b)
 }
 
 /*
@@ -13033,7 +13045,7 @@ func (e *ReportSchedule) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid ReportSchedule value %q", str)
 	}
 	*e = ReportSchedule(val)
 	return nil
@@ -13059,7 +13071,7 @@ func (e *ReportSchedule) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid ReportSchedule value %q", str)
 		}
 		*e = ReportSchedule(val)
 		return nil
@@ -13067,10 +13079,14 @@ func (e *ReportSchedule) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := ReportSchedule_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid ReportSchedule value %d", val)
+		}
 		*e = ReportSchedule(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid ReportSchedule value %v", b)
 }
 
 /*

--- a/edgeproto/common.pb.go
+++ b/edgeproto/common.pb.go
@@ -5,7 +5,6 @@ package edgeproto
 
 import (
 	"encoding/json"
-	"errors"
 	fmt "fmt"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
@@ -580,7 +579,7 @@ func (e *Liveness) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid Liveness value %q", str)
 	}
 	*e = Liveness(val)
 	return nil
@@ -611,7 +610,7 @@ func (e *Liveness) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid Liveness value %q", str)
 		}
 		*e = Liveness(val)
 		return nil
@@ -619,10 +618,14 @@ func (e *Liveness) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := Liveness_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid Liveness value %d", val)
+		}
 		*e = Liveness(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid Liveness value %v", b)
 }
 
 /*
@@ -683,7 +686,7 @@ func (e *IpSupport) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid IpSupport value %q", str)
 	}
 	*e = IpSupport(val)
 	return nil
@@ -714,7 +717,7 @@ func (e *IpSupport) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid IpSupport value %q", str)
 		}
 		*e = IpSupport(val)
 		return nil
@@ -722,10 +725,14 @@ func (e *IpSupport) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := IpSupport_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid IpSupport value %d", val)
+		}
 		*e = IpSupport(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid IpSupport value %v", b)
 }
 
 /*
@@ -786,7 +793,7 @@ func (e *IpAccess) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid IpAccess value %q", str)
 	}
 	*e = IpAccess(val)
 	return nil
@@ -817,7 +824,7 @@ func (e *IpAccess) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid IpAccess value %q", str)
 		}
 		*e = IpAccess(val)
 		return nil
@@ -825,10 +832,14 @@ func (e *IpAccess) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := IpAccess_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid IpAccess value %d", val)
+		}
 		*e = IpAccess(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid IpAccess value %v", b)
 }
 
 /*
@@ -950,7 +961,7 @@ func (e *TrackedState) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid TrackedState value %q", str)
 	}
 	*e = TrackedState(val)
 	return nil
@@ -976,7 +987,7 @@ func (e *TrackedState) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid TrackedState value %q", str)
 		}
 		*e = TrackedState(val)
 		return nil
@@ -984,10 +995,14 @@ func (e *TrackedState) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := TrackedState_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid TrackedState value %d", val)
+		}
 		*e = TrackedState(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid TrackedState value %v", b)
 }
 
 /*
@@ -1051,7 +1066,7 @@ func (e *CRMOverride) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid CRMOverride value %q", str)
 	}
 	*e = CRMOverride(val)
 	return nil
@@ -1077,7 +1092,7 @@ func (e *CRMOverride) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid CRMOverride value %q", str)
 		}
 		*e = CRMOverride(val)
 		return nil
@@ -1085,10 +1100,14 @@ func (e *CRMOverride) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := CRMOverride_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid CRMOverride value %d", val)
+		}
 		*e = CRMOverride(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid CRMOverride value %v", b)
 }
 
 /*

--- a/edgeproto/network.pb.go
+++ b/edgeproto/network.pb.go
@@ -1640,7 +1640,7 @@ func (e *NetworkConnectionType) UnmarshalYAML(unmarshal func(interface{}) error)
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid NetworkConnectionType value %q", str)
 	}
 	*e = NetworkConnectionType(val)
 	return nil
@@ -1666,7 +1666,7 @@ func (e *NetworkConnectionType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid NetworkConnectionType value %q", str)
 		}
 		*e = NetworkConnectionType(val)
 		return nil
@@ -1674,10 +1674,14 @@ func (e *NetworkConnectionType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := NetworkConnectionType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid NetworkConnectionType value %d", val)
+		}
 		*e = NetworkConnectionType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid NetworkConnectionType value %v", b)
 }
 
 /*

--- a/edgeproto/notice.pb.go
+++ b/edgeproto/notice.pb.go
@@ -518,7 +518,7 @@ func (e *NoticeAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid NoticeAction value %q", str)
 	}
 	*e = NoticeAction(val)
 	return nil
@@ -544,7 +544,7 @@ func (e *NoticeAction) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid NoticeAction value %q", str)
 		}
 		*e = NoticeAction(val)
 		return nil
@@ -552,10 +552,14 @@ func (e *NoticeAction) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := NoticeAction_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid NoticeAction value %d", val)
+		}
 		*e = NoticeAction(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid NoticeAction value %v", b)
 }
 
 /*

--- a/edgeproto/ratelimit.go
+++ b/edgeproto/ratelimit.go
@@ -19,7 +19,7 @@ func (f *FlowSettings) Validate() error {
 			}
 		}
 	} else {
-		return fmt.Errorf("Invalid FlowAlgorithm %v", f.FlowAlgorithm)
+		return fmt.Errorf("Invalid FlowAlgorithm")
 	}
 	return nil
 }
@@ -34,7 +34,7 @@ func (m *MaxReqsSettings) Validate() error {
 			return fmt.Errorf("Invalid Interval %d, must be greater than 0", m.Interval)
 		}
 	} else {
-		return fmt.Errorf("Invalid MaxReqsAlgorithm %v", m.MaxReqsAlgorithm)
+		return fmt.Errorf("Invalid MaxReqsAlgorithm")
 	}
 	return nil
 }

--- a/edgeproto/ratelimit.pb.go
+++ b/edgeproto/ratelimit.pb.go
@@ -3729,7 +3729,7 @@ func (e *ApiEndpointType) UnmarshalYAML(unmarshal func(interface{}) error) error
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid ApiEndpointType value %q", str)
 	}
 	*e = ApiEndpointType(val)
 	return nil
@@ -3755,7 +3755,7 @@ func (e *ApiEndpointType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid ApiEndpointType value %q", str)
 		}
 		*e = ApiEndpointType(val)
 		return nil
@@ -3763,10 +3763,14 @@ func (e *ApiEndpointType) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := ApiEndpointType_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid ApiEndpointType value %d", val)
+		}
 		*e = ApiEndpointType(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid ApiEndpointType value %v", b)
 }
 
 /*
@@ -3825,7 +3829,7 @@ func (e *RateLimitTarget) UnmarshalYAML(unmarshal func(interface{}) error) error
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid RateLimitTarget value %q", str)
 	}
 	*e = RateLimitTarget(val)
 	return nil
@@ -3851,7 +3855,7 @@ func (e *RateLimitTarget) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid RateLimitTarget value %q", str)
 		}
 		*e = RateLimitTarget(val)
 		return nil
@@ -3859,10 +3863,14 @@ func (e *RateLimitTarget) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := RateLimitTarget_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid RateLimitTarget value %d", val)
+		}
 		*e = RateLimitTarget(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid RateLimitTarget value %v", b)
 }
 
 /*
@@ -3916,7 +3924,7 @@ func (e *FlowRateLimitAlgorithm) UnmarshalYAML(unmarshal func(interface{}) error
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid FlowRateLimitAlgorithm value %q", str)
 	}
 	*e = FlowRateLimitAlgorithm(val)
 	return nil
@@ -3942,7 +3950,7 @@ func (e *FlowRateLimitAlgorithm) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid FlowRateLimitAlgorithm value %q", str)
 		}
 		*e = FlowRateLimitAlgorithm(val)
 		return nil
@@ -3950,10 +3958,14 @@ func (e *FlowRateLimitAlgorithm) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := FlowRateLimitAlgorithm_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid FlowRateLimitAlgorithm value %d", val)
+		}
 		*e = FlowRateLimitAlgorithm(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid FlowRateLimitAlgorithm value %v", b)
 }
 
 /*
@@ -4002,7 +4014,7 @@ func (e *MaxReqsRateLimitAlgorithm) UnmarshalYAML(unmarshal func(interface{}) er
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %q", str)
 	}
 	*e = MaxReqsRateLimitAlgorithm(val)
 	return nil
@@ -4028,7 +4040,7 @@ func (e *MaxReqsRateLimitAlgorithm) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %q", str)
 		}
 		*e = MaxReqsRateLimitAlgorithm(val)
 		return nil
@@ -4036,10 +4048,14 @@ func (e *MaxReqsRateLimitAlgorithm) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := MaxReqsRateLimitAlgorithm_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %d", val)
+		}
 		*e = MaxReqsRateLimitAlgorithm(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %v", b)
 }
 
 /*

--- a/edgeproto/restagtable.pb.go
+++ b/edgeproto/restagtable.pb.go
@@ -6,7 +6,6 @@ package edgeproto
 import (
 	context "context"
 	"encoding/json"
-	"errors"
 	fmt "fmt"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	_ "github.com/gogo/googleapis/google/api"
@@ -1571,7 +1570,7 @@ func (e *OptResNames) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid OptResNames value %q", str)
 	}
 	*e = OptResNames(val)
 	return nil
@@ -1597,7 +1596,7 @@ func (e *OptResNames) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid OptResNames value %q", str)
 		}
 		*e = OptResNames(val)
 		return nil
@@ -1605,10 +1604,14 @@ func (e *OptResNames) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := OptResNames_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid OptResNames value %d", val)
+		}
 		*e = OptResNames(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid OptResNames value %v", b)
 }
 
 /*

--- a/edgeproto/stream.pb.go
+++ b/edgeproto/stream.pb.go
@@ -6,7 +6,6 @@ package edgeproto
 import (
 	context "context"
 	"encoding/json"
-	"errors"
 	fmt "fmt"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	_ "github.com/gogo/googleapis/google/api"
@@ -1255,7 +1254,7 @@ func (e *StreamState) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid StreamState value %q", str)
 	}
 	*e = StreamState(val)
 	return nil
@@ -1286,7 +1285,7 @@ func (e *StreamState) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid StreamState value %q", str)
 		}
 		*e = StreamState(val)
 		return nil
@@ -1294,10 +1293,14 @@ func (e *StreamState) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := StreamState_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid StreamState value %d", val)
+		}
 		*e = StreamState(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid StreamState value %v", b)
 }
 
 /*

--- a/edgeproto/version.pb.go
+++ b/edgeproto/version.pb.go
@@ -5,7 +5,6 @@ package edgeproto
 
 import (
 	"encoding/json"
-	"errors"
 	fmt "fmt"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
@@ -334,7 +333,7 @@ func (e *VersionHash) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid VersionHash value %q", str)
 	}
 	*e = VersionHash(val)
 	return nil
@@ -365,7 +364,7 @@ func (e *VersionHash) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid VersionHash value %q", str)
 		}
 		*e = VersionHash(val)
 		return nil
@@ -373,10 +372,14 @@ func (e *VersionHash) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := VersionHash_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid VersionHash value %d", val)
+		}
 		*e = VersionHash(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid VersionHash value %v", b)
 }
 
 /*

--- a/edgeproto/vmpool.pb.go
+++ b/edgeproto/vmpool.pb.go
@@ -4062,7 +4062,7 @@ func (e *VMState) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid VMState value %q", str)
 	}
 	*e = VMState(val)
 	return nil
@@ -4093,7 +4093,7 @@ func (e *VMState) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid VMState value %q", str)
 		}
 		*e = VMState(val)
 		return nil
@@ -4101,10 +4101,14 @@ func (e *VMState) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := VMState_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid VMState value %d", val)
+		}
 		*e = VMState(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid VMState value %v", b)
 }
 
 /*
@@ -4165,7 +4169,7 @@ func (e *VMAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid VMAction value %q", str)
 	}
 	*e = VMAction(val)
 	return nil
@@ -4196,7 +4200,7 @@ func (e *VMAction) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid VMAction value %q", str)
 		}
 		*e = VMAction(val)
 		return nil
@@ -4204,10 +4208,14 @@ func (e *VMAction) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := VMAction_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid VMAction value %d", val)
+		}
 		*e = VMAction(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid VMAction value %v", b)
 }
 
 /*

--- a/log/debug.pb.go
+++ b/log/debug.pb.go
@@ -5,7 +5,6 @@ package log
 
 import (
 	"encoding/json"
-	"errors"
 	fmt "fmt"
 	proto "github.com/gogo/protobuf/proto"
 	"github.com/mobiledgex/edge-cloud/util"
@@ -188,7 +187,7 @@ func (e *DebugLevel) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid DebugLevel value %q", str)
 	}
 	*e = DebugLevel(val)
 	return nil
@@ -214,7 +213,7 @@ func (e *DebugLevel) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid DebugLevel value %q", str)
 		}
 		*e = DebugLevel(val)
 		return nil
@@ -222,10 +221,14 @@ func (e *DebugLevel) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := DebugLevel_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid DebugLevel value %d", val)
+		}
 		*e = DebugLevel(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid DebugLevel value %v", b)
 }
 
 /*

--- a/protoc-gen-gomex/mexgen/mex.go
+++ b/protoc-gen-gomex/mexgen/mex.go
@@ -224,7 +224,6 @@ func (m *mex) generateEnum(file *generator.FileDescriptor, desc *generator.EnumD
 		CommonPrefix: gensupport.GetEnumCommonPrefix(en),
 	}
 	m.enumTemplate.Execute(m.gen.Buffer, args)
-	m.importErrors = true
 	m.importStrconv = true
 	m.importJson = true
 	m.importUtil = true
@@ -275,7 +274,7 @@ func (e *{{.Name}}) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid {{.Name}} value %q", str)
 	}
 	*e = {{.Name}}(val)
 	return nil
@@ -310,7 +309,7 @@ func (e *{{.Name}}) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid {{.Name}} value %q", str)
 		}
 		*e = {{.Name}}(val)
 		return nil
@@ -318,10 +317,14 @@ func (e *{{.Name}}) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := {{.Name}}_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid {{.Name}} value %d", val)
+		}
 		*e = {{.Name}}(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid {{.Name}} value %v", b)
 }
 
 /*

--- a/testgen/sample.pb.go
+++ b/testgen/sample.pb.go
@@ -3158,7 +3158,7 @@ func (e *OuterEnum) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid OuterEnum value %q", str)
 	}
 	*e = OuterEnum(val)
 	return nil
@@ -3189,7 +3189,7 @@ func (e *OuterEnum) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid OuterEnum value %q", str)
 		}
 		*e = OuterEnum(val)
 		return nil
@@ -3197,10 +3197,14 @@ func (e *OuterEnum) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := OuterEnum_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid OuterEnum value %d", val)
+		}
 		*e = OuterEnum(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid OuterEnum value %v", b)
 }
 
 /*
@@ -3266,7 +3270,7 @@ func (e *TestGen_InnerEnum) UnmarshalYAML(unmarshal func(interface{}) error) err
 		}
 	}
 	if !ok {
-		return errors.New(fmt.Sprintf("No enum value for %s", str))
+		return fmt.Errorf("Invalid TestGen_InnerEnum value %q", str)
 	}
 	*e = TestGen_InnerEnum(val)
 	return nil
@@ -3297,7 +3301,7 @@ func (e *TestGen_InnerEnum) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return errors.New(fmt.Sprintf("No enum value for %s", str))
+			return fmt.Errorf("Invalid TestGen_InnerEnum value %q", str)
 		}
 		*e = TestGen_InnerEnum(val)
 		return nil
@@ -3305,10 +3309,14 @@ func (e *TestGen_InnerEnum) UnmarshalJSON(b []byte) error {
 	var val int32
 	err = json.Unmarshal(b, &val)
 	if err == nil {
+		_, ok := TestGen_InnerEnum_CamelName[val]
+		if !ok {
+			return fmt.Errorf("Invalid TestGen_InnerEnum value %d", val)
+		}
 		*e = TestGen_InnerEnum(val)
 		return nil
 	}
-	return fmt.Errorf("No enum value for %v", b)
+	return fmt.Errorf("Invalid TestGen_InnerEnum value %v", b)
 }
 
 /*


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5487 ratelimitsettings updateflow gives wrong error when key not found
* EDGECLOUD-5481 ratelimitsettings with invalid flowalgorithm,apiendpointtype and ratelimittarget need better error message
* EDGECLOUD-5480 CreateFlowRateLimitSettings api call without flowalgorithm gives wrong error

### Description

5487: Change in.Key.RateLimitKey.NotFoundError() to in.Key.NotFoundError()
5481: Change UnmarshalJSON auto-generate function to indicate in the error message the bad value that caused parsing to fail
5480: Omit the value when in error message since the value was not specified
