### PR TITLE
EDGECLOUD-5477 Flavor should be mandatory argument when creating an App

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -386,7 +386,10 @@ func (s *AppApi) configureApp(ctx context.Context, stm concurrency.STM, in *edge
 	}
 
 	flavor := &edgeproto.Flavor{}
-	if in.DefaultFlavor.Name != "" && !flavorApi.store.STMGet(stm, &in.DefaultFlavor, flavor) {
+	if in.DefaultFlavor.Name == "" {
+		return fmt.Errorf("Default flavor must be specified")
+	}
+	if !flavorApi.store.STMGet(stm, &in.DefaultFlavor, flavor) {
 		return in.DefaultFlavor.NotFoundError()
 	}
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5477 Flavor should be mandatory argument when creating an App

### Description

This makes the DefaultFlavor required when creating an App. This was primarily a UI request, but it also makes sense in trying to transition developers to use auto-prov to deploy their apps (which requires the default flavor), instead of manual AppInst deployment.

Surprisingly all the unit and e2e tests pass without modification. All test app data already has the default flavor specified.