### PR TITLE
Fix for minor bug that probably doesn't cause harm

### DIFF
--- a/integration/process/process_local.go
+++ b/integration/process/process_local.go
@@ -49,7 +49,7 @@ func (s *TLSCerts) AddInternalPkiArgs(args []string) []string {
 	if s.ServerCert != "" {
 		args = append(args, "--itlsCert", s.ServerCert)
 	}
-	if s.ServerCert != "" {
+	if s.ServerKey != "" {
 		args = append(args, "--itlsKey", s.ServerKey)
 	}
 	if s.CACert != "" {


### PR DESCRIPTION
Fixes copy/paste error. Since ServerCert and ServerKey normally come in pairs, this bug likely never causes problems, but it's best to fix it.
