### PR TITLE
fix fake platform update clusterinst resources

### DIFF
--- a/edgeproto/objs.go
+++ b/edgeproto/objs.go
@@ -74,6 +74,11 @@ func (a *AllData) Sort() {
 	sort.Slice(a.ClusterInsts[:], func(i, j int) bool {
 		return a.ClusterInsts[i].Key.GetKeyString() < a.ClusterInsts[j].Key.GetKeyString()
 	})
+	for ii := range a.ClusterInsts {
+		sort.Slice(a.ClusterInsts[ii].Resources.Vms, func(i, j int) bool {
+			return a.ClusterInsts[ii].Resources.Vms[i].Name < a.ClusterInsts[ii].Resources.Vms[j].Name
+		})
+	}
 	sort.Slice(a.Flavors[:], func(i, j int) bool {
 		return a.Flavors[i].Key.GetKeyString() < a.Flavors[j].Key.GetKeyString()
 	})

--- a/setup-env/e2e-tests/data/appdata_trusted_show.yml
+++ b/setup-env/e2e-tests/data/appdata_trusted_show.yml
@@ -261,6 +261,10 @@ clusterinsts:
   masternodeflavor: x1.small
   resources:
     vms:
+    - name: cluster2.cloudlet2.tmus.fake.net
+      type: rootlb
+      status: ACTIVE
+      infraflavor: x1.small
     - name: fake-master-1-cloudlet2-cluster2-acmeappco
       type: cluster-master
       status: ACTIVE
@@ -271,10 +275,6 @@ clusterinsts:
       infraflavor: x1.small
     - name: fake-node-2-cloudlet2-cluster2-acmeappco
       type: cluster-k8s-node
-      status: ACTIVE
-      infraflavor: x1.small
-    - name: cluster2.cloudlet2.tmus.fake.net
-      type: rootlb
       status: ACTIVE
       infraflavor: x1.small
 apps:


### PR DESCRIPTION
My change to include more data in the e2e comparison revealed a bug in the fake platform code for calculating ClusterInst node resources on Update. This fixes the fake platform code to remove nodes when a cluster is scaled down to fewer worker nodes. Previously, nodes that were removed due to scaling down were still in the list of VM resources.

I'm also now sorting the nodes in the resource list.

The e2e tests are actually in the infra test suite.