### PR TITLE
fix port range for network policy

### DIFF
--- a/cloud-resource-manager/k8smgmt/networkpolicy_test.go
+++ b/cloud-resource-manager/k8smgmt/networkpolicy_test.go
@@ -73,7 +73,7 @@ spec:
 			// 1000 port range, mapped
 			Proto:        dme.LProto_L_PROTO_TCP,
 			InternalPort: 51000,
-			EndPort:      52000,
+			EndPort:      51009,
 			PublicPort:   61000,
 		},
 	}
@@ -102,7 +102,24 @@ spec:
       port: 10101
     - protocol: TCP
       port: 51000
-      endPort: 52000
+    - protocol: TCP
+      port: 51001
+    - protocol: TCP
+      port: 51002
+    - protocol: TCP
+      port: 51003
+    - protocol: TCP
+      port: 51004
+    - protocol: TCP
+      port: 51005
+    - protocol: TCP
+      port: 51006
+    - protocol: TCP
+      port: 51007
+    - protocol: TCP
+      port: 51008
+    - protocol: TCP
+      port: 51009
 `)
 
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5950 anthos ports not accessible with port ranges

### Description

When specifying a port range for multi tenant app instances, only the first port in the range is reachable. The reason is that the NetworkPolicy manifest uses "endPort".  

The endPort attribute is not defined in io.k8s.api.networking.v1.NetworkPolicyPort until k8s version 1.21. In prior versions such as we have, the field is silently deleted when MergeEnvVars calls DecodeK8SYaml and re-constructs the manifest. I tried manually adding this back to the manifest in k8s version 1.20 and it generates an "unknown field" error.

To resolve this I replaced endPort with a loop over all the ports similar to how we do it for services.

Note: it would be nice if DecodeK8SYaml caught this error but the UniversalDeserializer does not run in strict mode and my experiments to fix this ended in frustration. I will open a jira ticket as a future improvement to see if we can detect these errors.

