### PR TITLE
EDGECLOUD-5790  App instance health status wrongly shows “Cloudletoffline” status for an online & operational cloudlet

### DIFF
--- a/controller/alert_api.go
+++ b/controller/alert_api.go
@@ -157,6 +157,11 @@ func (s *AlertApi) Delete(ctx context.Context, in *edgeproto.Alert, rev int64) {
 	if ok {
 		s.sourceCache.Delete(ctx, in, rev)
 		s.store.Delete(ctx, in, s.sync.syncWait)
+		// Reset HealthCheck state back to OK
+		name, ok := in.Labels["alertname"]
+		if ok && name == cloudcommon.AlertAppInstDown {
+			s.appInstSetStateFromHealthCheckAlert(ctx, in, dme.HealthCheck_HEALTH_CHECK_OK)
+		}
 	} else {
 		s.sourceCache.DeleteCondFunc(ctx, in, rev, func(old *edgeproto.Alert) bool {
 			if old.NotifyId != in.NotifyId {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5790  App instance health status wrongly shows “Cloudletoffline” status for an online & operational cloudlet

### Description

We discovered that we have some appInstances in the CloudletOffline state, even though the cloudlet is online. This is due to the fact that we don't properly clean up appInst state when cloudlet offline alert is cleaned up. 
When we delete cloudlet offline alert we should also set the health check to OK for each appInst on the cloudlet that's back online.

See https://github.com/mobiledgex/edge-cloud-infra/pull/1815 for e2e tests to validate the change.
