### PR TITLE
EDGECLOUD-5712  appinst alerts are not triggering for cpu mem and disk

### DIFF
--- a/docker/Dockerfile.cluster-svc
+++ b/docker/Dockerfile.cluster-svc
@@ -4,3 +4,4 @@ FROM $ALLINONE as allinone
 FROM gcr.io/distroless/base-debian10:debug
 
 COPY --from=allinone /usr/local/bin/cluster-svc /usr/local/bin/cluster-svc
+COPY --from=allinone /plugins/platforms.so /plugins/


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5712  appinst alerts are not triggering for cpu mem and disk

### Description
Copy in plugin.so to the cluster-svc component image.