### PR TITLE
change order of validation checks

### DIFF
--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -852,10 +852,6 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 		if err != nil {
 			return fmt.Errorf("Failed to get features for platform: %s", err)
 		}
-		platName := edgeproto.PlatformType_name[int32(cloudlet.PlatformType)]
-		if in.SharedVolumeSize != 0 && !features.SupportsSharedVolume {
-			return fmt.Errorf("Shared volumes not supported on %s", platName)
-		}
 		if len(in.Key.ClusterKey.Name) > cloudcommon.MaxClusterNameLength {
 			return fmt.Errorf("Cluster name limited to %d characters", cloudcommon.MaxClusterNameLength)
 		}
@@ -864,6 +860,10 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 		}
 		if features.IsSingleKubernetesCluster {
 			return fmt.Errorf("Single kubernetes cluster platform %s only supports AppInst creates", cloudlet.PlatformType.String())
+		}
+		platName := edgeproto.PlatformType_name[int32(cloudlet.PlatformType)]
+		if in.SharedVolumeSize != 0 && !features.SupportsSharedVolume {
+			return fmt.Errorf("Shared volumes not supported on %s", platName)
 		}
 		if in.Deployment == cloudcommon.DeploymentTypeKubernetes {
 			err = validateNumNodesForKubernetes(ctx, cloudlet.PlatformType, features, in.NumNodes)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5953 CreateClusterInst on anthos gives inconsistent error message

### Description

Move the SupportsSharedVolume for create cluster inst check down below the check for IsSingleKubernetesCluster that prevents cluster create on k8s baremetal. This ensures that the error message for cluster creation is the same regardless of whether the cluster was specified with a shared volume ("Single kubernetes cluster platform PLATFORM_TYPE_K8S_BARE_METAL only supports AppInst creates")