### PR TITLE
EDGECLOUD-5840: Controller allows setting deprecated values to appinst autoclusteripaccess field

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -803,9 +803,9 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			}
 		}
 
-		if app.Deployment == cloudcommon.DeploymentTypeVM && in.AutoClusterIpAccess != edgeproto.IpAccess_IP_ACCESS_UNKNOWN {
-			return fmt.Errorf("Cannot specify AutoClusterIpAccess if deployment type is VM")
-		}
+		// Since autoclusteripaccess is deprecated, set it to unknown
+		in.AutoClusterIpAccess = edgeproto.IpAccess_IP_ACCESS_UNKNOWN
+
 		err = validateImageTypeForPlatform(ctx, app.ImageType, cloudlet.PlatformType, cloudletFeatures)
 		if err != nil {
 			return err


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5840: Controller allows setting deprecated values to appinst autoclusteripaccess field

### Description
* QA team sets `autoclusteripaccess` value as 2 i.e. DedicatedOrShared (as part of gRPC request). But this value is removed from protobuf and hence causes etcd upgrade issues.
* `autoclusteripaccess` field is deprecated and no longer used in code. Hence, just set it to unknown regardless of what user sets it.

