### PR TITLE
Fixing URL for session DELETE

### DIFF
--- a/d-match-engine/dme-server/dme-main.go
+++ b/d-match-engine/dme-server/dme-main.go
@@ -108,18 +108,8 @@ func (s *server) FindCloudlet(ctx context.Context, req *dme.FindCloudletRequest)
 			duration = 24 * time.Hour // 24 hours - default value
 		}
 		log.SpanLog(ctx, log.DebugLevelDmereq, "Session duration", "app.QosSessionDuration", app.QosSessionDuration, " derived duration", duration)
-		var priorityType string
 
-		if strings.HasPrefix(qos, "LATENCY") {
-			priorityType = "latency"
-		} else if strings.HasPrefix(qos, "THROUGHPUT") {
-			priorityType = "throughput"
-		} else {
-			log.SpanLog(ctx, log.DebugLevelDmereq, "Received invalid value", "QosSessionProfile", app.QosSessionProfile)
-			priorityType = ""
-		}
-
-		if qos != "DEFAULT" && priorityType != "" {
+		if qos != "DEFAULT" {
 			var protocol string
 			var asAddr string
 			ips, _ := net.LookupIP(reply.Fqdn)
@@ -152,7 +142,7 @@ func (s *server) FindCloudlet(ctx context.Context, req *dme.FindCloudletRequest)
 			} else if protocol == "" {
 				log.SpanLog(ctx, log.DebugLevelDmereq, "Unknown port protocol. Aborting.", "port.Proto", port.Proto)
 			} else {
-				id, sesErr := operatorApiGw.CreatePrioritySession(ctx, priorityType, ueAddr, asAddr, asPort, protocol, qos, int64(duration.Seconds()))
+				id, sesErr := operatorApiGw.CreatePrioritySession(ctx, ueAddr, asAddr, asPort, protocol, qos, int64(duration.Seconds()))
 				if sesErr != nil {
 					log.SpanLog(ctx, log.DebugLevelDmereq, "CreatePrioritySession failed.", "sesErr", sesErr)
 				}

--- a/d-match-engine/operator/defaultoperator/defaultoperator.go
+++ b/d-match-engine/operator/defaultoperator/defaultoperator.go
@@ -46,12 +46,12 @@ func (*OperatorApiGw) GetVersionProperties() map[string]string {
 	return version.BuildProps("DefaultOperator")
 }
 
-func (*OperatorApiGw) CreatePrioritySession(ctx context.Context, priorityType string, ueAddr string, asAddr string, asPort string, protocol string, qos string, duration int64) (string, error) {
+func (*OperatorApiGw) CreatePrioritySession(ctx context.Context, ueAddr string, asAddr string, asPort string, protocol string, qos string, duration int64) (string, error) {
 	log.DebugLog(log.DebugLevelDmereq, "No default implementation for CreatePrioritySession()")
 	return "", nil
 }
 
-func (*OperatorApiGw) DeletePrioritySession(ctx context.Context, priorityType string, sessionId string) error {
+func (*OperatorApiGw) DeletePrioritySession(ctx context.Context, sessionId string, qos string) error {
 	log.DebugLog(log.DebugLevelDmereq, "No default implementation for DeletePrioritySession()")
 	return nil
 }

--- a/d-match-engine/operator/operator-api-gw.go
+++ b/d-match-engine/operator/operator-api-gw.go
@@ -32,9 +32,9 @@ type OperatorApiGw interface {
 	// GetQOSPositionKPI gets QOS KPIs for GPS positions
 	GetQOSPositionKPI(req *dme.QosPositionRequest, getQosSvr dme.MatchEngineApi_GetQosPositionKpiServer) error
 	// CreatePrioritySession requests either stable latency or throughput for a client session
-	CreatePrioritySession(ctx context.Context, priorityType string, ueAddr string, asAddr string, asPort string, protocol string, qos string, duration int64) (string, error)
+	CreatePrioritySession(ctx context.Context, ueAddr string, asAddr string, asPort string, protocol string, qos string, duration int64) (string, error)
 	// DeletePrioritySession removes a previously created priority session
-	DeletePrioritySession(ctx context.Context, priorityType string, sessionId string) error
+	DeletePrioritySession(ctx context.Context, sessionId string, qos string) error
 	// LookupQosParm looks up the QOS API parameter values for each QosSessionProfile enum value.
 	LookupQosParm(qos string) string
 }


### PR DESCRIPTION
### Description
There was a bug when trying to switch from a LATENCY profile to a THROUGHPUT one, if the old session needed to be deleted. In that case, the URL was built with the currently requested profile name, whereas it needs to be built with the previous session's profile. This update fixes that and simplifies some function signatures by not passing around the priorityType variable. Instead there is now a buildQosUrl function which takes the profile name, and is called from multiple places when the new URL is needed.
