### PR TITLE
k8s cluster-inst node resource info

### DIFF
--- a/cloud-resource-manager/k8smgmt/cluster_test.go
+++ b/cloud-resource-manager/k8smgmt/cluster_test.go
@@ -1,0 +1,1028 @@
+package k8smgmt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNodeInfos(t *testing.T) {
+	log.InitTracer(nil)
+	defer log.FinishTracer()
+	ctx := log.StartTestSpan(context.Background())
+
+	client := pc.DummyClient{}
+	client.Out = getNodesSampleOutput
+
+	nodeInfos, err := GetNodeInfos(ctx, &client, "")
+	require.Nil(t, err)
+
+	expNodes := []*edgeproto.NodeInfo{{
+		Name: "aks-agentpool-30520393-vmss000000",
+		Allocatable: map[string]*edgeproto.Udec64{
+			cloudcommon.ResourceVcpus: edgeproto.NewUdec64(1, 900*edgeproto.DecMillis),
+			cloudcommon.ResourceRamMb: edgeproto.NewUdec64(5368, 0),
+			cloudcommon.ResourceDisk:  edgeproto.NewUdec64(111, 0),
+		},
+		Capacity: map[string]*edgeproto.Udec64{
+			cloudcommon.ResourceVcpus: edgeproto.NewUdec64(2, 0),
+			cloudcommon.ResourceRamMb: edgeproto.NewUdec64(7961, 0),
+			cloudcommon.ResourceDisk:  edgeproto.NewUdec64(123, 0),
+		},
+	}, {
+		Name: "aks-agentpool-30520393-vmss000001",
+		Allocatable: map[string]*edgeproto.Udec64{
+			cloudcommon.ResourceVcpus: edgeproto.NewUdec64(1, 900*edgeproto.DecMillis),
+			cloudcommon.ResourceRamMb: edgeproto.NewUdec64(5368, 0),
+			cloudcommon.ResourceDisk:  edgeproto.NewUdec64(111, 0),
+		},
+		Capacity: map[string]*edgeproto.Udec64{
+			cloudcommon.ResourceVcpus: edgeproto.NewUdec64(2, 0),
+			cloudcommon.ResourceRamMb: edgeproto.NewUdec64(7961, 0),
+			cloudcommon.ResourceDisk:  edgeproto.NewUdec64(123, 0),
+		},
+	}, {
+		Name: "aks-agentpool-30520393-vmss000002",
+		Allocatable: map[string]*edgeproto.Udec64{
+			cloudcommon.ResourceVcpus: edgeproto.NewUdec64(1, 900*edgeproto.DecMillis),
+			cloudcommon.ResourceRamMb: edgeproto.NewUdec64(5368, 0),
+			cloudcommon.ResourceDisk:  edgeproto.NewUdec64(111, 0),
+		},
+		Capacity: map[string]*edgeproto.Udec64{
+			cloudcommon.ResourceVcpus: edgeproto.NewUdec64(2, 0),
+			cloudcommon.ResourceRamMb: edgeproto.NewUdec64(7961, 0),
+			cloudcommon.ResourceDisk:  edgeproto.NewUdec64(123, 0),
+		},
+	}}
+	require.Equal(t, expNodes, nodeInfos)
+}
+
+// Output of "kubectl get nodes --output=json"
+var getNodesSampleOutput = `
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2021-07-18T09:42:46Z",
+                "labels": {
+                    "agentpool": "agentpool",
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "Standard_D2s_v3",
+                    "beta.kubernetes.io/os": "linux",
+                    "failure-domain.beta.kubernetes.io/region": "southcentralus",
+                    "failure-domain.beta.kubernetes.io/zone": "0",
+                    "kubernetes.azure.com/node-image-version": "AKSUbuntu-1804gen2-2021.06.12",
+                    "kubernetes.azure.com/os-sku": "Ubuntu",
+                    "kubernetes.azure.com/role": "agent",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "aks-agentpool-30520393-vmss000000",
+                    "kubernetes.io/os": "linux",
+                    "kubernetes.io/role": "agent",
+                    "node-role.kubernetes.io/agent": "",
+                    "node.kubernetes.io/instance-type": "Standard_D2s_v3",
+                    "storageprofile": "managed",
+                    "storagetier": "Premium_LRS",
+                    "topology.kubernetes.io/region": "southcentralus",
+                    "topology.kubernetes.io/zone": "0"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    "f:kubernetes.io/role": {},
+                                    "f:node-role.kubernetes.io/agent": {}
+                                }
+                            }
+                        },
+                        "manager": "kubectl",
+                        "operation": "Update",
+                        "time": "2021-07-18T09:43:02Z"
+                    },
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:volumes.kubernetes.io/controller-managed-attach-detach": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:agentpool": {},
+                                    "f:beta.kubernetes.io/arch": {},
+                                    "f:beta.kubernetes.io/instance-type": {},
+                                    "f:beta.kubernetes.io/os": {},
+                                    "f:failure-domain.beta.kubernetes.io/region": {},
+                                    "f:failure-domain.beta.kubernetes.io/zone": {},
+                                    "f:kubernetes.azure.com/cluster": {},
+                                    "f:kubernetes.azure.com/node-image-version": {},
+                                    "f:kubernetes.azure.com/os-sku": {},
+                                    "f:kubernetes.azure.com/role": {},
+                                    "f:kubernetes.io/arch": {},
+                                    "f:kubernetes.io/hostname": {},
+                                    "f:kubernetes.io/os": {},
+                                    "f:node.kubernetes.io/instance-type": {},
+                                    "f:storageprofile": {},
+                                    "f:storagetier": {},
+                                    "f:topology.kubernetes.io/region": {},
+                                    "f:topology.kubernetes.io/zone": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:providerID": {}
+                            },
+                            "f:status": {
+                                "f:addresses": {
+                                    ".": {},
+                                    "k:{\"type\":\"Hostname\"}": {
+                                        ".": {},
+                                        "f:address": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"InternalIP\"}": {
+                                        ".": {},
+                                        "f:address": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:allocatable": {
+                                    ".": {},
+                                    "f:attachable-volumes-azure-disk": {},
+                                    "f:cpu": {},
+                                    "f:ephemeral-storage": {},
+                                    "f:hugepages-1Gi": {},
+                                    "f:hugepages-2Mi": {},
+                                    "f:memory": {},
+                                    "f:pods": {}
+                                },
+                                "f:capacity": {
+                                    ".": {},
+                                    "f:attachable-volumes-azure-disk": {},
+                                    "f:cpu": {},
+                                    "f:ephemeral-storage": {},
+                                    "f:hugepages-1Gi": {},
+                                    "f:hugepages-2Mi": {},
+                                    "f:memory": {},
+                                    "f:pods": {}
+                                },
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"DiskPressure\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"MemoryPressure\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"PIDPressure\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:config": {},
+                                "f:daemonEndpoints": {
+                                    "f:kubeletEndpoint": {
+                                        "f:Port": {}
+                                    }
+                                },
+                                "f:images": {},
+                                "f:nodeInfo": {
+                                    "f:architecture": {},
+                                    "f:bootID": {},
+                                    "f:containerRuntimeVersion": {},
+                                    "f:kernelVersion": {},
+                                    "f:kubeProxyVersion": {},
+                                    "f:kubeletVersion": {},
+                                    "f:machineID": {},
+                                    "f:operatingSystem": {},
+                                    "f:osImage": {},
+                                    "f:systemUUID": {}
+                                },
+                                "f:volumesInUse": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "time": "2021-07-18T12:35:04Z"
+                    },
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:node.alpha.kubernetes.io/ttl": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:podCIDR": {},
+                                "f:podCIDRs": {
+                                    ".": {},
+                                    "v:\"10.244.1.0/24\"": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"NetworkUnavailable\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:volumesAttached": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2021-07-18T12:35:36Z"
+                    }
+                ],
+                "name": "aks-agentpool-30520393-vmss000000",
+                "resourceVersion": "25296131",
+                "selfLink": "/api/v1/nodes/aks-agentpool-30520393-vmss000000",
+                "uid": "31af118e-5959-440a-8417-f3abbf6b9ed9"
+            },
+            "spec": {
+                "podCIDR": "10.244.1.0/24",
+                "podCIDRs": [
+                    "10.244.1.0/24"
+                ]
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "aks-agentpool-30520393-vmss000000",
+                        "type": "Hostname"
+                    },
+                    {
+                        "address": "10.240.0.4",
+                        "type": "InternalIP"
+                    }
+                ],
+                "allocatable": {
+                    "attachable-volumes-azure-disk": "4",
+                    "cpu": "1900m",
+                    "ephemeral-storage": "119716326407",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "5497568Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "attachable-volumes-azure-disk": "4",
+                    "cpu": "2",
+                    "ephemeral-storage": "129900528Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "8152800Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2021-07-18T09:43:09Z",
+                        "lastTransitionTime": "2021-07-18T09:43:09Z",
+                        "message": "RouteController created a route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:53:39Z",
+                        "lastTransitionTime": "2021-07-18T09:42:46Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:53:39Z",
+                        "lastTransitionTime": "2021-07-18T09:42:46Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:53:39Z",
+                        "lastTransitionTime": "2021-07-18T09:42:46Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:53:39Z",
+                        "lastTransitionTime": "2021-07-18T09:42:47Z",
+                        "message": "kubelet is posting ready status. AppArmor enabled",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "config": {},
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10211
+                    }
+                },
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "0615c9d0-7dc4-4000-b898-8d434ea2bb14",
+                    "containerRuntimeVersion": "docker://19.3.14",
+                    "kernelVersion": "5.4.0-1049-azure",
+                    "kubeProxyVersion": "v1.18.19",
+                    "kubeletVersion": "v1.18.19",
+                    "machineID": "aae645a2ac5644fa8edfd13dcc420af4",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 18.04.5 LTS",
+                    "systemUUID": "5baa476c-6d93-4888-8afc-b5970d23e731"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2021-07-18T09:43:29Z",
+                "labels": {
+                    "agentpool": "agentpool",
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "Standard_D2s_v3",
+                    "beta.kubernetes.io/os": "linux",
+                    "failure-domain.beta.kubernetes.io/region": "southcentralus",
+                    "failure-domain.beta.kubernetes.io/zone": "1",
+                    "kubernetes.azure.com/node-image-version": "AKSUbuntu-1804gen2-2021.06.12",
+                    "kubernetes.azure.com/os-sku": "Ubuntu",
+                    "kubernetes.azure.com/role": "agent",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "aks-agentpool-30520393-vmss000001",
+                    "kubernetes.io/os": "linux",
+                    "kubernetes.io/role": "agent",
+                    "node-role.kubernetes.io/agent": "",
+                    "node.kubernetes.io/instance-type": "Standard_D2s_v3",
+                    "storageprofile": "managed",
+                    "storagetier": "Premium_LRS",
+                    "topology.kubernetes.io/region": "southcentralus",
+                    "topology.kubernetes.io/zone": "1"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    "f:kubernetes.io/role": {},
+                                    "f:node-role.kubernetes.io/agent": {}
+                                }
+                            }
+                        },
+                        "manager": "kubectl",
+                        "operation": "Update",
+                        "time": "2021-07-18T09:44:02Z"
+                    },
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:volumes.kubernetes.io/controller-managed-attach-detach": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:agentpool": {},
+                                    "f:beta.kubernetes.io/arch": {},
+                                    "f:beta.kubernetes.io/instance-type": {},
+                                    "f:beta.kubernetes.io/os": {},
+                                    "f:failure-domain.beta.kubernetes.io/region": {},
+                                    "f:failure-domain.beta.kubernetes.io/zone": {},
+                                    "f:kubernetes.azure.com/cluster": {},
+                                    "f:kubernetes.azure.com/node-image-version": {},
+                                    "f:kubernetes.azure.com/os-sku": {},
+                                    "f:kubernetes.azure.com/role": {},
+                                    "f:kubernetes.io/arch": {},
+                                    "f:kubernetes.io/hostname": {},
+                                    "f:kubernetes.io/os": {},
+                                    "f:node.kubernetes.io/instance-type": {},
+                                    "f:storageprofile": {},
+                                    "f:storagetier": {},
+                                    "f:topology.kubernetes.io/region": {},
+                                    "f:topology.kubernetes.io/zone": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:providerID": {}
+                            },
+                            "f:status": {
+                                "f:addresses": {
+                                    ".": {},
+                                    "k:{\"type\":\"Hostname\"}": {
+                                        ".": {},
+                                        "f:address": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"InternalIP\"}": {
+                                        ".": {},
+                                        "f:address": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:allocatable": {
+                                    ".": {},
+                                    "f:attachable-volumes-azure-disk": {},
+                                    "f:cpu": {},
+                                    "f:ephemeral-storage": {},
+                                    "f:hugepages-1Gi": {},
+                                    "f:hugepages-2Mi": {},
+                                    "f:memory": {},
+                                    "f:pods": {}
+                                },
+                                "f:capacity": {
+                                    ".": {},
+                                    "f:attachable-volumes-azure-disk": {},
+                                    "f:cpu": {},
+                                    "f:ephemeral-storage": {},
+                                    "f:hugepages-1Gi": {},
+                                    "f:hugepages-2Mi": {},
+                                    "f:memory": {},
+                                    "f:pods": {}
+                                },
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"DiskPressure\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"MemoryPressure\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"PIDPressure\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:config": {},
+                                "f:daemonEndpoints": {
+                                    "f:kubeletEndpoint": {
+                                        "f:Port": {}
+                                    }
+                                },
+                                "f:images": {},
+                                "f:nodeInfo": {
+                                    "f:architecture": {},
+                                    "f:bootID": {},
+                                    "f:containerRuntimeVersion": {},
+                                    "f:kernelVersion": {},
+                                    "f:kubeProxyVersion": {},
+                                    "f:kubeletVersion": {},
+                                    "f:machineID": {},
+                                    "f:operatingSystem": {},
+                                    "f:osImage": {},
+                                    "f:systemUUID": {}
+                                },
+                                "f:volumesInUse": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "time": "2021-07-18T12:36:05Z"
+                    },
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:node.alpha.kubernetes.io/ttl": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:podCIDR": {},
+                                "f:podCIDRs": {
+                                    ".": {},
+                                    "v:\"10.244.2.0/24\"": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"NetworkUnavailable\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:volumesAttached": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2021-07-18T12:36:15Z"
+                    }
+                ],
+                "name": "aks-agentpool-30520393-vmss000001",
+                "resourceVersion": "25295719",
+                "selfLink": "/api/v1/nodes/aks-agentpool-30520393-vmss000001",
+                "uid": "3335beb8-ed1f-41cd-af49-9cbe3f063514"
+            },
+            "spec": {
+                "podCIDR": "10.244.2.0/24",
+                "podCIDRs": [
+                    "10.244.2.0/24"
+                ]
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "aks-agentpool-30520393-vmss000001",
+                        "type": "Hostname"
+                    },
+                    {
+                        "address": "10.240.0.5",
+                        "type": "InternalIP"
+                    }
+                ],
+                "allocatable": {
+                    "attachable-volumes-azure-disk": "4",
+                    "cpu": "1900m",
+                    "ephemeral-storage": "119716326407",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "5497568Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "attachable-volumes-azure-disk": "4",
+                    "cpu": "2",
+                    "ephemeral-storage": "129900528Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "8152800Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2021-07-18T09:43:50Z",
+                        "lastTransitionTime": "2021-07-18T09:43:50Z",
+                        "message": "RouteController created a route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:51:47Z",
+                        "lastTransitionTime": "2021-07-18T09:43:29Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:51:47Z",
+                        "lastTransitionTime": "2021-07-18T09:43:29Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:51:47Z",
+                        "lastTransitionTime": "2021-07-18T09:43:29Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:51:47Z",
+                        "lastTransitionTime": "2021-07-18T09:43:39Z",
+                        "message": "kubelet is posting ready status. AppArmor enabled",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "config": {},
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10211
+                    }
+                },
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "417a9d39-f61b-4cc7-b43b-1c58d2669f6f",
+                    "containerRuntimeVersion": "docker://19.3.14",
+                    "kernelVersion": "5.4.0-1049-azure",
+                    "kubeProxyVersion": "v1.18.19",
+                    "kubeletVersion": "v1.18.19",
+                    "machineID": "643edc584d36482aa3134748a2d288b4",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 18.04.5 LTS",
+                    "systemUUID": "128c4972-c980-4043-8f62-ed3dc9afac31"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2021-07-18T09:42:45Z",
+                "labels": {
+                    "agentpool": "agentpool",
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "Standard_D2s_v3",
+                    "beta.kubernetes.io/os": "linux",
+                    "failure-domain.beta.kubernetes.io/region": "southcentralus",
+                    "failure-domain.beta.kubernetes.io/zone": "2",
+                    "kubernetes.azure.com/node-image-version": "AKSUbuntu-1804gen2-2021.06.12",
+                    "kubernetes.azure.com/os-sku": "Ubuntu",
+                    "kubernetes.azure.com/role": "agent",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "aks-agentpool-30520393-vmss000002",
+                    "kubernetes.io/os": "linux",
+                    "kubernetes.io/role": "agent",
+                    "node-role.kubernetes.io/agent": "",
+                    "node.kubernetes.io/instance-type": "Standard_D2s_v3",
+                    "storageprofile": "managed",
+                    "storagetier": "Premium_LRS",
+                    "topology.kubernetes.io/region": "southcentralus",
+                    "topology.kubernetes.io/zone": "2"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    "f:kubernetes.io/role": {},
+                                    "f:node-role.kubernetes.io/agent": {}
+                                }
+                            }
+                        },
+                        "manager": "kubectl",
+                        "operation": "Update",
+                        "time": "2021-07-18T09:43:02Z"
+                    },
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:volumes.kubernetes.io/controller-managed-attach-detach": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:agentpool": {},
+                                    "f:beta.kubernetes.io/arch": {},
+                                    "f:beta.kubernetes.io/instance-type": {},
+                                    "f:beta.kubernetes.io/os": {},
+                                    "f:failure-domain.beta.kubernetes.io/region": {},
+                                    "f:failure-domain.beta.kubernetes.io/zone": {},
+                                    "f:kubernetes.azure.com/cluster": {},
+                                    "f:kubernetes.azure.com/node-image-version": {},
+                                    "f:kubernetes.azure.com/os-sku": {},
+                                    "f:kubernetes.azure.com/role": {},
+                                    "f:kubernetes.io/arch": {},
+                                    "f:kubernetes.io/hostname": {},
+                                    "f:kubernetes.io/os": {},
+                                    "f:node.kubernetes.io/instance-type": {},
+                                    "f:storageprofile": {},
+                                    "f:storagetier": {},
+                                    "f:topology.kubernetes.io/region": {},
+                                    "f:topology.kubernetes.io/zone": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:providerID": {}
+                            },
+                            "f:status": {
+                                "f:addresses": {
+                                    ".": {},
+                                    "k:{\"type\":\"Hostname\"}": {
+                                        ".": {},
+                                        "f:address": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"InternalIP\"}": {
+                                        ".": {},
+                                        "f:address": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:allocatable": {
+                                    ".": {},
+                                    "f:attachable-volumes-azure-disk": {},
+                                    "f:cpu": {},
+                                    "f:ephemeral-storage": {},
+                                    "f:hugepages-1Gi": {},
+                                    "f:hugepages-2Mi": {},
+                                    "f:memory": {},
+                                    "f:pods": {}
+                                },
+                                "f:capacity": {
+                                    ".": {},
+                                    "f:attachable-volumes-azure-disk": {},
+                                    "f:cpu": {},
+                                    "f:ephemeral-storage": {},
+                                    "f:hugepages-1Gi": {},
+                                    "f:hugepages-2Mi": {},
+                                    "f:memory": {},
+                                    "f:pods": {}
+                                },
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"DiskPressure\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"MemoryPressure\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"PIDPressure\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:config": {},
+                                "f:daemonEndpoints": {
+                                    "f:kubeletEndpoint": {
+                                        "f:Port": {}
+                                    }
+                                },
+                                "f:images": {},
+                                "f:nodeInfo": {
+                                    "f:architecture": {},
+                                    "f:bootID": {},
+                                    "f:containerRuntimeVersion": {},
+                                    "f:kernelVersion": {},
+                                    "f:kubeProxyVersion": {},
+                                    "f:kubeletVersion": {},
+                                    "f:machineID": {},
+                                    "f:operatingSystem": {},
+                                    "f:osImage": {},
+                                    "f:systemUUID": {}
+                                },
+                                "f:volumesInUse": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "time": "2021-07-18T12:34:38Z"
+                    },
+                    {
+                        "apiVersion": "v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:node.alpha.kubernetes.io/ttl": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:podCIDR": {},
+                                "f:podCIDRs": {
+                                    ".": {},
+                                    "v:\"10.244.0.0/24\"": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"NetworkUnavailable\"}": {
+                                        ".": {},
+                                        "f:lastHeartbeatTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:volumesAttached": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2021-07-18T12:34:45Z"
+                    }
+                ],
+                "name": "aks-agentpool-30520393-vmss000002",
+                "resourceVersion": "25295824",
+                "selfLink": "/api/v1/nodes/aks-agentpool-30520393-vmss000002",
+                "uid": "0dc68414-ce91-4115-8fc7-364f56449572"
+            },
+            "spec": {
+                "podCIDR": "10.244.0.0/24",
+                "podCIDRs": [
+                    "10.244.0.0/24"
+                ]
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "aks-agentpool-30520393-vmss000002",
+                        "type": "Hostname"
+                    },
+                    {
+                        "address": "10.240.0.6",
+                        "type": "InternalIP"
+                    }
+                ],
+                "allocatable": {
+                    "attachable-volumes-azure-disk": "4",
+                    "cpu": "1900m",
+                    "ephemeral-storage": "119716326407",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "5497564Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "attachable-volumes-azure-disk": "4",
+                    "cpu": "2",
+                    "ephemeral-storage": "129900528Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "8152796Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2021-07-18T09:43:09Z",
+                        "lastTransitionTime": "2021-07-18T09:43:09Z",
+                        "message": "RouteController created a route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:52:16Z",
+                        "lastTransitionTime": "2021-07-18T09:42:45Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:52:16Z",
+                        "lastTransitionTime": "2021-07-18T09:42:45Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:52:16Z",
+                        "lastTransitionTime": "2021-07-18T09:42:45Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2021-10-05T21:52:16Z",
+                        "lastTransitionTime": "2021-07-18T09:42:49Z",
+                        "message": "kubelet is posting ready status. AppArmor enabled",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "config": {},
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10211
+                    }
+                },
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "dc5a2572-50c4-4eca-abef-e351a27b5ea2",
+                    "containerRuntimeVersion": "docker://19.3.14",
+                    "kernelVersion": "5.4.0-1049-azure",
+                    "kubeProxyVersion": "v1.18.19",
+                    "kubeletVersion": "v1.18.19",
+                    "machineID": "a0f3ff3098744fe795119b2019c06253",
+                    "operatingSystem": "linux",
+                    "osImage": "Ubuntu 18.04.5 LTS",
+                    "systemUUID": "4c191a84-2005-45b5-8f39-fc647c71a75f"
+                }
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+`

