### PR TITLE
default the CRM HA role

### DIFF
--- a/cloud-resource-manager/redundancy/ha_manager.go
+++ b/cloud-resource-manager/redundancy/ha_manager.go
@@ -39,7 +39,7 @@ type HighAvailabilityManager struct {
 
 func (s *HighAvailabilityManager) InitFlags() {
 	flag.StringVar(&s.redisAddr, "redisAddr", "", "redis address")
-	flag.StringVar(&s.HARole, "HARole", "", string(process.HARolePrimary+" or "+process.HARoleSecondary))
+	flag.StringVar(&s.HARole, "HARole", string(process.HARolePrimary), string(process.HARolePrimary+" or "+process.HARoleSecondary))
 }
 
 func (s *HighAvailabilityManager) Init(nodeGroupKey string, nodeMgr *node.NodeMgr, activeDuration, activePollInterval edgeproto.Duration, haWatcher HAWatcher) error {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5836 crmserver of automationAzureCentralCloudlet keeps crashing

### Description

If the --HArole arg is not specified on CRM startup, startup will fail due to no role. In e2e the crm is always started up with a role specified, but in other deployments it will not be by default. For backwards compatibility and to avoid having to change chef/ansible for non-HA deployments, default the HA role to primary.