### PR TITLE
EDGECLOUD-5907 Upgrade edge-cloud-base-image to fix CVE 2021-43527

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include Makedefs
 
 GOVERS = $(shell go version | awk '{print $$3}' | cut -d. -f1,2)
 
-EDGE_CLOUD_BASE_IMAGE = $(REGISTRY)/edge-cloud-base-image@sha256:64606b47d0b95a619c3f31dcf8184cac14ff7df209e7590c99a6c7b536f9919e
+EDGE_CLOUD_BASE_IMAGE = $(REGISTRY)/edge-cloud-base-image@sha256:eff33badbbcde56b3100b07a369f34445ff78ef79802241fcaed3e5f77964bd2
 
 export GO111MODULE=on
 


### PR DESCRIPTION
No code or build manifest changes in the edge-cloud-base-image.  It just
needed to be rebuilt to pull in the latest version of the libnss3
package:
https://github.com/mobiledgex/edge-cloud-infra/actions/runs/1548677694

CVE details:
https://access.redhat.com/security/cve/CVE-2021-43527

> A remote code execution flaw was found in the way NSS verifies certificates. This flaw allows an attacker posing as an SSL/TLS server to trigger this issue in a client application compiled with NSS when it tries to initiate an SSL/TLS connection. Similarly, a server application compiled with NSS, which processes client certificates, can receive a malicious certificate via a client, triggering the flaw. The highest threat to this vulnerability is confidentiality, integrity, as well as system availability.
