### PR TITLE
EDGECLOUD-5947 AutoScale Scale down not working

### DIFF
--- a/cloud-resource-manager/platform/common/xind/xind.go
+++ b/cloud-resource-manager/platform/common/xind/xind.go
@@ -3,6 +3,7 @@ package xind
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
@@ -72,6 +73,9 @@ func (s *Xind) GatherCloudletInfo(ctx context.Context, info *edgeproto.CloudletI
 			return fmt.Errorf("fail to fetch flavor %s", k)
 		}
 	}
+	sort.Slice(flavors[:], func(i, j int) bool {
+		return flavors[i].Name < flavors[j].Name
+	})
 	info.Flavors = flavors
 	return nil
 }

--- a/cloud-resource-manager/platform/kind/kind.go
+++ b/cloud-resource-manager/platform/kind/kind.go
@@ -18,7 +18,8 @@ func (s *Platform) Init(ctx context.Context, platformConfig *platform.PlatformCo
 
 func (s *Platform) GetFeatures() *platform.Features {
 	return &platform.Features{
-		SupportsMultiTenantCluster: true,
-		CloudletServicesLocal:      true,
+		SupportsMultiTenantCluster:   true,
+		CloudletServicesLocal:        true,
+		NoKubernetesClusterAutoScale: true,
 	}
 }

--- a/cloud-resource-manager/platform/platform.go
+++ b/cloud-resource-manager/platform/platform.go
@@ -76,6 +76,7 @@ type Features struct {
 	IsSingleKubernetesCluster        bool // Entire platform is just a single K8S cluster
 	SupportsAppInstDedicatedIP       bool // Supports per AppInst dedicated IPs
 	SupportsPlatformHighAvailability bool // Supports High Availablity with 2 CRMs
+	NoKubernetesClusterAutoScale     bool // No support for k8s cluster auto-scale
 }
 
 // Platform abstracts the underlying cloudlet platform.

--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -1164,7 +1164,7 @@ func (s *CloudletApi) UpdateCloudlet(in *edgeproto.Cloudlet, inCb edgeproto.Clou
 				if !features.SupportsMultiTenantCluster {
 					return fmt.Errorf("Serverless cluster not supported on %s", platName)
 				}
-				go s.all.clusterInstApi.createDefaultMultiTenantCluster(ctx, cur.Key)
+				go s.all.clusterInstApi.createDefaultMultiTenantCluster(ctx, cur.Key, features)
 			} else {
 				go s.all.clusterInstApi.deleteDefaultMultiTenantCluster(ctx, cur.Key)
 			}

--- a/controller/cloudletinfo_api.go
+++ b/controller/cloudletinfo_api.go
@@ -85,7 +85,7 @@ func (s *CloudletInfoApi) Update(ctx context.Context, in *edgeproto.CloudletInfo
 		features, err := GetCloudletFeatures(ctx, cloudlet.PlatformType)
 		if err == nil {
 			if features.SupportsMultiTenantCluster && cloudlet.EnableDefaultServerlessCluster {
-				go s.all.clusterInstApi.createDefaultMultiTenantCluster(ctx, in.Key)
+				go s.all.clusterInstApi.createDefaultMultiTenantCluster(ctx, in.Key, features)
 			}
 		}
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5947 AutoScale Scale down not working

### Description

Changes needed for kind local test:
- sort flavors from Kind platform so they are in deterministic order
- disable AutoScaler on Kind multi-tenant cluster, because updates are not supported