### PR TITLE
EDGECLOUD-5829: CRM without restagmap doesn't receive updates to GPU driver cache

### DIFF
--- a/notify/notify_customupdate.go
+++ b/notify/notify_customupdate.go
@@ -51,11 +51,9 @@ func (s *CloudletSend) UpdateOk(ctx context.Context, key *edgeproto.CloudletKey)
 					Organization: key.Organization,
 				}, 0)
 			}
-			if s.sendrecv.gpuDriverSend != nil {
-				if resTagTbl, ok := cloudlet.ResTagMap["gpu"]; ok && resTagTbl != nil {
-					// also trigger send of GPU driver object
-					s.sendrecv.gpuDriverSend.updateInternal(ctx, &cloudlet.GpuConfig.Driver, 0)
-				}
+			if s.sendrecv.gpuDriverSend != nil && cloudlet.GpuConfig.Driver.Name != "" {
+				// also trigger send of GPU driver object
+				s.sendrecv.gpuDriverSend.updateInternal(ctx, &cloudlet.GpuConfig.Driver, 0)
 			}
 		}
 	}

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -170,8 +170,13 @@ func TestNotifyBasic(t *testing.T) {
 	vmpoolCloudlet.GpuConfig = edgeproto.GPUConfig{
 		Driver: testutil.GPUDriverData[0].Key,
 	}
+	// gpu config cloudlet with no restag table
+	gpuConfigNoResTagCloudlet := testutil.CloudletData[2]
+	gpuConfigNoResTagCloudlet.GpuConfig = edgeproto.GPUConfig{
+		Driver: testutil.GPUDriverData[2].Key,
+	}
 	serverHandler.CloudletCache.Update(ctx, &vmpoolCloudlet, 6)
-	serverHandler.CloudletCache.Update(ctx, &testutil.CloudletData[1], 7)
+	serverHandler.CloudletCache.Update(ctx, &gpuConfigNoResTagCloudlet, 7)
 	serverHandler.FlavorCache.Update(ctx, &testutil.FlavorData[0], 8)
 	serverHandler.FlavorCache.Update(ctx, &testutil.FlavorData[1], 9)
 	serverHandler.FlavorCache.Update(ctx, &testutil.FlavorData[2], 10)
@@ -205,6 +210,18 @@ func TestNotifyBasic(t *testing.T) {
 	require.Equal(t, 2, len(crmHandler.AppInstCache.Objs), "num appInsts")
 	require.Equal(t, 1, len(crmHandler.VMPoolCache.Objs), "num vmPools")
 	require.Equal(t, 1, len(crmHandler.GPUDriverCache.Objs), "num gpuDrivers")
+
+	// trigger updates with another CloudletInfo update, this also tests that
+	// GPU driver update is received by cloudlet with no restag table configured
+	crmHandler.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData[2], 0)
+	require.Nil(t, crmHandler.WaitForCloudlets(2), "num cloudlets")
+	require.Nil(t, crmHandler.WaitForFlavors(3), "num flavors")
+	require.Nil(t, crmHandler.WaitForClusterInsts(3), "num clusterInsts")
+	require.Nil(t, crmHandler.WaitForApps(1), "num apps")
+	require.Nil(t, crmHandler.WaitForAppInsts(2), "num appInsts")
+	require.Nil(t, crmHandler.WaitForVMPools(1), "num vmPools")
+	require.Nil(t, crmHandler.WaitForGPUDrivers(2), "num gpuDrivers")
+
 	// verify modRef values
 	appBuf := edgeproto.App{}
 	flavorBuf := edgeproto.Flavor{}
@@ -232,20 +249,20 @@ func TestNotifyBasic(t *testing.T) {
 	serverHandler.ClusterInstCache.Delete(ctx, &testutil.ClusterInstData[0], 0)
 	serverHandler.AppInstCache.Delete(ctx, &testutil.AppInstData[0], 0)
 	crmHandler.WaitForFlavors(2)
-	crmHandler.WaitForClusterInsts(1)
+	crmHandler.WaitForClusterInsts(2)
 	crmHandler.WaitForAppInsts(1)
 	require.Equal(t, 2, len(crmHandler.FlavorCache.Objs), "num flavors")
-	require.Equal(t, 1, len(crmHandler.ClusterInstCache.Objs), "num clusterInsts")
+	require.Equal(t, 2, len(crmHandler.ClusterInstCache.Objs), "num clusterInsts")
 	require.Equal(t, 1, len(crmHandler.AppInstCache.Objs), "num appInsts")
 	clientCRM.GetStats(stats)
-	require.Equal(t, uint64(1), stats.ObjRecv["Cloudlet"], "cloudlet updates")
+	require.Equal(t, uint64(2), stats.ObjRecv["Cloudlet"], "cloudlet updates")
 	require.Equal(t, uint64(4), stats.ObjRecv["Flavor"], "flavor updates")
-	require.Equal(t, uint64(3), stats.ObjRecv["ClusterInst"], "clusterInst updates")
+	require.Equal(t, uint64(4), stats.ObjRecv["ClusterInst"], "clusterInst updates")
 	require.Equal(t, uint64(3), stats.ObjRecv["AppInst"], "appInst updates")
 	stats = serverMgr.GetStats(clientCRM.GetLocalAddr())
-	require.Equal(t, uint64(1), stats.ObjSend["Cloudlet"], "sent cloudlets")
+	require.Equal(t, uint64(2), stats.ObjSend["Cloudlet"], "sent cloudlets")
 	require.Equal(t, uint64(4), stats.ObjSend["Flavor"], "sent flavors")
-	require.Equal(t, uint64(3), stats.ObjSend["ClusterInst"], "sent clusterInsts")
+	require.Equal(t, uint64(4), stats.ObjSend["ClusterInst"], "sent clusterInsts")
 	require.Equal(t, uint64(3), stats.ObjSend["AppInst"], "sent appInsts")
 	checkServerConnections(t, &serverMgr, 2)
 


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5829: CRM without restagmap doesn't receive updates to GPU driver cache
