### PR TITLE
EDGECLOUD-5711 EDGECLOUD-5766 more consistent parse error messages

### DIFF
--- a/cli/input.go
+++ b/cli/input.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	dmeproto "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/util"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -655,6 +657,18 @@ func GetParseHelp(t reflect.Type) (string, string, bool) {
 	}
 	if t == reflect.TypeOf(time.Duration(0)) || t == reflect.TypeOf(edgeproto.Duration(0)) {
 		return "duration", fmt.Sprintf(", valid values are 300ms, 1s, 1.5h, 2h45m, etc"), true
+	}
+	if t == reflect.TypeOf(edgeproto.Udec64{}) {
+		return "unsigned decimal", "", true
+	}
+	if typ, help, ok := edgeproto.GetEnumParseHelp(t); ok {
+		return typ, help, true
+	}
+	if typ, help, ok := dmeproto.GetEnumParseHelp(t); ok {
+		return typ, help, true
+	}
+	if typ, help, ok := log.GetEnumParseHelp(t); ok {
+		return typ, help, true
 	}
 	return t.Kind().String(), GetParseHelpKind(t.Kind()), false
 }

--- a/d-match-engine/dme-proto/app-client.pb.go
+++ b/d-match-engine/dme-proto/app-client.pb.go
@@ -7504,25 +7504,44 @@ var IDTypes_CamelValue = map[string]int32{
 	"Ipaddr":      3,
 }
 
+func ParseIDTypes(data interface{}) (IDTypes, error) {
+	if val, ok := data.(IDTypes); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := IDTypes_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = IDTypes_CamelName[val]
+			}
+		}
+		if !ok {
+			return IDTypes(0), fmt.Errorf("Invalid IDTypes value %q", str)
+		}
+		return IDTypes(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := IDTypes_CamelName[ival]; ok {
+			return IDTypes(ival), nil
+		} else {
+			return IDTypes(0), fmt.Errorf("Invalid IDTypes value %d", ival)
+		}
+	}
+	return IDTypes(0), fmt.Errorf("Invalid IDTypes value %v", data)
+}
+
 func (e *IDTypes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := IDTypes_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = IDTypes_CamelName[val]
-		}
+	val, err := ParseIDTypes(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid IDTypes value %q", str)
-	}
-	*e = IDTypes(val)
+	*e = val
 	return nil
 }
 