--- a/cloud-resource-manager/k8smgmt/quantity.go
+++ b/cloud-resource-manager/k8smgmt/quantity.go
@@ -1,0 +1,79 @@
+package k8smgmt
+
+import (
+	"fmt"
+
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// QuantityToUdec64 converts a kubernetes Quantity to a Udec64.
+// This should only fail if the value is negative, or the Quantity
+// does not conform to the range of values it's supposed to be limited to.
+func QuantityToUdec64(q resource.Quantity) (*edgeproto.Udec64, error) {
+	valInt64, ok := q.AsInt64()
+	if ok {
+		if valInt64 < 0 {
+			return nil, fmt.Errorf("Cannot assign negative quantity %s to unsigned decimal", q.String())
+		}
+		return &edgeproto.Udec64{
+			Whole: uint64(valInt64),
+		}, nil
+	}
+	dec := q.AsDec()
+	if dec.Sign() < 0 {
+		return nil, fmt.Errorf("Cannot assign negative quantity %s to unsigned decimal", q.String())
+	}
+	scale := int(dec.Scale())
+	// Quantity will never have a value larger than 2^63-1, or more than
+	// 3 decimal places. So dec.Unscaled() should never fail.
+	unscaled, ok := dec.Unscaled()
+	if !ok {
+		return nil, fmt.Errorf("Unexpected quantity %s out of range", q.String())
+	}
+	if scale == 0 {
+		return &edgeproto.Udec64{
+			Whole: uint64(unscaled),
+		}, nil
+	}
+	if scale < 0 {
+		// whole number, scale up value
+		upscale := uint64(1)
+		for i := 0; i > scale; i-- {
+			upscale *= 10
+		}
+		return &edgeproto.Udec64{
+			Whole: uint64(unscaled) * upscale,
+		}, nil
+	}
+	// scale > 0, means decimal value
+	downscale := uint64(1)
+	for i := 0; i < scale; i++ {
+		downscale *= 10
+	}
+	whole := uint64(unscaled) / downscale
+	decimals := uint64(unscaled) % downscale
+	// decimals is value after decimal place, so
+	// 1.2045 would have 2045 as the decimal. This needs to
+	// be scaled to nanos.
+	for i := edgeproto.DecPrecision; i > scale; i-- {
+		decimals *= 10
+	}
+	return &edgeproto.Udec64{
+		Whole: whole,
+		Nanos: uint32(decimals),
+	}, nil
+}
+
+// QuantityToUint64 converts a kubernetes Quantity to a uint64.
+// This fails if the quantity is negative or has decimal precision.
+func QuantityToUint64(q resource.Quantity) (uint64, error) {
+	valInt64, ok := q.AsInt64()
+	if !ok {
+		return 0, fmt.Errorf("Cannot convert quantity %s to uint64", q.String())
+	}
+	if valInt64 < 0 {
+		return 0, fmt.Errorf("Cannot assign negative quantity %s to uint64", q.String())
+	}
+	return uint64(valInt64), nil
+}

--- a/cloud-resource-manager/k8smgmt/quantity_test.go
+++ b/cloud-resource-manager/k8smgmt/quantity_test.go
@@ -1,0 +1,72 @@
+package k8smgmt
+
+import (
+	"testing"
+
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestQuantityToUdec64(t *testing.T) {
+	tests := []struct {
+		qStr   string
+		whole  uint64
+		nanos  uint32
+		expErr string
+	}{
+		{"0", 0, 0, ""},
+		{"1", 1, 0, ""},
+		{"1.9", 1, 900 * edgeproto.DecMillis, ""},
+		{"1.900", 1, 900 * edgeproto.DecMillis, ""},
+		{"1900m", 1, 900 * edgeproto.DecMillis, ""},
+		{"1.001", 1, 1 * edgeproto.DecMillis, ""},
+		{"0.010", 0, 10 * edgeproto.DecMillis, ""},
+		{"1M", 1000 * 1000, 0, ""},
+		{"1.1M", 1100 * 1000, 0, ""},
+		{"1Mi", 1024 * 1024, 0, ""},
+		{"20G", 20 * 1000 * 1000 * 1000, 0, ""},
+		{"20Gi", 20 * 1024 * 1024 * 1024, 0, ""},
+		{"-1", 0, 0, "Cannot assign negative"},
+		{"-0.001", 0, 0, "Cannot assign negative"},
+	}
+	for _, test := range tests {
+		q := resource.MustParse(test.qStr)
+		actDec, err := QuantityToUdec64(q)
+		if test.expErr == "" {
+			require.Nil(t, err)
+			expDec := edgeproto.NewUdec64(test.whole, test.nanos)
+			require.Equal(t, expDec, actDec)
+		} else {
+			require.NotNil(t, err)
+			require.Contains(t, err.Error(), test.expErr)
+		}
+	}
+}
+
+func TestQuantityToUint64(t *testing.T) {
+	tests := []struct {
+		qStr   string
+		expVal uint64
+		expErr string
+	}{
+		{"0", 0, ""},
+		{"1", 1, ""},
+		{"1M", 1000 * 1000, ""},
+		{"1Mi", 1024 * 1024, ""},
+		{"20Gi", 20 * 1024 * 1024 * 1024, ""},
+		{"0.1", 0, "Cannot convert quantity"},
+		{"-1", 0, "Cannot assign negative"},
+	}
+	for _, test := range tests {
+		q := resource.MustParse(test.qStr)
+		actVal, err := QuantityToUint64(q)
+		if test.expErr == "" {
+			require.Nil(t, err)
+			require.Equal(t, test.expVal, actVal)
+		} else {
+			require.NotNil(t, err)
+			require.Contains(t, err.Error(), test.expErr)
+		}
+	}
+}

--- a/cloud-resource-manager/platform/pc/dummy.go
+++ b/cloud-resource-manager/platform/pc/dummy.go
@@ -1,0 +1,66 @@
+package pc
+
+import (
+	"io"
+	"strings"
+	"time"
+
+	ssh "github.com/mobiledgex/golang-ssh"
+)
+
+// Dummy SSH Client for unit tests to mock SSH Client.
+// Ignores input and delivers specified output and error.
+
+type DummyClient struct {
+	Out string
+	Err error
+}
+
+func (s *DummyClient) Output(command string) (string, error) {
+	return s.Out, s.Err
+}
+
+func (s *DummyClient) OutputWithTimeout(command string, timeout time.Duration) (string, error) {
+	return s.Out, s.Err
+}
+
+func (s *DummyClient) Shell(sin io.Reader, sout, serr io.Writer, args ...string) error {
+	return nil
+}
+
+func (s *DummyClient) Start(command string) (io.ReadCloser, io.ReadCloser, io.WriteCloser, error) {
+	return NopReadCloser{strings.NewReader(s.Out)}, NopReadCloser{strings.NewReader("")}, NopWriteCloser{NullWriter{}}, s.Err
+}
+
+func (s *DummyClient) Wait() error {
+	return nil
+}
+
+func (s *DummyClient) AddHop(host string, port int) (ssh.Client, error) {
+	return s, nil
+}
+
+func (s *DummyClient) StartPersistentConn(timeout time.Duration) error {
+	return nil
+}
+
+func (s *DummyClient) StopPersistentConn() {}
+
+// For use with DummyClient Start() method
+type NopReadCloser struct {
+	io.Reader
+}
+
+func (NopReadCloser) Close() error { return nil }
+
+type NopWriteCloser struct {
+	io.Writer
+}
+
+func (NopWriteCloser) Close() error { return nil }
+
+type NullWriter struct{}
+
+func (NullWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}


### PR DESCRIPTION
More support code for multi-tenant kubernetes. This adds code to grab node resource info, and convert from kubernetes data structs into our proto-buffers data structs. This will be used for resource tracking when deploying AppInsts to a multi-tenant kubernetes cluster.
