### PR TITLE
Backport of EC-5790 and EC-4609

### DIFF
--- a/controller/alert_api.go
+++ b/controller/alert_api.go
@@ -19,6 +19,8 @@ type AlertApi struct {
 	sourceCache edgeproto.AlertCache // source of truth from crm/etc
 }
 
+var ControllerCreatedAlerts = "ControllerCreatedAlerts"
+
 var alertApi = AlertApi{}
 
 func InitAlertApi(sync *Sync) {
@@ -148,13 +150,25 @@ func (s *AlertApi) StoreUpdate(ctx context.Context, old, new *edgeproto.Alert) {
 func (s *AlertApi) Delete(ctx context.Context, in *edgeproto.Alert, rev int64) {
 	// Add a region label
 	in.Labels["region"] = *region
-	s.sourceCache.DeleteCondFunc(ctx, in, rev, func(old *edgeproto.Alert) bool {
-		if old.NotifyId != in.NotifyId {
-			// already updated by another thread, don't delete
-			return false
+	// Controller created alerts, so delete directly
+	_, ok := ctx.Value(ControllerCreatedAlerts).(*string)
+	if ok {
+		s.sourceCache.Delete(ctx, in, rev)
+		s.store.Delete(ctx, in, s.sync.syncWait)
+		// Reset HealthCheck state back to OK
+		name, ok := in.Labels["alertname"]
+		if ok && name == cloudcommon.AlertAppInstDown {
+			appInstSetStateFromHealthCheckAlert(ctx, in, dme.HealthCheck_HEALTH_CHECK_OK)
 		}
-		return true
-	})
+	} else {
+		s.sourceCache.DeleteCondFunc(ctx, in, rev, func(old *edgeproto.Alert) bool {
+			if old.NotifyId != in.NotifyId {
+				// already updated by another thread, don't delete
+				return false
+			}
+			return true
+		})
+	}
 	// Note that any further actions should done as part of StoreDelete.
 }
 

--- a/controller/cloudletinfo_api.go
+++ b/controller/cloudletinfo_api.go
@@ -207,6 +207,8 @@ func FireCloudletAndAppInstDownAlerts(ctx context.Context, in *edgeproto.Cloudle
 }
 
 func ClearCloudletAndAppInstDownAlerts(ctx context.Context, in *edgeproto.CloudletInfo) {
+	// We ignore the controller and notifyId check when cleaning up the alerts here
+	ctx = context.WithValue(ctx, ControllerCreatedAlerts, &ControllerCreatedAlerts)
 	clearCloudletDownAlert(ctx, in)
 	clearCloudletDownAppInstAlerts(ctx, in)
 }
@@ -331,9 +333,9 @@ func (s *CloudletInfoApi) Flush(ctx context.Context, notifyId int64) {
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelNotify, "mark cloudlet offline", "key", matches[ii], "err", err)
 		} else {
-			nodeMgr.Event(ectx, "Cloudlet offline", info.Key.Organization, info.Key.GetTags(), nil, "reason", "notify disconnect")
 			// Send a cloudlet down alert if a cloudlet was ready
 			if cloudletReady {
+				nodeMgr.Event(ectx, "Cloudlet offline", info.Key.Organization, info.Key.GetTags(), nil, "reason", "notify disconnect")
 				FireCloudletAndAppInstDownAlerts(ctx, &info)
 			}
 		}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-4609 CloudletDown alert not clearing when running 2 controllers in replica
* EDGECLOUD-5790 App instance health status wrongly shows “Cloudletoffline” status for an online & operational cloudlet

### Description
backport EDGECLOUD-4609  EDGECLOUD-5790 to R3.0 hf branch