### PR TITLE
EDGECLOUD-5687 Fix capitalization of error message

### DIFF
--- a/cloudcommon/ratelimit/ratelimit-interceptors.go
+++ b/cloudcommon/ratelimit/ratelimit-interceptors.go
@@ -76,7 +76,7 @@ func GetDmeStreamRateLimiterInterceptor(limiter Limiter) grpc.StreamServerInterc
 		if err != nil {
 			errMsg := fmt.Sprintf("Request for %s rate limited, please retry later.", info.FullMethod)
 			if err != nil {
-				errMsg += fmt.Sprintf(" Error is %s.", err.Error())
+				errMsg += fmt.Sprintf(" Error is: %s.", err.Error())
 			}
 			log.SpanLog(cctx, log.DebugLevelDmereq, "Stream Dme API Rate limited", "api", method, "err", errMsg)
 			return status.Errorf(codes.ResourceExhausted, errMsg)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5687 rate limiting GetQosPositionKpi message needs punctuation changes

### Description
Fix capitalization of error message.