### PR TITLE
tpe update (by admin) with rules and nonexisting org, should give correct error of key not found

### DIFF
--- a/controller/trustpolicyexception_api_test.go
+++ b/controller/trustpolicyexception_api_test.go
@@ -108,7 +108,10 @@ func TestTrustPolicyExceptionApi(t *testing.T) {
 	// test that TPE update with non-existent AppKey Organization, fails
 	tpeData.Fields = []string{
 		edgeproto.TrustPolicyExceptionFieldKeyAppKey,
-		edgeproto.TrustPolicyExceptionFieldKeyAppKeyOrganization}
+		edgeproto.TrustPolicyExceptionFieldKeyAppKeyOrganization,
+		edgeproto.TrustPolicyExceptionFieldOutboundSecurityRules,
+		edgeproto.TrustPolicyExceptionFieldOutboundSecurityRulesRemoteCidr}
+	tpeData.OutboundSecurityRules[0].RemoteCidr = "1.1.0.0/16"
 	tpeData.Key.AppKey.Organization = "MarsAppOrg"
 	_, err = apis.trustPolicyExceptionApi.UpdateTrustPolicyException(ctx, &tpeData)
 	require.NotNil(t, err)


### PR DESCRIPTION

### Issues Fixed

EDGECLOUD-5965
Please see Andy's comment on bug verification.
The bug is fixed except one small issue.
When logged in as an admin, and a nonexistent key is provided but with security rules, it gives a message
"Operator can update only state field"


### Description

Please see 
https://github.com/mobiledgex/edge-cloud-infra/pull/1895
