### PR TITLE
set ip access for k8s baremetal

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -1093,6 +1093,13 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			initCloudletRefs(&cloudletRefs, &in.Key.ClusterInstKey.CloudletKey)
 		}
 
+		if cloudletFeatures.IsSingleKubernetesCluster {
+			if in.DedicatedIp {
+				ipaccess = edgeproto.IpAccess_IP_ACCESS_DEDICATED
+			} else {
+				ipaccess = edgeproto.IpAccess_IP_ACCESS_SHARED
+			}
+		}
 		ports, _ := edgeproto.ParseAppPorts(app.AccessPorts)
 		if !cloudcommon.IsClusterInstReqd(&app) {
 			in.Uri = cloudcommon.GetVMAppFQDN(&in.Key, &in.Key.ClusterInstKey.CloudletKey, *appDNSRoot)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5943 anthos appinst create is not mapping ports to different public ports

### Description

For cloudlets with IsSingleKubernetesCluster=true, the IP access was not being left as Unknown. This causes 2 side effects
- FQDN is "defaultclust" and not "shared" for shared access
- port remapping is not done

This edge-cloud change sets the ipaccess type, there is a corresponding change in infra to use the original "shared" name for k8s baremetal shared LB name, this reverts a change I made earlier to accommodate the "defaultclust" name.