### PR TITLE
EDGECLOUD-5774: K8s svc manifest empty protocol should default to TCP

### DIFF
--- a/cloudcommon/deployment.go
+++ b/cloudcommon/deployment.go
@@ -177,6 +177,10 @@ func IsValidDeploymentManifest(deploymentType, command, manifest string, ports [
 			}
 			for _, kp := range ksvc.Spec.Ports {
 				appPort := dme.AppPort{}
+				if kp.Protocol == "" {
+					// default to TCP, as k8s does the same
+					kp.Protocol = v1.ProtocolTCP
+				}
 				appPort.Proto, err = edgeproto.GetLProto(string(kp.Protocol))
 				if err != nil {
 					log.DebugLog(log.DebugLevelApi, "unrecognized port protocol in kubernetes manifest", "proto", string(kp.Protocol))


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5774: K8s svc manifest empty protocol should default to TCP

### Description

* Our current k8s manifest validation code skips service ports that do not have protocol specified in it. K8s defaults protocol to TCP and hence we should also do the same rather than skip it.