### PR TITLE
namespaces are limited to 63 chars and cannot end in dash

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -293,8 +293,8 @@ func CreateAllNamespaces(ctx context.Context, client ssh.Client, names *KubeName
 			if strings.Contains(out, "already exists") {
 				log.SpanLog(ctx, log.DebugLevelInfra, "namespace already exists")
 			} else {
-				log.SpanLog(ctx, log.DebugLevelInfra, "kubectl create namespace failed", "out", string(out), "err", err)
-				return fmt.Errorf("kubectl create namespace failed - %v", err)
+				log.SpanLog(ctx, log.DebugLevelInfra, "kubectl create namespace failed", "namespace", n, "out", string(out), "err", err)
+				return fmt.Errorf("kubectl create namespace %s failed - %s,%v", n, string(out), err)
 			}
 		}
 	}

--- a/cloud-resource-manager/k8smgmt/kubenames.go
+++ b/cloud-resource-manager/k8smgmt/kubenames.go
@@ -61,7 +61,7 @@ func GetCloudletClusterName(clusterKey *edgeproto.ClusterInstKey) string {
 
 func GetNamespace(appInstKey *edgeproto.AppInstKey) string {
 	// Note that we use the virtual cluster name, not the real cluster name
-	return util.DNSSanitize(fmt.Sprintf("%s-%s-%s-%s", appInstKey.AppKey.Organization, appInstKey.AppKey.Name, appInstKey.AppKey.Version, appInstKey.ClusterInstKey.ClusterKey.Name))
+	return util.NamespaceSanitize(fmt.Sprintf("%s-%s-%s-%s", appInstKey.AppKey.Organization, appInstKey.AppKey.Name, appInstKey.AppKey.Version, appInstKey.ClusterInstKey.ClusterKey.Name))
 }
 
 func NormalizeName(name string) string {

--- a/util/validate.go
+++ b/util/validate.go
@@ -23,6 +23,7 @@ var emailMatch = regexp.MustCompile(`(.+)@(.+)\.(.+)`)
 var dockerNameMatch = regexp.MustCompile(`^[0-9a-zA-Z][a-zA-Z0-9_.-]+$`)
 
 const maxHostnameLength = 63
+const maxK8sNamespaceLength = 63
 
 // region names are used in Vault approle names, which are very
 // restrictive in what characters they allow.
@@ -114,6 +115,15 @@ func K8SSanitize(name string) string {
 		",", "",
 		"!", "")
 	return strings.ToLower(r.Replace(name))
+}
+
+// Namespaces are limited to 63 characters and cannot end in "-"
+func NamespaceSanitize(name string) string {
+	r := DNSSanitize(name)
+	if len(r) > maxK8sNamespaceLength {
+		r = r[:maxK8sNamespaceLength]
+	}
+	return strings.TrimRight(r, "-")
 }
 
 // alphanumeric plus -_. first char must be alpha, <= 255 chars.


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5842 Anthos appinst create fails when name is too long

### Description

When doing CreateAppinst with a combination of long org, app and cluster names, the deployment will fail because namespaces in k8s cannot be over 63 chars long. They also cannot end in a dash, so that is fixed here too.