### PR TITLE
EDGECLOUD-5829: CRM without restagmap doesn't receive updates to GPU driver cache

### DIFF
--- a/notify/notify_customupdate.go
+++ b/notify/notify_customupdate.go
@@ -71,11 +71,9 @@ func (s *CloudletSend) UpdateOk(ctx context.Context, key *edgeproto.CloudletKey)
 					Organization: key.Organization,
 				}, 0)
 			}
-			if s.sendrecv.gpuDriverSend != nil {
-				if resTagTbl, ok := cloudlet.ResTagMap["gpu"]; ok && resTagTbl != nil {
-					// also trigger send of GPU driver object
-					s.sendrecv.gpuDriverSend.updateInternal(ctx, &cloudlet.GpuConfig.Driver, 0)
-				}
+			if s.sendrecv.gpuDriverSend != nil && cloudlet.GpuConfig.Driver.Name != "" {
+				// also trigger send of GPU driver object
+				s.sendrecv.gpuDriverSend.updateInternal(ctx, &cloudlet.GpuConfig.Driver, 0)
 			}
 		}
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5829: CRM without restagmap doesn't receive updates to GPU driver cache

### Description

* ResTag map is not required for cloudlets with non-native flavors like VCD. But the notify code was sending updates of GPU driver to cloudlets with restag map set to 'GPU' only. Fixed the code to look for GPU driver config rather than restag map