@@ -7536,32 +7555,29 @@ func (e *IDTypes) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := IDTypes_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = IDTypes_CamelName[val]
+		val, err := ParseIDTypes(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(IDTypes(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid IDTypes value %q", str)
-		}
 		*e = IDTypes(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := IDTypes_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid IDTypes value %d", val)
+		val, err := ParseIDTypes(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = IDTypes(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid IDTypes value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(IDTypes(0)),
+	}
 }
 
 func (e IDTypes) MarshalJSON() ([]byte, error) {
@@ -7595,43 +7611,10 @@ var ReplyStatus_CamelValue = map[string]int32{
 	"RsFail":      2,
 }
 
-func (e *ReplyStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := ReplyStatus_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = ReplyStatus_CamelValue["Rs"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = ReplyStatus_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid ReplyStatus value %q", str)
-	}
-	*e = ReplyStatus(val)
-	return nil
-}
-
-func (e ReplyStatus) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(ReplyStatus_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Rs")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *ReplyStatus) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseReplyStatus(data interface{}) (ReplyStatus, error) {
+	if val, ok := data.(ReplyStatus); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := ReplyStatus_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -7646,22 +7629,67 @@ func (e *ReplyStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid ReplyStatus value %q", str)
+			return ReplyStatus(0), fmt.Errorf("Invalid ReplyStatus value %q", str)
 		}
-		*e = ReplyStatus(val)
-		return nil
+		return ReplyStatus(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := ReplyStatus_CamelName[ival]; ok {
+			return ReplyStatus(ival), nil
+		} else {
+			return ReplyStatus(0), fmt.Errorf("Invalid ReplyStatus value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return ReplyStatus(0), fmt.Errorf("Invalid ReplyStatus value %v", data)
+}
+
+func (e *ReplyStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseReplyStatus(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e ReplyStatus) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(ReplyStatus_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Rs")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *ReplyStatus) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := ReplyStatus_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid ReplyStatus value %d", val)
+		val, err := ParseReplyStatus(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(ReplyStatus(0)),
+			}
 		}
 		*e = ReplyStatus(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid ReplyStatus value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseReplyStatus(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(ReplyStatus(0)),
+	}
 }
 
 func (e ReplyStatus) MarshalJSON() ([]byte, error) {
@@ -7698,43 +7726,10 @@ var FindCloudletReply_FindStatus_CamelValue = map[string]int32{
 	"FindNotfound": 2,
 }
 
-func (e *FindCloudletReply_FindStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := FindCloudletReply_FindStatus_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = FindCloudletReply_FindStatus_CamelValue["Find"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = FindCloudletReply_FindStatus_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid FindCloudletReply_FindStatus value %q", str)
-	}
-	*e = FindCloudletReply_FindStatus(val)
-	return nil
-}
-
-func (e FindCloudletReply_FindStatus) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(FindCloudletReply_FindStatus_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Find")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *FindCloudletReply_FindStatus) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseFindCloudletReply_FindStatus(data interface{}) (FindCloudletReply_FindStatus, error) {
+	if val, ok := data.(FindCloudletReply_FindStatus); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := FindCloudletReply_FindStatus_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -7749,22 +7744,67 @@ func (e *FindCloudletReply_FindStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid FindCloudletReply_FindStatus value %q", str)
+			return FindCloudletReply_FindStatus(0), fmt.Errorf("Invalid FindCloudletReply_FindStatus value %q", str)
 		}
-		*e = FindCloudletReply_FindStatus(val)
-		return nil
+		return FindCloudletReply_FindStatus(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := FindCloudletReply_FindStatus_CamelName[ival]; ok {
+			return FindCloudletReply_FindStatus(ival), nil
+		} else {
+			return FindCloudletReply_FindStatus(0), fmt.Errorf("Invalid FindCloudletReply_FindStatus value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return FindCloudletReply_FindStatus(0), fmt.Errorf("Invalid FindCloudletReply_FindStatus value %v", data)
+}
+
+func (e *FindCloudletReply_FindStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseFindCloudletReply_FindStatus(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e FindCloudletReply_FindStatus) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(FindCloudletReply_FindStatus_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Find")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *FindCloudletReply_FindStatus) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := FindCloudletReply_FindStatus_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid FindCloudletReply_FindStatus value %d", val)
+		val, err := ParseFindCloudletReply_FindStatus(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(FindCloudletReply_FindStatus(0)),
+			}
 		}
 		*e = FindCloudletReply_FindStatus(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid FindCloudletReply_FindStatus value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseFindCloudletReply_FindStatus(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(FindCloudletReply_FindStatus(0)),
+	}
 }
 
 func (e FindCloudletReply_FindStatus) MarshalJSON() ([]byte, error) {
@@ -7801,25 +7841,44 @@ var VerifyLocationReply_TowerStatus_CamelValue = map[string]int32{
 	"NotConnectedToSpecifiedTower": 2,
 }
 
+func ParseVerifyLocationReply_TowerStatus(data interface{}) (VerifyLocationReply_TowerStatus, error) {
+	if val, ok := data.(VerifyLocationReply_TowerStatus); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := VerifyLocationReply_TowerStatus_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = VerifyLocationReply_TowerStatus_CamelName[val]
+			}
+		}
+		if !ok {
+			return VerifyLocationReply_TowerStatus(0), fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %q", str)
+		}
+		return VerifyLocationReply_TowerStatus(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := VerifyLocationReply_TowerStatus_CamelName[ival]; ok {
+			return VerifyLocationReply_TowerStatus(ival), nil
+		} else {
+			return VerifyLocationReply_TowerStatus(0), fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %d", ival)
+		}
+	}
+	return VerifyLocationReply_TowerStatus(0), fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %v", data)
+}
+
 func (e *VerifyLocationReply_TowerStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := VerifyLocationReply_TowerStatus_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = VerifyLocationReply_TowerStatus_CamelName[val]
-		}
+	val, err := ParseVerifyLocationReply_TowerStatus(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %q", str)
-	}
-	*e = VerifyLocationReply_TowerStatus(val)
+	*e = val
 	return nil
 }
 
@@ -7833,32 +7892,29 @@ func (e *VerifyLocationReply_TowerStatus) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := VerifyLocationReply_TowerStatus_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = VerifyLocationReply_TowerStatus_CamelName[val]
+		val, err := ParseVerifyLocationReply_TowerStatus(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(VerifyLocationReply_TowerStatus(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %q", str)
-		}
 		*e = VerifyLocationReply_TowerStatus(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := VerifyLocationReply_TowerStatus_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %d", val)
+		val, err := ParseVerifyLocationReply_TowerStatus(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = VerifyLocationReply_TowerStatus(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid VerifyLocationReply_TowerStatus value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(VerifyLocationReply_TowerStatus(0)),
+	}
 }
 
 func (e VerifyLocationReply_TowerStatus) MarshalJSON() ([]byte, error) {
@@ -7917,43 +7973,10 @@ var VerifyLocationReply_GPSLocationStatus_CamelValue = map[string]int32{
 	"LocErrorOther":             7,
 }
 
-func (e *VerifyLocationReply_GPSLocationStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := VerifyLocationReply_GPSLocationStatus_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = VerifyLocationReply_GPSLocationStatus_CamelValue["Loc"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = VerifyLocationReply_GPSLocationStatus_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %q", str)
-	}
-	*e = VerifyLocationReply_GPSLocationStatus(val)
-	return nil
-}
-
-func (e VerifyLocationReply_GPSLocationStatus) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(VerifyLocationReply_GPSLocationStatus_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Loc")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *VerifyLocationReply_GPSLocationStatus) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseVerifyLocationReply_GPSLocationStatus(data interface{}) (VerifyLocationReply_GPSLocationStatus, error) {
+	if val, ok := data.(VerifyLocationReply_GPSLocationStatus); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := VerifyLocationReply_GPSLocationStatus_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -7968,22 +7991,67 @@ func (e *VerifyLocationReply_GPSLocationStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %q", str)
+			return VerifyLocationReply_GPSLocationStatus(0), fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %q", str)
 		}
-		*e = VerifyLocationReply_GPSLocationStatus(val)
-		return nil
+		return VerifyLocationReply_GPSLocationStatus(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := VerifyLocationReply_GPSLocationStatus_CamelName[ival]; ok {
+			return VerifyLocationReply_GPSLocationStatus(ival), nil
+		} else {
+			return VerifyLocationReply_GPSLocationStatus(0), fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return VerifyLocationReply_GPSLocationStatus(0), fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %v", data)
+}
+
+func (e *VerifyLocationReply_GPSLocationStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseVerifyLocationReply_GPSLocationStatus(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e VerifyLocationReply_GPSLocationStatus) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(VerifyLocationReply_GPSLocationStatus_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Loc")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *VerifyLocationReply_GPSLocationStatus) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := VerifyLocationReply_GPSLocationStatus_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %d", val)
+		val, err := ParseVerifyLocationReply_GPSLocationStatus(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(VerifyLocationReply_GPSLocationStatus(0)),
+			}
 		}
 		*e = VerifyLocationReply_GPSLocationStatus(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid VerifyLocationReply_GPSLocationStatus value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseVerifyLocationReply_GPSLocationStatus(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(VerifyLocationReply_GPSLocationStatus(0)),
+	}
 }
 
 func (e VerifyLocationReply_GPSLocationStatus) MarshalJSON() ([]byte, error) {
@@ -8020,43 +8088,10 @@ var GetLocationReply_LocStatus_CamelValue = map[string]int32{
 	"LocDenied":  2,
 }
 
-func (e *GetLocationReply_LocStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := GetLocationReply_LocStatus_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = GetLocationReply_LocStatus_CamelValue["Loc"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = GetLocationReply_LocStatus_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid GetLocationReply_LocStatus value %q", str)
-	}
-	*e = GetLocationReply_LocStatus(val)
-	return nil
-}
-
-func (e GetLocationReply_LocStatus) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(GetLocationReply_LocStatus_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Loc")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *GetLocationReply_LocStatus) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseGetLocationReply_LocStatus(data interface{}) (GetLocationReply_LocStatus, error) {
+	if val, ok := data.(GetLocationReply_LocStatus); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := GetLocationReply_LocStatus_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -8071,22 +8106,67 @@ func (e *GetLocationReply_LocStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid GetLocationReply_LocStatus value %q", str)
+			return GetLocationReply_LocStatus(0), fmt.Errorf("Invalid GetLocationReply_LocStatus value %q", str)
 		}
-		*e = GetLocationReply_LocStatus(val)
-		return nil
+		return GetLocationReply_LocStatus(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := GetLocationReply_LocStatus_CamelName[ival]; ok {
+			return GetLocationReply_LocStatus(ival), nil
+		} else {
+			return GetLocationReply_LocStatus(0), fmt.Errorf("Invalid GetLocationReply_LocStatus value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return GetLocationReply_LocStatus(0), fmt.Errorf("Invalid GetLocationReply_LocStatus value %v", data)
+}
+
+func (e *GetLocationReply_LocStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseGetLocationReply_LocStatus(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e GetLocationReply_LocStatus) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(GetLocationReply_LocStatus_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Loc")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *GetLocationReply_LocStatus) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := GetLocationReply_LocStatus_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid GetLocationReply_LocStatus value %d", val)
+		val, err := ParseGetLocationReply_LocStatus(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(GetLocationReply_LocStatus(0)),
+			}
 		}
 		*e = GetLocationReply_LocStatus(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid GetLocationReply_LocStatus value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseGetLocationReply_LocStatus(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(GetLocationReply_LocStatus(0)),
+	}
 }
 
 func (e GetLocationReply_LocStatus) MarshalJSON() ([]byte, error) {
@@ -8123,43 +8203,10 @@ var AppInstListReply_AIStatus_CamelValue = map[string]int32{
 	"AiFail":      2,
 }
 
-func (e *AppInstListReply_AIStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := AppInstListReply_AIStatus_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = AppInstListReply_AIStatus_CamelValue["Ai"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = AppInstListReply_AIStatus_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid AppInstListReply_AIStatus value %q", str)
-	}
-	*e = AppInstListReply_AIStatus(val)
-	return nil
-}
-
-func (e AppInstListReply_AIStatus) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(AppInstListReply_AIStatus_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Ai")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *AppInstListReply_AIStatus) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseAppInstListReply_AIStatus(data interface{}) (AppInstListReply_AIStatus, error) {
+	if val, ok := data.(AppInstListReply_AIStatus); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := AppInstListReply_AIStatus_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -8174,22 +8221,67 @@ func (e *AppInstListReply_AIStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid AppInstListReply_AIStatus value %q", str)
+			return AppInstListReply_AIStatus(0), fmt.Errorf("Invalid AppInstListReply_AIStatus value %q", str)
 		}
-		*e = AppInstListReply_AIStatus(val)
-		return nil
+		return AppInstListReply_AIStatus(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := AppInstListReply_AIStatus_CamelName[ival]; ok {
+			return AppInstListReply_AIStatus(ival), nil
+		} else {
+			return AppInstListReply_AIStatus(0), fmt.Errorf("Invalid AppInstListReply_AIStatus value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return AppInstListReply_AIStatus(0), fmt.Errorf("Invalid AppInstListReply_AIStatus value %v", data)
+}
+
+func (e *AppInstListReply_AIStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseAppInstListReply_AIStatus(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e AppInstListReply_AIStatus) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(AppInstListReply_AIStatus_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Ai")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *AppInstListReply_AIStatus) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := AppInstListReply_AIStatus_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid AppInstListReply_AIStatus value %d", val)
+		val, err := ParseAppInstListReply_AIStatus(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(AppInstListReply_AIStatus(0)),
+			}
 		}
 		*e = AppInstListReply_AIStatus(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid AppInstListReply_AIStatus value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseAppInstListReply_AIStatus(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(AppInstListReply_AIStatus(0)),
+	}
 }
 
 func (e AppInstListReply_AIStatus) MarshalJSON() ([]byte, error) {
@@ -8226,43 +8318,10 @@ var FqdnListReply_FLStatus_CamelValue = map[string]int32{
 	"FlFail":      2,
 }
 
-func (e *FqdnListReply_FLStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := FqdnListReply_FLStatus_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = FqdnListReply_FLStatus_CamelValue["Fl"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = FqdnListReply_FLStatus_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid FqdnListReply_FLStatus value %q", str)
-	}
-	*e = FqdnListReply_FLStatus(val)
-	return nil
-}
-
-func (e FqdnListReply_FLStatus) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(FqdnListReply_FLStatus_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Fl")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *FqdnListReply_FLStatus) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseFqdnListReply_FLStatus(data interface{}) (FqdnListReply_FLStatus, error) {
+	if val, ok := data.(FqdnListReply_FLStatus); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := FqdnListReply_FLStatus_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -8277,22 +8336,67 @@ func (e *FqdnListReply_FLStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid FqdnListReply_FLStatus value %q", str)
+			return FqdnListReply_FLStatus(0), fmt.Errorf("Invalid FqdnListReply_FLStatus value %q", str)
 		}
-		*e = FqdnListReply_FLStatus(val)
-		return nil
+		return FqdnListReply_FLStatus(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := FqdnListReply_FLStatus_CamelName[ival]; ok {
+			return FqdnListReply_FLStatus(ival), nil
+		} else {
+			return FqdnListReply_FLStatus(0), fmt.Errorf("Invalid FqdnListReply_FLStatus value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return FqdnListReply_FLStatus(0), fmt.Errorf("Invalid FqdnListReply_FLStatus value %v", data)
+}
+
+func (e *FqdnListReply_FLStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseFqdnListReply_FLStatus(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e FqdnListReply_FLStatus) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(FqdnListReply_FLStatus_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Fl")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *FqdnListReply_FLStatus) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := FqdnListReply_FLStatus_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid FqdnListReply_FLStatus value %d", val)
+		val, err := ParseFqdnListReply_FLStatus(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(FqdnListReply_FLStatus(0)),
+			}
 		}
 		*e = FqdnListReply_FLStatus(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid FqdnListReply_FLStatus value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseFqdnListReply_FLStatus(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(FqdnListReply_FLStatus(0)),
+	}
 }
 
 func (e FqdnListReply_FLStatus) MarshalJSON() ([]byte, error) {
@@ -8329,43 +8433,10 @@ var AppOfficialFqdnReply_AOFStatus_CamelValue = map[string]int32{
 	"AofFail":      2,
 }
 
-func (e *AppOfficialFqdnReply_AOFStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := AppOfficialFqdnReply_AOFStatus_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = AppOfficialFqdnReply_AOFStatus_CamelValue["Aof"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = AppOfficialFqdnReply_AOFStatus_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %q", str)
-	}
-	*e = AppOfficialFqdnReply_AOFStatus(val)
-	return nil
-}
-
-func (e AppOfficialFqdnReply_AOFStatus) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(AppOfficialFqdnReply_AOFStatus_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Aof")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *AppOfficialFqdnReply_AOFStatus) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseAppOfficialFqdnReply_AOFStatus(data interface{}) (AppOfficialFqdnReply_AOFStatus, error) {
+	if val, ok := data.(AppOfficialFqdnReply_AOFStatus); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := AppOfficialFqdnReply_AOFStatus_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -8380,22 +8451,67 @@ func (e *AppOfficialFqdnReply_AOFStatus) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %q", str)
+			return AppOfficialFqdnReply_AOFStatus(0), fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %q", str)
 		}
-		*e = AppOfficialFqdnReply_AOFStatus(val)
-		return nil
+		return AppOfficialFqdnReply_AOFStatus(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := AppOfficialFqdnReply_AOFStatus_CamelName[ival]; ok {
+			return AppOfficialFqdnReply_AOFStatus(ival), nil
+		} else {
+			return AppOfficialFqdnReply_AOFStatus(0), fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return AppOfficialFqdnReply_AOFStatus(0), fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %v", data)
+}
+
+func (e *AppOfficialFqdnReply_AOFStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseAppOfficialFqdnReply_AOFStatus(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e AppOfficialFqdnReply_AOFStatus) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(AppOfficialFqdnReply_AOFStatus_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Aof")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *AppOfficialFqdnReply_AOFStatus) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := AppOfficialFqdnReply_AOFStatus_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %d", val)
+		val, err := ParseAppOfficialFqdnReply_AOFStatus(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(AppOfficialFqdnReply_AOFStatus(0)),
+			}
 		}
 		*e = AppOfficialFqdnReply_AOFStatus(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid AppOfficialFqdnReply_AOFStatus value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseAppOfficialFqdnReply_AOFStatus(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(AppOfficialFqdnReply_AOFStatus(0)),
+	}
 }
 
 func (e AppOfficialFqdnReply_AOFStatus) MarshalJSON() ([]byte, error) {
@@ -8432,43 +8548,10 @@ var DynamicLocGroupRequest_DlgCommType_CamelValue = map[string]int32{
 	"DlgOpen":      2,
 }
 
-func (e *DynamicLocGroupRequest_DlgCommType) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := DynamicLocGroupRequest_DlgCommType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = DynamicLocGroupRequest_DlgCommType_CamelValue["Dlg"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = DynamicLocGroupRequest_DlgCommType_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %q", str)
-	}
-	*e = DynamicLocGroupRequest_DlgCommType(val)
-	return nil
-}
-
-func (e DynamicLocGroupRequest_DlgCommType) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(DynamicLocGroupRequest_DlgCommType_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Dlg")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *DynamicLocGroupRequest_DlgCommType) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseDynamicLocGroupRequest_DlgCommType(data interface{}) (DynamicLocGroupRequest_DlgCommType, error) {
+	if val, ok := data.(DynamicLocGroupRequest_DlgCommType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := DynamicLocGroupRequest_DlgCommType_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -8483,22 +8566,67 @@ func (e *DynamicLocGroupRequest_DlgCommType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %q", str)
+			return DynamicLocGroupRequest_DlgCommType(0), fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %q", str)
 		}
-		*e = DynamicLocGroupRequest_DlgCommType(val)
-		return nil
+		return DynamicLocGroupRequest_DlgCommType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := DynamicLocGroupRequest_DlgCommType_CamelName[ival]; ok {
+			return DynamicLocGroupRequest_DlgCommType(ival), nil
+		} else {
+			return DynamicLocGroupRequest_DlgCommType(0), fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return DynamicLocGroupRequest_DlgCommType(0), fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %v", data)
+}
+
+func (e *DynamicLocGroupRequest_DlgCommType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseDynamicLocGroupRequest_DlgCommType(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e DynamicLocGroupRequest_DlgCommType) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(DynamicLocGroupRequest_DlgCommType_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Dlg")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *DynamicLocGroupRequest_DlgCommType) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := DynamicLocGroupRequest_DlgCommType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %d", val)
+		val, err := ParseDynamicLocGroupRequest_DlgCommType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(DynamicLocGroupRequest_DlgCommType(0)),
+			}
 		}
 		*e = DynamicLocGroupRequest_DlgCommType(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid DynamicLocGroupRequest_DlgCommType value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseDynamicLocGroupRequest_DlgCommType(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(DynamicLocGroupRequest_DlgCommType(0)),
+	}
 }
 
 func (e DynamicLocGroupRequest_DlgCommType) MarshalJSON() ([]byte, error) {
@@ -8550,43 +8678,10 @@ var ClientEdgeEvent_ClientEventType_CamelValue = map[string]int32{
 	"EventCustomEvent":         5,
 }
 
-func (e *ClientEdgeEvent_ClientEventType) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := ClientEdgeEvent_ClientEventType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = ClientEdgeEvent_ClientEventType_CamelValue["Event"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = ClientEdgeEvent_ClientEventType_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %q", str)
-	}
-	*e = ClientEdgeEvent_ClientEventType(val)
-	return nil
-}
-
-func (e ClientEdgeEvent_ClientEventType) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(ClientEdgeEvent_ClientEventType_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Event")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *ClientEdgeEvent_ClientEventType) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseClientEdgeEvent_ClientEventType(data interface{}) (ClientEdgeEvent_ClientEventType, error) {
+	if val, ok := data.(ClientEdgeEvent_ClientEventType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := ClientEdgeEvent_ClientEventType_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -8601,22 +8696,67 @@ func (e *ClientEdgeEvent_ClientEventType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %q", str)
+			return ClientEdgeEvent_ClientEventType(0), fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %q", str)
 		}
-		*e = ClientEdgeEvent_ClientEventType(val)
-		return nil
+		return ClientEdgeEvent_ClientEventType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := ClientEdgeEvent_ClientEventType_CamelName[ival]; ok {
+			return ClientEdgeEvent_ClientEventType(ival), nil
+		} else {
+			return ClientEdgeEvent_ClientEventType(0), fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return ClientEdgeEvent_ClientEventType(0), fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %v", data)
+}
+
+func (e *ClientEdgeEvent_ClientEventType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseClientEdgeEvent_ClientEventType(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e ClientEdgeEvent_ClientEventType) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(ClientEdgeEvent_ClientEventType_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Event")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *ClientEdgeEvent_ClientEventType) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := ClientEdgeEvent_ClientEventType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %d", val)
+		val, err := ParseClientEdgeEvent_ClientEventType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(ClientEdgeEvent_ClientEventType(0)),
+			}
 		}
 		*e = ClientEdgeEvent_ClientEventType(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid ClientEdgeEvent_ClientEventType value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseClientEdgeEvent_ClientEventType(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(ClientEdgeEvent_ClientEventType(0)),
+	}
 }
 
 func (e ClientEdgeEvent_ClientEventType) MarshalJSON() ([]byte, error) {
@@ -8683,43 +8823,10 @@ var ServerEdgeEvent_ServerEventType_CamelValue = map[string]int32{
 	"EventError":               8,
 }
 
-func (e *ServerEdgeEvent_ServerEventType) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := ServerEdgeEvent_ServerEventType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = ServerEdgeEvent_ServerEventType_CamelValue["Event"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = ServerEdgeEvent_ServerEventType_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %q", str)
-	}
-	*e = ServerEdgeEvent_ServerEventType(val)
-	return nil
-}
-
-func (e ServerEdgeEvent_ServerEventType) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(ServerEdgeEvent_ServerEventType_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Event")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *ServerEdgeEvent_ServerEventType) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseServerEdgeEvent_ServerEventType(data interface{}) (ServerEdgeEvent_ServerEventType, error) {
+	if val, ok := data.(ServerEdgeEvent_ServerEventType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := ServerEdgeEvent_ServerEventType_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -8734,22 +8841,67 @@ func (e *ServerEdgeEvent_ServerEventType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %q", str)
+			return ServerEdgeEvent_ServerEventType(0), fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %q", str)
 		}
-		*e = ServerEdgeEvent_ServerEventType(val)
-		return nil
+		return ServerEdgeEvent_ServerEventType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := ServerEdgeEvent_ServerEventType_CamelName[ival]; ok {
+			return ServerEdgeEvent_ServerEventType(ival), nil
+		} else {
+			return ServerEdgeEvent_ServerEventType(0), fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return ServerEdgeEvent_ServerEventType(0), fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %v", data)
+}
+
+func (e *ServerEdgeEvent_ServerEventType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseServerEdgeEvent_ServerEventType(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e ServerEdgeEvent_ServerEventType) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(ServerEdgeEvent_ServerEventType_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Event")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *ServerEdgeEvent_ServerEventType) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := ServerEdgeEvent_ServerEventType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %d", val)
+		val, err := ParseServerEdgeEvent_ServerEventType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(ServerEdgeEvent_ServerEventType(0)),
+			}
 		}
 		*e = ServerEdgeEvent_ServerEventType(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid ServerEdgeEvent_ServerEventType value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseServerEdgeEvent_ServerEventType(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(ServerEdgeEvent_ServerEventType(0)),
+	}
 }
 
 func (e ServerEdgeEvent_ServerEventType) MarshalJSON() ([]byte, error) {
@@ -8844,48 +8996,43 @@ func applyMatchOptions(opts *MatchOptions, args ...MatchOpt) {
 // Allows decoding to handle protobuf enums that are
 // represented as strings.
 func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
-	if from.Kind() != reflect.String {
-		return data, nil
-	}
 	switch to {
 	case reflect.TypeOf(LProto(0)):
-		if en, ok := LProto_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := LProto_CamelValue["LProto"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseLProto(data)
 	case reflect.TypeOf(HealthCheck(0)):
-		if en, ok := HealthCheck_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := HealthCheck_CamelValue["HealthCheck"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseHealthCheck(data)
 	case reflect.TypeOf(CloudletState(0)):
-		if en, ok := CloudletState_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := CloudletState_CamelValue["CloudletState"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseCloudletState(data)
 	case reflect.TypeOf(MaintenanceState(0)):
-		if en, ok := MaintenanceState_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseMaintenanceState(data)
 	case reflect.TypeOf(IDTypes(0)):
-		if en, ok := IDTypes_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseIDTypes(data)
 	case reflect.TypeOf(ReplyStatus(0)):
-		if en, ok := ReplyStatus_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := ReplyStatus_CamelValue["Rs"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseReplyStatus(data)
 	}
 	return data, nil
+}
+
+// GetEnumParseHelp gets end-user specific messages for
+// enum parse errors.
+// It returns the enum type name, a help message with
+// valid values, and a bool that indicates if a type was matched.
+func GetEnumParseHelp(t reflect.Type) (string, string, bool) {
+	switch t {
+	case reflect.TypeOf(LProto(0)):
+		return "LProto", ", valid values are one of Unknown, Tcp, Udp, or 0, 1, 2", true
+	case reflect.TypeOf(HealthCheck(0)):
+		return "HealthCheck", ", valid values are one of Unknown, FailRootlbOffline, FailServerFail, Ok, CloudletOffline, or 0, 1, 2, 3, 4", true
+	case reflect.TypeOf(CloudletState(0)):
+		return "CloudletState", ", valid values are one of Unknown, Errors, Ready, Offline, NotPresent, Init, Upgrade, NeedSync, or 0, 1, 2, 3, 4, 5, 6, 7", true
+	case reflect.TypeOf(MaintenanceState(0)):
+		return "MaintenanceState", ", valid values are one of NormalOperation, MaintenanceStart, FailoverRequested, FailoverDone, FailoverError, MaintenanceStartNoFailover, CrmRequested, CrmUnderMaintenance, CrmError, NormalOperationInit, UnderMaintenance, or 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 31", true
+	case reflect.TypeOf(IDTypes(0)):
+		return "IDTypes", ", valid values are one of IdUndefined, Imei, Msisdn, Ipaddr, or 0, 1, 2, 3", true
+	case reflect.TypeOf(ReplyStatus(0)):
+		return "ReplyStatus", ", valid values are one of Undefined, Success, Fail, or 0, 1, 2", true
+	}
+	return "", "", false
 }
 
 var ShowMethodNames = map[string]struct{}{}

--- a/d-match-engine/dme-proto/appcommon.pb.go
+++ b/d-match-engine/dme-proto/appcommon.pb.go
@@ -13,6 +13,7 @@ import (
 	io "io"
 	math "math"
 	math_bits "math/bits"
+	reflect "reflect"
 	"strconv"
 	strings "strings"
 )
@@ -767,43 +768,10 @@ var LProto_CamelValue = map[string]int32{
 	"LProtoUdp":     2,
 }
 
-func (e *LProto) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := LProto_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = LProto_CamelValue["LProto"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = LProto_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid LProto value %q", str)
-	}
-	*e = LProto(val)
-	return nil
-}
-
-func (e LProto) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(LProto_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "LProto")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *LProto) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseLProto(data interface{}) (LProto, error) {
+	if val, ok := data.(LProto); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := LProto_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -818,22 +786,67 @@ func (e *LProto) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid LProto value %q", str)
+			return LProto(0), fmt.Errorf("Invalid LProto value %q", str)
 		}
-		*e = LProto(val)
-		return nil
+		return LProto(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := LProto_CamelName[ival]; ok {
+			return LProto(ival), nil
+		} else {
+			return LProto(0), fmt.Errorf("Invalid LProto value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return LProto(0), fmt.Errorf("Invalid LProto value %v", data)
+}
+
+func (e *LProto) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseLProto(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e LProto) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(LProto_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "LProto")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *LProto) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := LProto_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid LProto value %d", val)
+		val, err := ParseLProto(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(LProto(0)),
+			}
 		}
 		*e = LProto(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid LProto value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseLProto(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(LProto(0)),
+	}
 }
 
 func (e LProto) MarshalJSON() ([]byte, error) {
@@ -880,43 +893,10 @@ var HealthCheck_CamelValue = map[string]int32{
 	"HealthCheckCloudletOffline":   4,
 }
 
-func (e *HealthCheck) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := HealthCheck_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = HealthCheck_CamelValue["HealthCheck"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = HealthCheck_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid HealthCheck value %q", str)
-	}
-	*e = HealthCheck(val)
-	return nil
-}
-
-func (e HealthCheck) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(HealthCheck_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "HealthCheck")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *HealthCheck) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseHealthCheck(data interface{}) (HealthCheck, error) {
+	if val, ok := data.(HealthCheck); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := HealthCheck_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -931,22 +911,67 @@ func (e *HealthCheck) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid HealthCheck value %q", str)
+			return HealthCheck(0), fmt.Errorf("Invalid HealthCheck value %q", str)
 		}
-		*e = HealthCheck(val)
-		return nil
+		return HealthCheck(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := HealthCheck_CamelName[ival]; ok {
+			return HealthCheck(ival), nil
+		} else {
+			return HealthCheck(0), fmt.Errorf("Invalid HealthCheck value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return HealthCheck(0), fmt.Errorf("Invalid HealthCheck value %v", data)
+}
+
+func (e *HealthCheck) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseHealthCheck(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e HealthCheck) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(HealthCheck_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "HealthCheck")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *HealthCheck) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := HealthCheck_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid HealthCheck value %d", val)
+		val, err := ParseHealthCheck(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(HealthCheck(0)),
+			}
 		}
 		*e = HealthCheck(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid HealthCheck value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseHealthCheck(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(HealthCheck(0)),
+	}
 }
 
 func (e HealthCheck) MarshalJSON() ([]byte, error) {
@@ -1008,43 +1033,10 @@ var CloudletState_CamelValue = map[string]int32{
 	"CloudletStateNeedSync":   7,
 }
 
-func (e *CloudletState) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := CloudletState_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = CloudletState_CamelValue["CloudletState"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = CloudletState_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid CloudletState value %q", str)
-	}
-	*e = CloudletState(val)
-	return nil
-}
-
-func (e CloudletState) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(CloudletState_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "CloudletState")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *CloudletState) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseCloudletState(data interface{}) (CloudletState, error) {
+	if val, ok := data.(CloudletState); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := CloudletState_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -1059,22 +1051,67 @@ func (e *CloudletState) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid CloudletState value %q", str)
+			return CloudletState(0), fmt.Errorf("Invalid CloudletState value %q", str)
 		}
-		*e = CloudletState(val)
-		return nil
+		return CloudletState(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := CloudletState_CamelName[ival]; ok {
+			return CloudletState(ival), nil
+		} else {
+			return CloudletState(0), fmt.Errorf("Invalid CloudletState value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return CloudletState(0), fmt.Errorf("Invalid CloudletState value %v", data)
+}
+
+func (e *CloudletState) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseCloudletState(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e CloudletState) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(CloudletState_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "CloudletState")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *CloudletState) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := CloudletState_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid CloudletState value %d", val)
+		val, err := ParseCloudletState(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(CloudletState(0)),
+			}
 		}
 		*e = CloudletState(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid CloudletState value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseCloudletState(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(CloudletState(0)),
+	}
 }
 
 func (e CloudletState) MarshalJSON() ([]byte, error) {
@@ -1151,25 +1188,44 @@ var MaintenanceState_CamelValue = map[string]int32{
 	"UnderMaintenance":           31,
 }
 
+func ParseMaintenanceState(data interface{}) (MaintenanceState, error) {
+	if val, ok := data.(MaintenanceState); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := MaintenanceState_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = MaintenanceState_CamelName[val]
+			}
+		}
+		if !ok {
+			return MaintenanceState(0), fmt.Errorf("Invalid MaintenanceState value %q", str)
+		}
+		return MaintenanceState(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := MaintenanceState_CamelName[ival]; ok {
+			return MaintenanceState(ival), nil
+		} else {
+			return MaintenanceState(0), fmt.Errorf("Invalid MaintenanceState value %d", ival)
+		}
+	}
+	return MaintenanceState(0), fmt.Errorf("Invalid MaintenanceState value %v", data)
+}
+
 func (e *MaintenanceState) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := MaintenanceState_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = MaintenanceState_CamelName[val]
-		}
+	val, err := ParseMaintenanceState(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid MaintenanceState value %q", str)
-	}
-	*e = MaintenanceState(val)
+	*e = val
 	return nil
 }
 
@@ -1183,32 +1239,29 @@ func (e *MaintenanceState) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := MaintenanceState_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = MaintenanceState_CamelName[val]
+		val, err := ParseMaintenanceState(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(MaintenanceState(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid MaintenanceState value %q", str)
-		}
 		*e = MaintenanceState(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := MaintenanceState_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid MaintenanceState value %d", val)
+		val, err := ParseMaintenanceState(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = MaintenanceState(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid MaintenanceState value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(MaintenanceState(0)),
+	}
 }
 
 func (e MaintenanceState) MarshalJSON() ([]byte, error) {

--- a/d-match-engine/dme-proto/dynamic-location-group.pb.go
+++ b/d-match-engine/dme-proto/dynamic-location-group.pb.go
@@ -16,6 +16,7 @@ import (
 	io "io"
 	math "math"
 	math_bits "math/bits"
+	reflect "reflect"
 	"strconv"
 	strings "strings"
 )
@@ -491,43 +492,10 @@ var DlgMessage_DlgAck_CamelValue = map[string]int32{
 	"DlgNoAck":            2,
 }
 
-func (e *DlgMessage_DlgAck) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := DlgMessage_DlgAck_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = DlgMessage_DlgAck_CamelValue["Dlg"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = DlgMessage_DlgAck_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid DlgMessage_DlgAck value %q", str)
-	}
-	*e = DlgMessage_DlgAck(val)
-	return nil
-}
-
-func (e DlgMessage_DlgAck) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(DlgMessage_DlgAck_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Dlg")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *DlgMessage_DlgAck) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseDlgMessage_DlgAck(data interface{}) (DlgMessage_DlgAck, error) {
+	if val, ok := data.(DlgMessage_DlgAck); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := DlgMessage_DlgAck_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -542,22 +510,67 @@ func (e *DlgMessage_DlgAck) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid DlgMessage_DlgAck value %q", str)
+			return DlgMessage_DlgAck(0), fmt.Errorf("Invalid DlgMessage_DlgAck value %q", str)
 		}
-		*e = DlgMessage_DlgAck(val)
-		return nil
+		return DlgMessage_DlgAck(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := DlgMessage_DlgAck_CamelName[ival]; ok {
+			return DlgMessage_DlgAck(ival), nil
+		} else {
+			return DlgMessage_DlgAck(0), fmt.Errorf("Invalid DlgMessage_DlgAck value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return DlgMessage_DlgAck(0), fmt.Errorf("Invalid DlgMessage_DlgAck value %v", data)
+}
+
+func (e *DlgMessage_DlgAck) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseDlgMessage_DlgAck(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e DlgMessage_DlgAck) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(DlgMessage_DlgAck_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Dlg")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *DlgMessage_DlgAck) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := DlgMessage_DlgAck_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid DlgMessage_DlgAck value %d", val)
+		val, err := ParseDlgMessage_DlgAck(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(DlgMessage_DlgAck(0)),
+			}
 		}
 		*e = DlgMessage_DlgAck(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid DlgMessage_DlgAck value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseDlgMessage_DlgAck(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(DlgMessage_DlgAck(0)),
+	}
 }
 
 func (e DlgMessage_DlgAck) MarshalJSON() ([]byte, error) {

--- a/edgeproto/alert.pb.go
+++ b/edgeproto/alert.pb.go
@@ -1132,159 +1132,127 @@ func applyMatchOptions(opts *MatchOptions, args ...MatchOpt) {
 // Allows decoding to handle protobuf enums that are
 // represented as strings.
 func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
-	if from.Kind() != reflect.String {
-		return data, nil
-	}
 	switch to {
 	case reflect.TypeOf(OptResNames(0)):
-		if en, ok := OptResNames_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseOptResNames(data)
 	case reflect.TypeOf(Liveness(0)):
-		if en, ok := Liveness_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := Liveness_CamelValue["Liveness"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseLiveness(data)
 	case reflect.TypeOf(IpSupport(0)):
-		if en, ok := IpSupport_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := IpSupport_CamelValue["IpSupport"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseIpSupport(data)
 	case reflect.TypeOf(IpAccess(0)):
-		if en, ok := IpAccess_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := IpAccess_CamelValue["IpAccess"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseIpAccess(data)
 	case reflect.TypeOf(TrackedState(0)):
-		if en, ok := TrackedState_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseTrackedState(data)
 	case reflect.TypeOf(CRMOverride(0)):
-		if en, ok := CRMOverride_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseCRMOverride(data)
 	case reflect.TypeOf(ImageType(0)):
-		if en, ok := ImageType_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := ImageType_CamelValue["ImageType"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseImageType(data)
 	case reflect.TypeOf(QosSessionProfile(0)):
-		if en, ok := QosSessionProfile_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := QosSessionProfile_CamelValue["Qos"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseQosSessionProfile(data)
 	case reflect.TypeOf(VmAppOsType(0)):
-		if en, ok := VmAppOsType_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := VmAppOsType_CamelValue["VmAppOs"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseVmAppOsType(data)
 	case reflect.TypeOf(DeleteType(0)):
-		if en, ok := DeleteType_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseDeleteType(data)
 	case reflect.TypeOf(AccessType(0)):
-		if en, ok := AccessType_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := AccessType_CamelValue["AccessType"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseAccessType(data)
 	case reflect.TypeOf(PlatformType(0)):
-		if en, ok := PlatformType_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := PlatformType_CamelValue["PlatformType"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParsePlatformType(data)
 	case reflect.TypeOf(InfraApiAccess(0)):
-		if en, ok := InfraApiAccess_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseInfraApiAccess(data)
 	case reflect.TypeOf(OSType(0)):
-		if en, ok := OSType_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseOSType(data)
 	case reflect.TypeOf(ReportSchedule(0)):
-		if en, ok := ReportSchedule_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseReportSchedule(data)
 	case reflect.TypeOf(VMState(0)):
-		if en, ok := VMState_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := VMState_CamelValue["Vm"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseVMState(data)
 	case reflect.TypeOf(VMAction(0)):
-		if en, ok := VMAction_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := VMAction_CamelValue["VmAction"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseVMAction(data)
 	case reflect.TypeOf(TrustPolicyExceptionState(0)):
-		if en, ok := TrustPolicyExceptionState_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := TrustPolicyExceptionState_CamelValue["TrustPolicyExceptionState"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseTrustPolicyExceptionState(data)
 	case reflect.TypeOf(NetworkConnectionType(0)):
-		if en, ok := NetworkConnectionType_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseNetworkConnectionType(data)
 	case reflect.TypeOf(PowerState(0)):
-		if en, ok := PowerState_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParsePowerState(data)
 	case reflect.TypeOf(ApiEndpointType(0)):
-		if en, ok := ApiEndpointType_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseApiEndpointType(data)
 	case reflect.TypeOf(RateLimitTarget(0)):
-		if en, ok := RateLimitTarget_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseRateLimitTarget(data)
 	case reflect.TypeOf(FlowRateLimitAlgorithm(0)):
-		if en, ok := FlowRateLimitAlgorithm_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseFlowRateLimitAlgorithm(data)
 	case reflect.TypeOf(MaxReqsRateLimitAlgorithm(0)):
-		if en, ok := MaxReqsRateLimitAlgorithm_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseMaxReqsRateLimitAlgorithm(data)
 	case reflect.TypeOf(NoticeAction(0)):
-		if en, ok := NoticeAction_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseNoticeAction(data)
 	case reflect.TypeOf(StreamState(0)):
-		if en, ok := StreamState_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := StreamState_CamelValue["Stream"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseStreamState(data)
 	case reflect.TypeOf(VersionHash(0)):
-		if en, ok := VersionHash_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := VersionHash_CamelValue["Hash"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseVersionHash(data)
 	}
 	return data, nil
+}
+
+// GetEnumParseHelp gets end-user specific messages for
+// enum parse errors.
+// It returns the enum type name, a help message with
+// valid values, and a bool that indicates if a type was matched.
+func GetEnumParseHelp(t reflect.Type) (string, string, bool) {
+	switch t {
+	case reflect.TypeOf(OptResNames(0)):
+		return "OptResNames", ", valid values are one of Gpu, Nas, Nic, or 0, 1, 2", true
+	case reflect.TypeOf(Liveness(0)):
+		return "Liveness", ", valid values are one of Unknown, Static, Dynamic, Autoprov, or 0, 1, 2, 3", true
+	case reflect.TypeOf(IpSupport(0)):
+		return "IpSupport", ", valid values are one of Unknown, Static, Dynamic, or 0, 1, 2", true
+	case reflect.TypeOf(IpAccess(0)):
+		return "IpAccess", ", valid values are one of Unknown, Dedicated, Shared, or 0, 1, 3", true
+	case reflect.TypeOf(TrackedState(0)):
+		return "TrackedState", ", valid values are one of TrackedStateUnknown, NotPresent, CreateRequested, Creating, CreateError, Ready, UpdateRequested, Updating, UpdateError, DeleteRequested, Deleting, DeleteError, DeletePrepare, CrmInitok, CreatingDependencies, DeleteDone, or 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15", true
+	case reflect.TypeOf(CRMOverride(0)):
+		return "CRMOverride", ", valid values are one of NoOverride, IgnoreCrmErrors, IgnoreCrm, IgnoreTransientState, IgnoreCrmAndTransientState, or 0, 1, 2, 3, 4", true
+	case reflect.TypeOf(ImageType(0)):
+		return "ImageType", ", valid values are one of Unknown, Docker, Qcow, Helm, Ovf, or 0, 1, 2, 3, 4", true
+	case reflect.TypeOf(QosSessionProfile(0)):
+		return "QosSessionProfile", ", valid values are one of NoPriority, LowLatency, ThroughputDownS, ThroughputDownM, ThroughputDownL, or 0, 1, 2, 3, 4", true
+	case reflect.TypeOf(VmAppOsType(0)):
+		return "VmAppOsType", ", valid values are one of Unknown, Linux, Windows10, Windows2012, Windows2016, Windows2019, or 0, 1, 2, 3, 4, 5", true
+	case reflect.TypeOf(DeleteType(0)):
+		return "DeleteType", ", valid values are one of NoAutoDelete, AutoDelete, or 0, 1", true
+	case reflect.TypeOf(AccessType(0)):
+		return "AccessType", ", valid values are one of DefaultForDeployment, Direct, LoadBalancer, or 0, 1, 2", true
+	case reflect.TypeOf(PlatformType(0)):
+		return "PlatformType", ", valid values are one of Fake, Dind, Openstack, Azure, Gcp, Edgebox, Fakeinfra, Vsphere, AwsEks, VmPool, AwsEc2, Vcd, K8SBareMetal, Kind, Kindinfra, FakeSingleCluster, Federation, FakeVmPool, or 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17", true
+	case reflect.TypeOf(InfraApiAccess(0)):
+		return "InfraApiAccess", ", valid values are one of DirectAccess, RestrictedAccess, or 0, 1", true
+	case reflect.TypeOf(OSType(0)):
+		return "OSType", ", valid values are one of Linux, Windows, Others, or 0, 1, 20", true
+	case reflect.TypeOf(ReportSchedule(0)):
+		return "ReportSchedule", ", valid values are one of EveryWeek, Every15Days, Every30Days, EveryMonth, or 0, 1, 2, 3", true
+	case reflect.TypeOf(VMState(0)):
+		return "VMState", ", valid values are one of Free, InProgress, InUse, Add, Remove, Update, ForceFree, or 0, 1, 2, 3, 4, 5, 6", true
+	case reflect.TypeOf(VMAction(0)):
+		return "VMAction", ", valid values are one of Done, Allocate, Release, or 0, 1, 2", true
+	case reflect.TypeOf(TrustPolicyExceptionState(0)):
+		return "TrustPolicyExceptionState", ", valid values are one of Unknown, ApprovalRequested, Active, Rejected, or 0, 1, 2, 3", true
+	case reflect.TypeOf(NetworkConnectionType(0)):
+		return "NetworkConnectionType", ", valid values are one of Undefined, ConnectToLoadBalancer, ConnectToClusterNodes, ConnectToAll, or 0, 1, 2, 3", true
+	case reflect.TypeOf(PowerState(0)):
+		return "PowerState", ", valid values are one of PowerStateUnknown, PowerOnRequested, PoweringOn, PowerOn, PowerOffRequested, PoweringOff, PowerOff, RebootRequested, Rebooting, Reboot, PowerStateError, or 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10", true
+	case reflect.TypeOf(ApiEndpointType(0)):
+		return "ApiEndpointType", ", valid values are one of UnknownApiEndpointType, Dme, or 0, 1", true
+	case reflect.TypeOf(RateLimitTarget(0)):
+		return "RateLimitTarget", ", valid values are one of UnknownTarget, AllRequests, PerIp, PerUser, or 0, 1, 2, 3", true
+	case reflect.TypeOf(FlowRateLimitAlgorithm(0)):
+		return "FlowRateLimitAlgorithm", ", valid values are one of UnknownFlowAlgorithm, TokenBucketAlgorithm, LeakyBucketAlgorithm, or 0, 1, 2", true
+	case reflect.TypeOf(MaxReqsRateLimitAlgorithm(0)):
+		return "MaxReqsRateLimitAlgorithm", ", valid values are one of UnknownMaxReqsAlgorithm, FixedWindowAlgorithm, or 0, 1", true
+	case reflect.TypeOf(NoticeAction(0)):
+		return "NoticeAction", ", valid values are one of None, Update, Delete, Version, SendallEnd, or 0, 1, 2, 3, 4", true
+	case reflect.TypeOf(StreamState(0)):
+		return "StreamState", ", valid values are one of Unknown, Start, Stop, Error, or 0, 1, 2, 3", true
+	case reflect.TypeOf(VersionHash(0)):
+		return "VersionHash", ", valid values are one of D41D8Cd98F00B204E9800998Ecf8427E, D4Ca5418A77D22D968Ce7A2Afc549Dfe, 7848D42E3A2Eaf36E53Bbd3Af581B13A, F31B7A9D7E06F72107E0Ab13C708704E, 03Fad51F0343D41F617329151F474D2B, 7D32A983Fafc3Da768E045B1Dc4D5F50, 747C14Bdfe2043F09D251568E4A722C6, C7Fb20F545A5Bc9869B00Bb770753C31, 83Cd5C44B5C7387Ebf7D055E7345Ab42, D8A4E697D0D693479Cfd9C1C523D7E06, E8360Aa30F234Ecefdfdb9Fb2Dc79C20, C53C7840D242Efc7209549A36Fcf9E04, 1A57396698C4Ade15F0579C9F5714Cd6, 71C580746Ee2A6B7D1A4182B3A54407A, A18636Af1F4272C38Ca72881B2A8Bcea, Efbddcee4Ba444E3656F64E430A5E3Be, C2C322505017054033953F6104002Bf5, Facc3C3C9C76463C8D8B3C874Ce43487, 8Ba950479A03Ab77Edfad426Ea53C173, F4Eb139F7A8373A484Ab9749Eadc31F5, 09Fae4D440Aa06Acb9664167D2E1F036, 8C5A9C29Caff4Ace0A23A9Dab9A15Bf7, B7C6A74Ce2F30B3Bda179E00617459Cf, 911D86A4Eb2Bbfbff1173Ffbdd197A8C, 99349A696D0B5872542F81B4B0B4788E, 264850A5C1F7A054B4De1A87E5D28Dcc, 748B47Eaf414B0F2C15E4C6A9298B5F1, 1480647750F7638Ff5494C0E715Bb98C, 208A22352E46F6Bbe34F3B72Aaf99Ee5, 6F8F268D3945699608651E1A8Bb38E5E, 2Dfdb2Ed2Cf52241B2B3Db1D39E11Bc6, or 0, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38", true
+	}
+	return "", "", false
 }
 
 var ShowMethodNames = map[string]struct{}{

--- a/edgeproto/app.pb.go
+++ b/edgeproto/app.pb.go
@@ -4223,43 +4223,10 @@ var ImageType_CamelValue = map[string]int32{
 	"ImageTypeOvf":     4,
 }
 
-func (e *ImageType) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := ImageType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = ImageType_CamelValue["ImageType"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = ImageType_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid ImageType value %q", str)
-	}
-	*e = ImageType(val)
-	return nil
-}
-
-func (e ImageType) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(ImageType_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "ImageType")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *ImageType) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseImageType(data interface{}) (ImageType, error) {
+	if val, ok := data.(ImageType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := ImageType_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -4274,22 +4241,67 @@ func (e *ImageType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid ImageType value %q", str)
+			return ImageType(0), fmt.Errorf("Invalid ImageType value %q", str)
 		}
-		*e = ImageType(val)
-		return nil
+		return ImageType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := ImageType_CamelName[ival]; ok {
+			return ImageType(ival), nil
+		} else {
+			return ImageType(0), fmt.Errorf("Invalid ImageType value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return ImageType(0), fmt.Errorf("Invalid ImageType value %v", data)
+}
+
+func (e *ImageType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseImageType(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e ImageType) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(ImageType_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "ImageType")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *ImageType) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := ImageType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid ImageType value %d", val)
+		val, err := ParseImageType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(ImageType(0)),
+			}
 		}
 		*e = ImageType(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid ImageType value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseImageType(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(ImageType(0)),
+	}
 }
 
 func (e ImageType) MarshalJSON() ([]byte, error) {
@@ -4336,43 +4348,10 @@ var QosSessionProfile_CamelValue = map[string]int32{
 	"QosThroughputDownL": 4,
 }
 
-func (e *QosSessionProfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := QosSessionProfile_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = QosSessionProfile_CamelValue["Qos"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = QosSessionProfile_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid QosSessionProfile value %q", str)
-	}
-	*e = QosSessionProfile(val)
-	return nil
-}
-
-func (e QosSessionProfile) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(QosSessionProfile_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Qos")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *QosSessionProfile) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseQosSessionProfile(data interface{}) (QosSessionProfile, error) {
+	if val, ok := data.(QosSessionProfile); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := QosSessionProfile_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -4387,22 +4366,67 @@ func (e *QosSessionProfile) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid QosSessionProfile value %q", str)
+			return QosSessionProfile(0), fmt.Errorf("Invalid QosSessionProfile value %q", str)
 		}
-		*e = QosSessionProfile(val)
-		return nil
+		return QosSessionProfile(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := QosSessionProfile_CamelName[ival]; ok {
+			return QosSessionProfile(ival), nil
+		} else {
+			return QosSessionProfile(0), fmt.Errorf("Invalid QosSessionProfile value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return QosSessionProfile(0), fmt.Errorf("Invalid QosSessionProfile value %v", data)
+}
+
+func (e *QosSessionProfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseQosSessionProfile(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e QosSessionProfile) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(QosSessionProfile_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Qos")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *QosSessionProfile) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := QosSessionProfile_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid QosSessionProfile value %d", val)
+		val, err := ParseQosSessionProfile(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(QosSessionProfile(0)),
+			}
 		}
 		*e = QosSessionProfile(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid QosSessionProfile value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseQosSessionProfile(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(QosSessionProfile(0)),
+	}
 }
 
 func (e QosSessionProfile) MarshalJSON() ([]byte, error) {
@@ -4454,43 +4478,10 @@ var VmAppOsType_CamelValue = map[string]int32{
 	"VmAppOsWindows2019": 5,
 }
 
-func (e *VmAppOsType) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := VmAppOsType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = VmAppOsType_CamelValue["VmAppOs"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = VmAppOsType_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid VmAppOsType value %q", str)
-	}
-	*e = VmAppOsType(val)
-	return nil
-}
-
-func (e VmAppOsType) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(VmAppOsType_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "VmAppOs")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *VmAppOsType) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseVmAppOsType(data interface{}) (VmAppOsType, error) {
+	if val, ok := data.(VmAppOsType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := VmAppOsType_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -4505,22 +4496,67 @@ func (e *VmAppOsType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid VmAppOsType value %q", str)
+			return VmAppOsType(0), fmt.Errorf("Invalid VmAppOsType value %q", str)
 		}
-		*e = VmAppOsType(val)
-		return nil
+		return VmAppOsType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := VmAppOsType_CamelName[ival]; ok {
+			return VmAppOsType(ival), nil
+		} else {
+			return VmAppOsType(0), fmt.Errorf("Invalid VmAppOsType value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return VmAppOsType(0), fmt.Errorf("Invalid VmAppOsType value %v", data)
+}
+
+func (e *VmAppOsType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseVmAppOsType(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e VmAppOsType) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(VmAppOsType_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "VmAppOs")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *VmAppOsType) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := VmAppOsType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid VmAppOsType value %d", val)
+		val, err := ParseVmAppOsType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(VmAppOsType(0)),
+			}
 		}
 		*e = VmAppOsType(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid VmAppOsType value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseVmAppOsType(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(VmAppOsType(0)),
+	}
 }
 
 func (e VmAppOsType) MarshalJSON() ([]byte, error) {
@@ -4552,25 +4588,44 @@ var DeleteType_CamelValue = map[string]int32{
 	"AutoDelete":   1,
 }
 
+func ParseDeleteType(data interface{}) (DeleteType, error) {
+	if val, ok := data.(DeleteType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := DeleteType_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = DeleteType_CamelName[val]
+			}
+		}
+		if !ok {
+			return DeleteType(0), fmt.Errorf("Invalid DeleteType value %q", str)
+		}
+		return DeleteType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := DeleteType_CamelName[ival]; ok {
+			return DeleteType(ival), nil
+		} else {
+			return DeleteType(0), fmt.Errorf("Invalid DeleteType value %d", ival)
+		}
+	}
+	return DeleteType(0), fmt.Errorf("Invalid DeleteType value %v", data)
+}
+
 func (e *DeleteType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := DeleteType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = DeleteType_CamelName[val]
-		}
+	val, err := ParseDeleteType(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid DeleteType value %q", str)
-	}
-	*e = DeleteType(val)
+	*e = val
 	return nil
 }
 
@@ -4584,32 +4639,29 @@ func (e *DeleteType) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := DeleteType_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = DeleteType_CamelName[val]
+		val, err := ParseDeleteType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(DeleteType(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid DeleteType value %q", str)
-		}
 		*e = DeleteType(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := DeleteType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid DeleteType value %d", val)
+		val, err := ParseDeleteType(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = DeleteType(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid DeleteType value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(DeleteType(0)),
+	}
 }
 
 func (e DeleteType) MarshalJSON() ([]byte, error) {
@@ -4643,43 +4695,10 @@ var AccessType_CamelValue = map[string]int32{
 	"AccessTypeLoadBalancer":         2,
 }
 
-func (e *AccessType) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := AccessType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = AccessType_CamelValue["AccessType"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = AccessType_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid AccessType value %q", str)
-	}
-	*e = AccessType(val)
-	return nil
-}
-
-func (e AccessType) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(AccessType_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "AccessType")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *AccessType) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseAccessType(data interface{}) (AccessType, error) {
+	if val, ok := data.(AccessType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := AccessType_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -4694,22 +4713,67 @@ func (e *AccessType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid AccessType value %q", str)
+			return AccessType(0), fmt.Errorf("Invalid AccessType value %q", str)
 		}
-		*e = AccessType(val)
-		return nil
+		return AccessType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := AccessType_CamelName[ival]; ok {
+			return AccessType(ival), nil
+		} else {
+			return AccessType(0), fmt.Errorf("Invalid AccessType value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return AccessType(0), fmt.Errorf("Invalid AccessType value %v", data)
+}
+
+func (e *AccessType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseAccessType(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e AccessType) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(AccessType_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "AccessType")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *AccessType) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := AccessType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid AccessType value %d", val)
+		val, err := ParseAccessType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(AccessType(0)),
+			}
 		}
 		*e = AccessType(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid AccessType value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseAccessType(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(AccessType(0)),
+	}
 }
 
 func (e AccessType) MarshalJSON() ([]byte, error) {

--- a/edgeproto/cloudlet.pb.go
+++ b/edgeproto/cloudlet.pb.go
@@ -13788,43 +13788,10 @@ var PlatformType_CamelValue = map[string]int32{
 	"PlatformTypeFakeVmPool":        17,
 }
 
-func (e *PlatformType) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := PlatformType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = PlatformType_CamelValue["PlatformType"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = PlatformType_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid PlatformType value %q", str)
-	}
-	*e = PlatformType(val)
-	return nil
-}
-
-func (e PlatformType) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(PlatformType_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "PlatformType")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *PlatformType) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParsePlatformType(data interface{}) (PlatformType, error) {
+	if val, ok := data.(PlatformType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := PlatformType_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -13839,22 +13806,67 @@ func (e *PlatformType) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid PlatformType value %q", str)
+			return PlatformType(0), fmt.Errorf("Invalid PlatformType value %q", str)
 		}
-		*e = PlatformType(val)
-		return nil
+		return PlatformType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := PlatformType_CamelName[ival]; ok {
+			return PlatformType(ival), nil
+		} else {
+			return PlatformType(0), fmt.Errorf("Invalid PlatformType value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return PlatformType(0), fmt.Errorf("Invalid PlatformType value %v", data)
+}
+
+func (e *PlatformType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParsePlatformType(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e PlatformType) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(PlatformType_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "PlatformType")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *PlatformType) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := PlatformType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid PlatformType value %d", val)
+		val, err := ParsePlatformType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(PlatformType(0)),
+			}
 		}
 		*e = PlatformType(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid PlatformType value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParsePlatformType(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(PlatformType(0)),
+	}
 }
 
 func (e PlatformType) MarshalJSON() ([]byte, error) {
@@ -13886,25 +13898,44 @@ var InfraApiAccess_CamelValue = map[string]int32{
 	"RestrictedAccess": 1,
 }
 
+func ParseInfraApiAccess(data interface{}) (InfraApiAccess, error) {
+	if val, ok := data.(InfraApiAccess); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := InfraApiAccess_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = InfraApiAccess_CamelName[val]
+			}
+		}
+		if !ok {
+			return InfraApiAccess(0), fmt.Errorf("Invalid InfraApiAccess value %q", str)
+		}
+		return InfraApiAccess(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := InfraApiAccess_CamelName[ival]; ok {
+			return InfraApiAccess(ival), nil
+		} else {
+			return InfraApiAccess(0), fmt.Errorf("Invalid InfraApiAccess value %d", ival)
+		}
+	}
+	return InfraApiAccess(0), fmt.Errorf("Invalid InfraApiAccess value %v", data)
+}
+
 func (e *InfraApiAccess) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := InfraApiAccess_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = InfraApiAccess_CamelName[val]
-		}
+	val, err := ParseInfraApiAccess(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid InfraApiAccess value %q", str)
-	}
-	*e = InfraApiAccess(val)
+	*e = val
 	return nil
 }
 
@@ -13918,32 +13949,29 @@ func (e *InfraApiAccess) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := InfraApiAccess_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = InfraApiAccess_CamelName[val]
+		val, err := ParseInfraApiAccess(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(InfraApiAccess(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid InfraApiAccess value %q", str)
-		}
 		*e = InfraApiAccess(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := InfraApiAccess_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid InfraApiAccess value %d", val)
+		val, err := ParseInfraApiAccess(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = InfraApiAccess(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid InfraApiAccess value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(InfraApiAccess(0)),
+	}
 }
 
 func (e InfraApiAccess) MarshalJSON() ([]byte, error) {
@@ -13977,25 +14005,44 @@ var OSType_CamelValue = map[string]int32{
 	"Others":  20,
 }
 
+func ParseOSType(data interface{}) (OSType, error) {
+	if val, ok := data.(OSType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := OSType_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = OSType_CamelName[val]
+			}
+		}
+		if !ok {
+			return OSType(0), fmt.Errorf("Invalid OSType value %q", str)
+		}
+		return OSType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := OSType_CamelName[ival]; ok {
+			return OSType(ival), nil
+		} else {
+			return OSType(0), fmt.Errorf("Invalid OSType value %d", ival)
+		}
+	}
+	return OSType(0), fmt.Errorf("Invalid OSType value %v", data)
+}
+
 func (e *OSType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := OSType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = OSType_CamelName[val]
-		}
+	val, err := ParseOSType(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid OSType value %q", str)
-	}
-	*e = OSType(val)
+	*e = val
 	return nil
 }
 
@@ -14009,32 +14056,29 @@ func (e *OSType) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := OSType_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = OSType_CamelName[val]
+		val, err := ParseOSType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(OSType(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid OSType value %q", str)
-		}
 		*e = OSType(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := OSType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid OSType value %d", val)
+		val, err := ParseOSType(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = OSType(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid OSType value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(OSType(0)),
+	}
 }
 
 func (e OSType) MarshalJSON() ([]byte, error) {
@@ -14073,25 +14117,44 @@ var ReportSchedule_CamelValue = map[string]int32{
 	"EveryMonth":  3,
 }
 
+func ParseReportSchedule(data interface{}) (ReportSchedule, error) {
+	if val, ok := data.(ReportSchedule); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := ReportSchedule_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = ReportSchedule_CamelName[val]
+			}
+		}
+		if !ok {
+			return ReportSchedule(0), fmt.Errorf("Invalid ReportSchedule value %q", str)
+		}
+		return ReportSchedule(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := ReportSchedule_CamelName[ival]; ok {
+			return ReportSchedule(ival), nil
+		} else {
+			return ReportSchedule(0), fmt.Errorf("Invalid ReportSchedule value %d", ival)
+		}
+	}
+	return ReportSchedule(0), fmt.Errorf("Invalid ReportSchedule value %v", data)
+}
+
 func (e *ReportSchedule) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := ReportSchedule_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = ReportSchedule_CamelName[val]
-		}
+	val, err := ParseReportSchedule(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid ReportSchedule value %q", str)
-	}
-	*e = ReportSchedule(val)
+	*e = val
 	return nil
 }
 
@@ -14105,32 +14168,29 @@ func (e *ReportSchedule) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := ReportSchedule_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = ReportSchedule_CamelName[val]
+		val, err := ParseReportSchedule(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(ReportSchedule(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid ReportSchedule value %q", str)
-		}
 		*e = ReportSchedule(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := ReportSchedule_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid ReportSchedule value %d", val)
+		val, err := ParseReportSchedule(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = ReportSchedule(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid ReportSchedule value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(ReportSchedule(0)),
+	}
 }
 
 func (e ReportSchedule) MarshalJSON() ([]byte, error) {

--- a/edgeproto/common.pb.go
+++ b/edgeproto/common.pb.go
@@ -12,6 +12,7 @@ import (
 	io "io"
 	math "math"
 	math_bits "math/bits"
+	reflect "reflect"
 	"strconv"
 	strings "strings"
 )
@@ -562,43 +563,10 @@ var Liveness_CamelValue = map[string]int32{
 	"LivenessAutoprov": 3,
 }
 
-func (e *Liveness) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := Liveness_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = Liveness_CamelValue["Liveness"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = Liveness_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid Liveness value %q", str)
-	}
-	*e = Liveness(val)
-	return nil
-}
-
-func (e Liveness) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(Liveness_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Liveness")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *Liveness) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseLiveness(data interface{}) (Liveness, error) {
+	if val, ok := data.(Liveness); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := Liveness_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -613,22 +581,67 @@ func (e *Liveness) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid Liveness value %q", str)
+			return Liveness(0), fmt.Errorf("Invalid Liveness value %q", str)
 		}
-		*e = Liveness(val)
-		return nil
+		return Liveness(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := Liveness_CamelName[ival]; ok {
+			return Liveness(ival), nil
+		} else {
+			return Liveness(0), fmt.Errorf("Invalid Liveness value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return Liveness(0), fmt.Errorf("Invalid Liveness value %v", data)
+}
+
+func (e *Liveness) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseLiveness(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e Liveness) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(Liveness_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Liveness")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *Liveness) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := Liveness_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid Liveness value %d", val)
+		val, err := ParseLiveness(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(Liveness(0)),
+			}
 		}
 		*e = Liveness(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid Liveness value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseLiveness(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(Liveness(0)),
+	}
 }
 
 func (e Liveness) MarshalJSON() ([]byte, error) {
@@ -665,43 +678,10 @@ var IpSupport_CamelValue = map[string]int32{
 	"IpSupportDynamic": 2,
 }
 
-func (e *IpSupport) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := IpSupport_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = IpSupport_CamelValue["IpSupport"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = IpSupport_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid IpSupport value %q", str)
-	}
-	*e = IpSupport(val)
-	return nil
-}
-
-func (e IpSupport) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(IpSupport_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "IpSupport")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *IpSupport) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseIpSupport(data interface{}) (IpSupport, error) {
+	if val, ok := data.(IpSupport); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := IpSupport_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -716,22 +696,67 @@ func (e *IpSupport) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid IpSupport value %q", str)
+			return IpSupport(0), fmt.Errorf("Invalid IpSupport value %q", str)
 		}
-		*e = IpSupport(val)
-		return nil
+		return IpSupport(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := IpSupport_CamelName[ival]; ok {
+			return IpSupport(ival), nil
+		} else {
+			return IpSupport(0), fmt.Errorf("Invalid IpSupport value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return IpSupport(0), fmt.Errorf("Invalid IpSupport value %v", data)
+}
+
+func (e *IpSupport) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseIpSupport(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e IpSupport) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(IpSupport_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "IpSupport")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *IpSupport) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := IpSupport_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid IpSupport value %d", val)
+		val, err := ParseIpSupport(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(IpSupport(0)),
+			}
 		}
 		*e = IpSupport(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid IpSupport value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseIpSupport(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(IpSupport(0)),
+	}
 }
 
 func (e IpSupport) MarshalJSON() ([]byte, error) {
@@ -768,43 +793,10 @@ var IpAccess_CamelValue = map[string]int32{
 	"IpAccessShared":    3,
 }
 
-func (e *IpAccess) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := IpAccess_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = IpAccess_CamelValue["IpAccess"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = IpAccess_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid IpAccess value %q", str)
-	}
-	*e = IpAccess(val)
-	return nil
-}
-
-func (e IpAccess) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(IpAccess_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "IpAccess")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *IpAccess) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseIpAccess(data interface{}) (IpAccess, error) {
+	if val, ok := data.(IpAccess); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := IpAccess_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -819,22 +811,67 @@ func (e *IpAccess) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid IpAccess value %q", str)
+			return IpAccess(0), fmt.Errorf("Invalid IpAccess value %q", str)
 		}
-		*e = IpAccess(val)
-		return nil
+		return IpAccess(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := IpAccess_CamelName[ival]; ok {
+			return IpAccess(ival), nil
+		} else {
+			return IpAccess(0), fmt.Errorf("Invalid IpAccess value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return IpAccess(0), fmt.Errorf("Invalid IpAccess value %v", data)
+}
+
+func (e *IpAccess) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseIpAccess(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e IpAccess) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(IpAccess_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "IpAccess")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *IpAccess) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := IpAccess_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid IpAccess value %d", val)
+		val, err := ParseIpAccess(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(IpAccess(0)),
+			}
 		}
 		*e = IpAccess(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid IpAccess value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseIpAccess(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(IpAccess(0)),
+	}
 }
 
 func (e IpAccess) MarshalJSON() ([]byte, error) {
@@ -936,25 +973,44 @@ var TrackedState_CamelValue = map[string]int32{
 	"DeleteDone":           15,
 }
 
+func ParseTrackedState(data interface{}) (TrackedState, error) {
+	if val, ok := data.(TrackedState); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := TrackedState_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = TrackedState_CamelName[val]
+			}
+		}
+		if !ok {
+			return TrackedState(0), fmt.Errorf("Invalid TrackedState value %q", str)
+		}
+		return TrackedState(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := TrackedState_CamelName[ival]; ok {
+			return TrackedState(ival), nil
+		} else {
+			return TrackedState(0), fmt.Errorf("Invalid TrackedState value %d", ival)
+		}
+	}
+	return TrackedState(0), fmt.Errorf("Invalid TrackedState value %v", data)
+}
+
 func (e *TrackedState) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := TrackedState_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = TrackedState_CamelName[val]
-		}
+	val, err := ParseTrackedState(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid TrackedState value %q", str)
-	}
-	*e = TrackedState(val)
+	*e = val
 	return nil
 }
 
@@ -968,32 +1024,29 @@ func (e *TrackedState) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := TrackedState_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = TrackedState_CamelName[val]
+		val, err := ParseTrackedState(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(TrackedState(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid TrackedState value %q", str)
-		}
 		*e = TrackedState(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := TrackedState_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid TrackedState value %d", val)
+		val, err := ParseTrackedState(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = TrackedState(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid TrackedState value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(TrackedState(0)),
+	}
 }
 
 func (e TrackedState) MarshalJSON() ([]byte, error) {
@@ -1037,25 +1090,44 @@ var CRMOverride_CamelValue = map[string]int32{
 	"IgnoreCrmAndTransientState": 4,
 }
 
+func ParseCRMOverride(data interface{}) (CRMOverride, error) {
+	if val, ok := data.(CRMOverride); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := CRMOverride_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = CRMOverride_CamelName[val]
+			}
+		}
+		if !ok {
+			return CRMOverride(0), fmt.Errorf("Invalid CRMOverride value %q", str)
+		}
+		return CRMOverride(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := CRMOverride_CamelName[ival]; ok {
+			return CRMOverride(ival), nil
+		} else {
+			return CRMOverride(0), fmt.Errorf("Invalid CRMOverride value %d", ival)
+		}
+	}
+	return CRMOverride(0), fmt.Errorf("Invalid CRMOverride value %v", data)
+}
+
 func (e *CRMOverride) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := CRMOverride_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = CRMOverride_CamelName[val]
-		}
+	val, err := ParseCRMOverride(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid CRMOverride value %q", str)
-	}
-	*e = CRMOverride(val)
+	*e = val
 	return nil
 }
 
@@ -1069,32 +1141,29 @@ func (e *CRMOverride) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := CRMOverride_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = CRMOverride_CamelName[val]
+		val, err := ParseCRMOverride(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(CRMOverride(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid CRMOverride value %q", str)
-		}
 		*e = CRMOverride(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := CRMOverride_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid CRMOverride value %d", val)
+		val, err := ParseCRMOverride(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = CRMOverride(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid CRMOverride value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(CRMOverride(0)),
+	}
 }
 
 func (e CRMOverride) MarshalJSON() ([]byte, error) {

--- a/edgeproto/decimal.go
+++ b/edgeproto/decimal.go
@@ -3,6 +3,7 @@ package edgeproto
 import (
 	"encoding/json"
 	fmt "fmt"
+	reflect "reflect"
 	"strconv"
 	strings "strings"
 )
@@ -204,7 +205,10 @@ func (u *Udec64) UnmarshalJSON(b []byte) error {
 	if err == nil {
 		udec64, err := ParseUdec64(str)
 		if err != nil {
-			return err
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(Udec64{}),
+			}
 		}
 		*u = *udec64
 		return nil
@@ -215,7 +219,10 @@ func (u *Udec64) UnmarshalJSON(b []byte) error {
 		u.Whole = val
 		return nil
 	}
-	return fmt.Errorf("Invalid unsigned decimal 64 type")
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(Udec64{}),
+	}
 }
 
 func (u Udec64) MarshalJSON() ([]byte, error) {

--- a/edgeproto/duration_type.go
+++ b/edgeproto/duration_type.go
@@ -44,7 +44,10 @@ func (e *Duration) UnmarshalJSON(b []byte) error {
 	if err == nil {
 		dur, err := time.ParseDuration(str)
 		if err != nil {
-			return NewDurationParseError(str, err)
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(Duration(0)),
+			}
 		}
 		*e = Duration(dur)
 		return nil
@@ -55,7 +58,10 @@ func (e *Duration) UnmarshalJSON(b []byte) error {
 		*e = Duration(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid duration type")
+	return &json.UnmarshalTypeError{
+		Value: "value " + str,
+		Type:  reflect.TypeOf(Duration(0)),
+	}
 }
 
 func (e Duration) MarshalJSON() ([]byte, error) {
@@ -95,7 +101,7 @@ func DecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
 }
 
 // DurationParseError wraps a time.Duration parse error so that
-// it can be recognized as such from errors returned from json.Unmarshal.
+// it can be recognized as such from errors returned from map decode.
 type DurationParseError struct {
 	Value string
 	Err   error

--- a/edgeproto/network.pb.go
+++ b/edgeproto/network.pb.go
@@ -1729,25 +1729,44 @@ var NetworkConnectionType_CamelValue = map[string]int32{
 	"ConnectToAll":          3,
 }
 
+func ParseNetworkConnectionType(data interface{}) (NetworkConnectionType, error) {
+	if val, ok := data.(NetworkConnectionType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := NetworkConnectionType_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = NetworkConnectionType_CamelName[val]
+			}
+		}
+		if !ok {
+			return NetworkConnectionType(0), fmt.Errorf("Invalid NetworkConnectionType value %q", str)
+		}
+		return NetworkConnectionType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := NetworkConnectionType_CamelName[ival]; ok {
+			return NetworkConnectionType(ival), nil
+		} else {
+			return NetworkConnectionType(0), fmt.Errorf("Invalid NetworkConnectionType value %d", ival)
+		}
+	}
+	return NetworkConnectionType(0), fmt.Errorf("Invalid NetworkConnectionType value %v", data)
+}
+
 func (e *NetworkConnectionType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := NetworkConnectionType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = NetworkConnectionType_CamelName[val]
-		}
+	val, err := ParseNetworkConnectionType(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid NetworkConnectionType value %q", str)
-	}
-	*e = NetworkConnectionType(val)
+	*e = val
 	return nil
 }
 
@@ -1761,32 +1780,29 @@ func (e *NetworkConnectionType) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := NetworkConnectionType_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = NetworkConnectionType_CamelName[val]
+		val, err := ParseNetworkConnectionType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(NetworkConnectionType(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid NetworkConnectionType value %q", str)
-		}
 		*e = NetworkConnectionType(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := NetworkConnectionType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid NetworkConnectionType value %d", val)
+		val, err := ParseNetworkConnectionType(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = NetworkConnectionType(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid NetworkConnectionType value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(NetworkConnectionType(0)),
+	}
 }
 
 func (e NetworkConnectionType) MarshalJSON() ([]byte, error) {

--- a/edgeproto/ratelimit.pb.go
+++ b/edgeproto/ratelimit.pb.go
@@ -3848,25 +3848,44 @@ var ApiEndpointType_CamelValue = map[string]int32{
 	"Dme":                    1,
 }
 
+func ParseApiEndpointType(data interface{}) (ApiEndpointType, error) {
+	if val, ok := data.(ApiEndpointType); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := ApiEndpointType_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = ApiEndpointType_CamelName[val]
+			}
+		}
+		if !ok {
+			return ApiEndpointType(0), fmt.Errorf("Invalid ApiEndpointType value %q", str)
+		}
+		return ApiEndpointType(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := ApiEndpointType_CamelName[ival]; ok {
+			return ApiEndpointType(ival), nil
+		} else {
+			return ApiEndpointType(0), fmt.Errorf("Invalid ApiEndpointType value %d", ival)
+		}
+	}
+	return ApiEndpointType(0), fmt.Errorf("Invalid ApiEndpointType value %v", data)
+}
+
 func (e *ApiEndpointType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := ApiEndpointType_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = ApiEndpointType_CamelName[val]
-		}
+	val, err := ParseApiEndpointType(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid ApiEndpointType value %q", str)
-	}
-	*e = ApiEndpointType(val)
+	*e = val
 	return nil
 }
 
@@ -3880,32 +3899,29 @@ func (e *ApiEndpointType) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := ApiEndpointType_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = ApiEndpointType_CamelName[val]
+		val, err := ParseApiEndpointType(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(ApiEndpointType(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid ApiEndpointType value %q", str)
-		}
 		*e = ApiEndpointType(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := ApiEndpointType_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid ApiEndpointType value %d", val)
+		val, err := ParseApiEndpointType(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = ApiEndpointType(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid ApiEndpointType value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(ApiEndpointType(0)),
+	}
 }
 
 func (e ApiEndpointType) MarshalJSON() ([]byte, error) {
@@ -3944,25 +3960,44 @@ var RateLimitTarget_CamelValue = map[string]int32{
 	"PerUser":       3,
 }
 
+func ParseRateLimitTarget(data interface{}) (RateLimitTarget, error) {
+	if val, ok := data.(RateLimitTarget); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := RateLimitTarget_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = RateLimitTarget_CamelName[val]
+			}
+		}
+		if !ok {
+			return RateLimitTarget(0), fmt.Errorf("Invalid RateLimitTarget value %q", str)
+		}
+		return RateLimitTarget(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := RateLimitTarget_CamelName[ival]; ok {
+			return RateLimitTarget(ival), nil
+		} else {
+			return RateLimitTarget(0), fmt.Errorf("Invalid RateLimitTarget value %d", ival)
+		}
+	}
+	return RateLimitTarget(0), fmt.Errorf("Invalid RateLimitTarget value %v", data)
+}
+
 func (e *RateLimitTarget) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := RateLimitTarget_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = RateLimitTarget_CamelName[val]
-		}
+	val, err := ParseRateLimitTarget(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid RateLimitTarget value %q", str)
-	}
-	*e = RateLimitTarget(val)
+	*e = val
 	return nil
 }
 
@@ -3976,32 +4011,29 @@ func (e *RateLimitTarget) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := RateLimitTarget_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = RateLimitTarget_CamelName[val]
+		val, err := ParseRateLimitTarget(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(RateLimitTarget(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid RateLimitTarget value %q", str)
-		}
 		*e = RateLimitTarget(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := RateLimitTarget_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid RateLimitTarget value %d", val)
+		val, err := ParseRateLimitTarget(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = RateLimitTarget(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid RateLimitTarget value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(RateLimitTarget(0)),
+	}
 }
 
 func (e RateLimitTarget) MarshalJSON() ([]byte, error) {
@@ -4035,25 +4067,44 @@ var FlowRateLimitAlgorithm_CamelValue = map[string]int32{
 	"LeakyBucketAlgorithm": 2,
 }
 
+func ParseFlowRateLimitAlgorithm(data interface{}) (FlowRateLimitAlgorithm, error) {
+	if val, ok := data.(FlowRateLimitAlgorithm); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := FlowRateLimitAlgorithm_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = FlowRateLimitAlgorithm_CamelName[val]
+			}
+		}
+		if !ok {
+			return FlowRateLimitAlgorithm(0), fmt.Errorf("Invalid FlowRateLimitAlgorithm value %q", str)
+		}
+		return FlowRateLimitAlgorithm(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := FlowRateLimitAlgorithm_CamelName[ival]; ok {
+			return FlowRateLimitAlgorithm(ival), nil
+		} else {
+			return FlowRateLimitAlgorithm(0), fmt.Errorf("Invalid FlowRateLimitAlgorithm value %d", ival)
+		}
+	}
+	return FlowRateLimitAlgorithm(0), fmt.Errorf("Invalid FlowRateLimitAlgorithm value %v", data)
+}
+
 func (e *FlowRateLimitAlgorithm) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := FlowRateLimitAlgorithm_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = FlowRateLimitAlgorithm_CamelName[val]
-		}
+	val, err := ParseFlowRateLimitAlgorithm(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid FlowRateLimitAlgorithm value %q", str)
-	}
-	*e = FlowRateLimitAlgorithm(val)
+	*e = val
 	return nil
 }
 
@@ -4067,32 +4118,29 @@ func (e *FlowRateLimitAlgorithm) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := FlowRateLimitAlgorithm_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = FlowRateLimitAlgorithm_CamelName[val]
+		val, err := ParseFlowRateLimitAlgorithm(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(FlowRateLimitAlgorithm(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid FlowRateLimitAlgorithm value %q", str)
-		}
 		*e = FlowRateLimitAlgorithm(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := FlowRateLimitAlgorithm_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid FlowRateLimitAlgorithm value %d", val)
+		val, err := ParseFlowRateLimitAlgorithm(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = FlowRateLimitAlgorithm(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid FlowRateLimitAlgorithm value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(FlowRateLimitAlgorithm(0)),
+	}
 }
 
 func (e FlowRateLimitAlgorithm) MarshalJSON() ([]byte, error) {
@@ -4121,25 +4169,44 @@ var MaxReqsRateLimitAlgorithm_CamelValue = map[string]int32{
 	"FixedWindowAlgorithm":    1,
 }
 
+func ParseMaxReqsRateLimitAlgorithm(data interface{}) (MaxReqsRateLimitAlgorithm, error) {
+	if val, ok := data.(MaxReqsRateLimitAlgorithm); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := MaxReqsRateLimitAlgorithm_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = MaxReqsRateLimitAlgorithm_CamelName[val]
+			}
+		}
+		if !ok {
+			return MaxReqsRateLimitAlgorithm(0), fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %q", str)
+		}
+		return MaxReqsRateLimitAlgorithm(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := MaxReqsRateLimitAlgorithm_CamelName[ival]; ok {
+			return MaxReqsRateLimitAlgorithm(ival), nil
+		} else {
+			return MaxReqsRateLimitAlgorithm(0), fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %d", ival)
+		}
+	}
+	return MaxReqsRateLimitAlgorithm(0), fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %v", data)
+}
+
 func (e *MaxReqsRateLimitAlgorithm) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := MaxReqsRateLimitAlgorithm_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = MaxReqsRateLimitAlgorithm_CamelName[val]
-		}
+	val, err := ParseMaxReqsRateLimitAlgorithm(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %q", str)
-	}
-	*e = MaxReqsRateLimitAlgorithm(val)
+	*e = val
 	return nil
 }
 
@@ -4153,32 +4220,29 @@ func (e *MaxReqsRateLimitAlgorithm) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := MaxReqsRateLimitAlgorithm_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = MaxReqsRateLimitAlgorithm_CamelName[val]
+		val, err := ParseMaxReqsRateLimitAlgorithm(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(MaxReqsRateLimitAlgorithm(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %q", str)
-		}
 		*e = MaxReqsRateLimitAlgorithm(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := MaxReqsRateLimitAlgorithm_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %d", val)
+		val, err := ParseMaxReqsRateLimitAlgorithm(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = MaxReqsRateLimitAlgorithm(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid MaxReqsRateLimitAlgorithm value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(MaxReqsRateLimitAlgorithm(0)),
+	}
 }
 
 func (e MaxReqsRateLimitAlgorithm) MarshalJSON() ([]byte, error) {

--- a/edgeproto/trustpolicyexception.pb.go
+++ b/edgeproto/trustpolicyexception.pb.go
@@ -1589,43 +1589,10 @@ var TrustPolicyExceptionState_CamelValue = map[string]int32{
 	"TrustPolicyExceptionStateRejected":          3,
 }
 
-func (e *TrustPolicyExceptionState) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := TrustPolicyExceptionState_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = TrustPolicyExceptionState_CamelValue["TrustPolicyExceptionState"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = TrustPolicyExceptionState_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid TrustPolicyExceptionState value %q", str)
-	}
-	*e = TrustPolicyExceptionState(val)
-	return nil
-}
-
-func (e TrustPolicyExceptionState) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(TrustPolicyExceptionState_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "TrustPolicyExceptionState")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *TrustPolicyExceptionState) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseTrustPolicyExceptionState(data interface{}) (TrustPolicyExceptionState, error) {
+	if val, ok := data.(TrustPolicyExceptionState); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := TrustPolicyExceptionState_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -1640,22 +1607,67 @@ func (e *TrustPolicyExceptionState) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid TrustPolicyExceptionState value %q", str)
+			return TrustPolicyExceptionState(0), fmt.Errorf("Invalid TrustPolicyExceptionState value %q", str)
 		}
-		*e = TrustPolicyExceptionState(val)
-		return nil
+		return TrustPolicyExceptionState(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := TrustPolicyExceptionState_CamelName[ival]; ok {
+			return TrustPolicyExceptionState(ival), nil
+		} else {
+			return TrustPolicyExceptionState(0), fmt.Errorf("Invalid TrustPolicyExceptionState value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return TrustPolicyExceptionState(0), fmt.Errorf("Invalid TrustPolicyExceptionState value %v", data)
+}
+
+func (e *TrustPolicyExceptionState) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseTrustPolicyExceptionState(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e TrustPolicyExceptionState) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(TrustPolicyExceptionState_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "TrustPolicyExceptionState")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *TrustPolicyExceptionState) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := TrustPolicyExceptionState_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid TrustPolicyExceptionState value %d", val)
+		val, err := ParseTrustPolicyExceptionState(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(TrustPolicyExceptionState(0)),
+			}
 		}
 		*e = TrustPolicyExceptionState(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid TrustPolicyExceptionState value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseTrustPolicyExceptionState(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(TrustPolicyExceptionState(0)),
+	}
 }
 
 func (e TrustPolicyExceptionState) MarshalJSON() ([]byte, error) {

--- a/edgeproto/vmpool.pb.go
+++ b/edgeproto/vmpool.pb.go
@@ -4185,43 +4185,10 @@ var VMState_CamelValue = map[string]int32{
 	"VmForceFree":  6,
 }
 
-func (e *VMState) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := VMState_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = VMState_CamelValue["Vm"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = VMState_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid VMState value %q", str)
-	}
-	*e = VMState(val)
-	return nil
-}
-
-func (e VMState) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(VMState_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Vm")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *VMState) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseVMState(data interface{}) (VMState, error) {
+	if val, ok := data.(VMState); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := VMState_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -4236,22 +4203,67 @@ func (e *VMState) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid VMState value %q", str)
+			return VMState(0), fmt.Errorf("Invalid VMState value %q", str)
 		}
-		*e = VMState(val)
-		return nil
+		return VMState(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := VMState_CamelName[ival]; ok {
+			return VMState(ival), nil
+		} else {
+			return VMState(0), fmt.Errorf("Invalid VMState value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return VMState(0), fmt.Errorf("Invalid VMState value %v", data)
+}
+
+func (e *VMState) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseVMState(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e VMState) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(VMState_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Vm")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *VMState) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := VMState_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid VMState value %d", val)
+		val, err := ParseVMState(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(VMState(0)),
+			}
 		}
 		*e = VMState(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid VMState value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseVMState(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(VMState(0)),
+	}
 }
 
 func (e VMState) MarshalJSON() ([]byte, error) {
@@ -4288,43 +4300,10 @@ var VMAction_CamelValue = map[string]int32{
 	"VmActionRelease":  2,
 }
 
-func (e *VMAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := VMAction_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = VMAction_CamelValue["VmAction"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = VMAction_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid VMAction value %q", str)
-	}
-	*e = VMAction(val)
-	return nil
-}
-
-func (e VMAction) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(VMAction_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "VmAction")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *VMAction) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseVMAction(data interface{}) (VMAction, error) {
+	if val, ok := data.(VMAction); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := VMAction_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -4339,22 +4318,67 @@ func (e *VMAction) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid VMAction value %q", str)
+			return VMAction(0), fmt.Errorf("Invalid VMAction value %q", str)
 		}
-		*e = VMAction(val)
-		return nil
+		return VMAction(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := VMAction_CamelName[ival]; ok {
+			return VMAction(ival), nil
+		} else {
+			return VMAction(0), fmt.Errorf("Invalid VMAction value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return VMAction(0), fmt.Errorf("Invalid VMAction value %v", data)
+}
+
+func (e *VMAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseVMAction(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e VMAction) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(VMAction_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "VmAction")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *VMAction) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := VMAction_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid VMAction value %d", val)
+		val, err := ParseVMAction(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(VMAction(0)),
+			}
 		}
 		*e = VMAction(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid VMAction value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseVMAction(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(VMAction(0)),
+	}
 }
 
 func (e VMAction) MarshalJSON() ([]byte, error) {

--- a/log/debug.pb.go
+++ b/log/debug.pb.go
@@ -171,25 +171,44 @@ var DebugLevel_CamelValue = map[string]int32{
 	"Events":  11,
 }
 
+func ParseDebugLevel(data interface{}) (DebugLevel, error) {
+	if val, ok := data.(DebugLevel); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
+		val, ok := DebugLevel_CamelValue[util.CamelCase(str)]
+		if !ok {
+			// may be int value instead of enum name
+			ival, err := strconv.Atoi(str)
+			val = int32(ival)
+			if err == nil {
+				_, ok = DebugLevel_CamelName[val]
+			}
+		}
+		if !ok {
+			return DebugLevel(0), fmt.Errorf("Invalid DebugLevel value %q", str)
+		}
+		return DebugLevel(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := DebugLevel_CamelName[ival]; ok {
+			return DebugLevel(ival), nil
+		} else {
+			return DebugLevel(0), fmt.Errorf("Invalid DebugLevel value %d", ival)
+		}
+	}
+	return DebugLevel(0), fmt.Errorf("Invalid DebugLevel value %v", data)
+}
+
 func (e *DebugLevel) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
 		return err
 	}
-	val, ok := DebugLevel_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = DebugLevel_CamelName[val]
-		}
+	val, err := ParseDebugLevel(str)
+	if err != nil {
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("Invalid DebugLevel value %q", str)
-	}
-	*e = DebugLevel(val)
+	*e = val
 	return nil
 }
 
@@ -203,32 +222,29 @@ func (e *DebugLevel) UnmarshalJSON(b []byte) error {
 	var str string
 	err := json.Unmarshal(b, &str)
 	if err == nil {
-		val, ok := DebugLevel_CamelValue[util.CamelCase(str)]
-		if !ok {
-			// may be int value instead of enum name
-			ival, err := strconv.Atoi(str)
-			val = int32(ival)
-			if err == nil {
-				_, ok = DebugLevel_CamelName[val]
+		val, err := ParseDebugLevel(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(DebugLevel(0)),
 			}
 		}
-		if !ok {
-			return fmt.Errorf("Invalid DebugLevel value %q", str)
-		}
 		*e = DebugLevel(val)
 		return nil
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
 	if err == nil {
-		_, ok := DebugLevel_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid DebugLevel value %d", val)
+		val, err := ParseDebugLevel(ival)
+		if err == nil {
+			*e = val
+			return nil
 		}
-		*e = DebugLevel(val)
-		return nil
 	}
-	return fmt.Errorf("Invalid DebugLevel value %v", b)
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(DebugLevel(0)),
+	}
 }
 
 func (e DebugLevel) MarshalJSON() ([]byte, error) {
@@ -276,16 +292,23 @@ func applyMatchOptions(opts *MatchOptions, args ...MatchOpt) {
 // Allows decoding to handle protobuf enums that are
 // represented as strings.
 func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
-	if from.Kind() != reflect.String {
-		return data, nil
-	}
 	switch to {
 	case reflect.TypeOf(DebugLevel(0)):
-		if en, ok := DebugLevel_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseDebugLevel(data)
 	}
 	return data, nil
+}
+
+// GetEnumParseHelp gets end-user specific messages for
+// enum parse errors.
+// It returns the enum type name, a help message with
+// valid values, and a bool that indicates if a type was matched.
+func GetEnumParseHelp(t reflect.Type) (string, string, bool) {
+	switch t {
+	case reflect.TypeOf(DebugLevel(0)):
+		return "DebugLevel", ", valid values are one of Etcd, Api, Notify, Dmedb, Dmereq, Locapi, Infra, Metrics, Upgrade, Info, Sampled, Events, or 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11", true
+	}
+	return "", "", false
 }
 
 var ShowMethodNames = map[string]struct{}{}

--- a/testgen/sample.pb.go
+++ b/testgen/sample.pb.go
@@ -3207,43 +3207,10 @@ var OuterEnum_CamelValue = map[string]int32{
 	"Outer3": 3,
 }
 
-func (e *OuterEnum) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := OuterEnum_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = OuterEnum_CamelValue["Outer"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = OuterEnum_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid OuterEnum value %q", str)
-	}
-	*e = OuterEnum(val)
-	return nil
-}
-
-func (e OuterEnum) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(OuterEnum_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Outer")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *OuterEnum) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseOuterEnum(data interface{}) (OuterEnum, error) {
+	if val, ok := data.(OuterEnum); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := OuterEnum_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -3258,22 +3225,67 @@ func (e *OuterEnum) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid OuterEnum value %q", str)
+			return OuterEnum(0), fmt.Errorf("Invalid OuterEnum value %q", str)
 		}
-		*e = OuterEnum(val)
-		return nil
+		return OuterEnum(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := OuterEnum_CamelName[ival]; ok {
+			return OuterEnum(ival), nil
+		} else {
+			return OuterEnum(0), fmt.Errorf("Invalid OuterEnum value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return OuterEnum(0), fmt.Errorf("Invalid OuterEnum value %v", data)
+}
+
+func (e *OuterEnum) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseOuterEnum(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e OuterEnum) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(OuterEnum_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Outer")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *OuterEnum) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := OuterEnum_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid OuterEnum value %d", val)
+		val, err := ParseOuterEnum(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(OuterEnum(0)),
+			}
 		}
 		*e = OuterEnum(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid OuterEnum value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseOuterEnum(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(OuterEnum(0)),
+	}
 }
 
 func (e OuterEnum) MarshalJSON() ([]byte, error) {
@@ -3315,43 +3327,10 @@ var TestGen_InnerEnum_CamelValue = map[string]int32{
 	"Inner3": 3,
 }
 
-func (e *TestGen_InnerEnum) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	err := unmarshal(&str)
-	if err != nil {
-		return err
-	}
-	val, ok := TestGen_InnerEnum_CamelValue[util.CamelCase(str)]
-	if !ok {
-		// may have omitted common prefix
-		val, ok = TestGen_InnerEnum_CamelValue["Inner"+util.CamelCase(str)]
-	}
-	if !ok {
-		// may be enum value instead of string
-		ival, err := strconv.Atoi(str)
-		val = int32(ival)
-		if err == nil {
-			_, ok = TestGen_InnerEnum_CamelName[val]
-		}
-	}
-	if !ok {
-		return fmt.Errorf("Invalid TestGen_InnerEnum value %q", str)
-	}
-	*e = TestGen_InnerEnum(val)
-	return nil
-}
-
-func (e TestGen_InnerEnum) MarshalYAML() (interface{}, error) {
-	str := proto.EnumName(TestGen_InnerEnum_CamelName, int32(e))
-	str = strings.TrimPrefix(str, "Inner")
-	return str, nil
-}
-
-// custom JSON encoding/decoding
-func (e *TestGen_InnerEnum) UnmarshalJSON(b []byte) error {
-	var str string
-	err := json.Unmarshal(b, &str)
-	if err == nil {
+func ParseTestGen_InnerEnum(data interface{}) (TestGen_InnerEnum, error) {
+	if val, ok := data.(TestGen_InnerEnum); ok {
+		return val, nil
+	} else if str, ok := data.(string); ok {
 		val, ok := TestGen_InnerEnum_CamelValue[util.CamelCase(str)]
 		if !ok {
 			// may have omitted common prefix
@@ -3366,22 +3345,67 @@ func (e *TestGen_InnerEnum) UnmarshalJSON(b []byte) error {
 			}
 		}
 		if !ok {
-			return fmt.Errorf("Invalid TestGen_InnerEnum value %q", str)
+			return TestGen_InnerEnum(0), fmt.Errorf("Invalid TestGen_InnerEnum value %q", str)
 		}
-		*e = TestGen_InnerEnum(val)
-		return nil
+		return TestGen_InnerEnum(val), nil
+	} else if ival, ok := data.(int32); ok {
+		if _, ok := TestGen_InnerEnum_CamelName[ival]; ok {
+			return TestGen_InnerEnum(ival), nil
+		} else {
+			return TestGen_InnerEnum(0), fmt.Errorf("Invalid TestGen_InnerEnum value %d", ival)
+		}
 	}
-	var val int32
-	err = json.Unmarshal(b, &val)
+	return TestGen_InnerEnum(0), fmt.Errorf("Invalid TestGen_InnerEnum value %v", data)
+}
+
+func (e *TestGen_InnerEnum) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	val, err := ParseTestGen_InnerEnum(str)
+	if err != nil {
+		return err
+	}
+	*e = val
+	return nil
+}
+
+func (e TestGen_InnerEnum) MarshalYAML() (interface{}, error) {
+	str := proto.EnumName(TestGen_InnerEnum_CamelName, int32(e))
+	str = strings.TrimPrefix(str, "Inner")
+	return str, nil
+}
+
+// custom JSON encoding/decoding
+func (e *TestGen_InnerEnum) UnmarshalJSON(b []byte) error {
+	var str string
+	err := json.Unmarshal(b, &str)
 	if err == nil {
-		_, ok := TestGen_InnerEnum_CamelName[val]
-		if !ok {
-			return fmt.Errorf("Invalid TestGen_InnerEnum value %d", val)
+		val, err := ParseTestGen_InnerEnum(str)
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: "string " + str,
+				Type:  reflect.TypeOf(TestGen_InnerEnum(0)),
+			}
 		}
 		*e = TestGen_InnerEnum(val)
 		return nil
 	}
-	return fmt.Errorf("Invalid TestGen_InnerEnum value %v", b)
+	var ival int32
+	err = json.Unmarshal(b, &ival)
+	if err == nil {
+		val, err := ParseTestGen_InnerEnum(ival)
+		if err == nil {
+			*e = val
+			return nil
+		}
+	}
+	return &json.UnmarshalTypeError{
+		Value: "value " + string(b),
+		Type:  reflect.TypeOf(TestGen_InnerEnum(0)),
+	}
 }
 
 func (e TestGen_InnerEnum) MarshalJSON() ([]byte, error) {
@@ -3436,19 +3460,23 @@ func applyMatchOptions(opts *MatchOptions, args ...MatchOpt) {
 // Allows decoding to handle protobuf enums that are
 // represented as strings.
 func EnumDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
-	if from.Kind() != reflect.String {
-		return data, nil
-	}
 	switch to {
 	case reflect.TypeOf(OuterEnum(0)):
-		if en, ok := OuterEnum_CamelValue[util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
-		if en, ok := OuterEnum_CamelValue["Outer"+util.CamelCase(data.(string))]; ok {
-			return en, nil
-		}
+		return ParseOuterEnum(data)
 	}
 	return data, nil
+}
+
+// GetEnumParseHelp gets end-user specific messages for
+// enum parse errors.
+// It returns the enum type name, a help message with
+// valid values, and a bool that indicates if a type was matched.
+func GetEnumParseHelp(t reflect.Type) (string, string, bool) {
+	switch t {
+	case reflect.TypeOf(OuterEnum(0)):
+		return "OuterEnum", ", valid values are one of 0, 1, 2, 3, or 0, 1, 2, 3", true
+	}
+	return "", "", false
 }
 
 var ShowMethodNames = map[string]struct{}{}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5711 Create/Update cloudlet error messages incorrect
* EDGECLOUD-5766 inconsistent error message for CreateApp serverless_config.vcpus with negative and decimal numbers

### Description

Improves the helpfulness and consistency of JSON and mcctl parse errors when dealing with custom Unmarshalers.

The custom UnmarshalJSON functions now return an error of type json.UnmarshalTypeError. This particular error type will be detected by the JSON library, and it will fill in the field that had the error (but for some reason doesn't always fill in the offset). This fixes an issue where errors from custom unmarshalers are less helpful than other parse errors, because they lacked the context of where in the JSON the error originated.

In addition, I've made it so that the mcctl command line arguments use the same code to parse and generate help as the JSON unmarshal code (in infra), such that both mcctl and direct API calls should have very similar errors for custom unmarshalers.

Enum parse errors now also indicate the valid values.