### PR TITLE
EDGECLOUD-5502 Reverting float format change

### DIFF
--- a/cloudcommon/ratelimit/tokenbucket-limiter.go
+++ b/cloudcommon/ratelimit/tokenbucket-limiter.go
@@ -32,7 +32,7 @@ func NewTokenBucketLimiter(tokensPerSecond float64, bucketSize int) *TokenBucket
 func (t *TokenBucketLimiter) Limit(ctx context.Context, info *CallerInfo) error {
 	tokenAvailable := t.limiter.Allow()
 	if !tokenAvailable {
-		return fmt.Errorf("Exceeded rate of %.2f requests per second", t.tokensPerSecond)
+		return fmt.Errorf("Exceeded rate of %f requests per second", t.tokensPerSecond)
 	} else {
 		return nil
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5502 rate limit error from DME has incorrect punctuation

### Description

Reverting float format change to avoid breaking tests.
