### PR TITLE
EDGECLOUD-5673  shepherd got Prometheus LB IP not found after upgrade from HF3 to R3.1

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -207,6 +207,15 @@ func UpdateLoadBalancerPortMap(ctx context.Context, client ssh.Client, names *Ku
 			break
 		}
 		if lbip == "" {
+			// it could be old cluster where we just patch "External IPs"
+			for _, extIp := range s.Spec.ExternalIPs {
+				if strings.Contains(extIp, "pending") || extIp == "" {
+					continue
+				}
+				lbip = extIp
+			}
+		}
+		if lbip == "" {
 			continue
 		}
 		ports := s.Spec.Ports


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5673  shepherd got Prometheus LB IP not found after upgrade from HF3 to R3.1

### Description

Check the externalIPs if we unable to find the ip using load balancer ingress. This could be the case in old clusters when we upgrade from 3.0 to 3.1 and the new version of shepherd expects to get the ip of prometheus service assigned via metaLB