### PR TITLE
DME REST API noTLS fix

### DIFF
--- a/cloudcommon/node/publicnode.go
+++ b/cloudcommon/node/publicnode.go
@@ -80,6 +80,10 @@ func NewPublicCertManager(commonName string, getPublicCertApi cloudcommon.GetPub
 	return mgr, nil
 }
 
+func (s *PublicCertManager) TLSMode() mextls.TLSMode {
+	return s.tlsMode
+}
+
 func (s *PublicCertManager) updateCert(ctx context.Context) error {
 	if s.tlsMode == mextls.NoTLS || !s.useGetPublicCertApi {
 		// If no tls or using command line certs, do not update

--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -660,7 +660,7 @@ func main() {
 			dme.RegisterMatchEngineApiHandler,
 		},
 	}
-	if clientTlsConfig != nil {
+	if clientTlsConfig != nil && publicCertManager.TLSMode() != tls.NoTLS {
 		gwcfg.GetCertificate = clientTlsConfig.GetClientCertificate
 	}
 


### PR DESCRIPTION
Bruce was trying to run DME locally without a TLS cert on it's API endpoint (using the PUBLIC_ENDPOINT_TLS=false env var in local_multi.yml). But there's actually a bug in the code.

The way the DME's grpc REST gateway works, is that there is a REST listener endpoint which accepts the REST request. It then converts the JSON data to gRPC, then issues a new request (locally) to the gRPC endpoint. If TLS is enabled, there's 3 TLS configs here. The REST gateway server TLS, the gRPC server TLS, and the internal REST->gRPC client TLS.

In this bug, TLS was being disabled on both the REST and gRPC server endpoints, but not the internal REST->gRPC client. The fix is to disable TLS on the client if TLS is being disabled on the public API endpoints (REST/gRPC).