### PR TITLE
Fix e2e-tests

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -116,8 +116,8 @@ func NewControllerData(pf platform.Platform, key *edgeproto.CloudletKey, nodeMgr
 	cd.CloudletCache.SetDeletedCb(cd.cloudletDeleted)
 	cd.VMPoolCache.SetUpdatedCb(cd.VMPoolChanged)
 	cd.SettingsCache.SetUpdatedCb(cd.settingsChanged)
-	cd.CloudletPoolCache.SetUpdatedCb(cd.cloudletPoolChanged)
-	cd.CloudletPoolCache.SetDeletedCb(cd.cloudletPoolDeleted)
+	cd.CloudletPoolCache.AddUpdatedCb(cd.cloudletPoolChanged)
+	cd.CloudletPoolCache.AddDeletedCb(cd.cloudletPoolDeleted)
 
 	cd.TrustPolicyExceptionCache.SetUpdatedCb(cd.trustPolicyExceptionChanged)
 	cd.TrustPolicyExceptionCache.SetDeletedCb(cd.trustPolicyExceptionDeleted)


### PR DESCRIPTION
* `SetUpdatedCb/SetDeletedCb` were replacing the callbacks set by the following `Init` function in `cloudcommon/node/cloudletpoollookup.go`:
```
func (s *CloudletPoolCache) Init() {
        edgeproto.InitCloudletPoolCache(&s.cache)
        s.PoolsByCloudlet.Init()
        s.cache.AddUpdatedCb(s.updatedPool)
        s.cache.AddDeletedCb(s.deletedPool)
}
```