### PR TITLE
EDGECLOUD-5956 allow update App to AllowServerless=false

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -638,6 +638,10 @@ func (s *AppApi) UpdateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 				return err
 			}
 		}
+		if !cur.AllowServerless {
+			// clear serverless config
+			cur.ServerlessConfig = nil
+		}
 		// for update, trigger regenerating deployment manifest
 		if cur.DeploymentGenerator != "" {
 			cur.DeploymentManifest = ""

--- a/controller/app_api_test.go
+++ b/controller/app_api_test.go
@@ -211,6 +211,36 @@ func TestAppApi(t *testing.T) {
 	_, err = apis.appApi.CreateApp(ctx, &app)
 	require.NotNil(t, err, "Create app with maxpktsize fails")
 
+	// update app with serverless config
+	app.Deployment = "kubernetes"
+	app.AccessPorts = "tcp:888"
+	_, err = apis.appApi.CreateApp(ctx, &app)
+	require.Nil(t, err)
+	app.AllowServerless = true
+	app.ServerlessConfig = &edgeproto.ServerlessConfig{}
+	app.ServerlessConfig.Vcpus = *edgeproto.NewUdec64(5, 0)
+	app.ServerlessConfig.Ram = 24
+	app.ServerlessConfig.MinReplicas = 1
+	app.Fields = []string{
+		edgeproto.AppFieldAllowServerless,
+		edgeproto.AppFieldServerlessConfig,
+		edgeproto.AppFieldServerlessConfigVcpus,
+		edgeproto.AppFieldServerlessConfigRam,
+		edgeproto.AppFieldServerlessConfigMinReplicas,
+	}
+	_, err = apis.appApi.UpdateApp(ctx, &app)
+	require.Nil(t, err)
+	// disable serverless config
+	app.AllowServerless = false
+	app.Fields = []string{
+		edgeproto.AppFieldAllowServerless,
+	}
+	_, err = apis.appApi.UpdateApp(ctx, &app)
+	require.Nil(t, err)
+	// clean up app
+	_, err = apis.appApi.DeleteApp(ctx, &app)
+	require.Nil(t, err)
+
 	// test updating app with a list of alertpolicies
 	alertPolicyApp := testutil.AppData[1]
 	alertPolicyApp.Deployment = cloudcommon.DeploymentTypeKubernetes


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5956 unable to update app to allowserverless=false

### Description

The configureApp function that validates the new App state after being updated was complaining because allowserverless was false, but old serverless settings from before the update were on the App. For create, we don't want to allow the user to specify serverless settings if alloweserverless is false.

To fix, on update, clear any serverless config on the App if the user is disabling allowserverless.