### PR TITLE
fix update trustpolicy

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -1287,7 +1287,7 @@ func (cd *ControllerData) cloudletChanged(ctx context.Context, old *edgeproto.Cl
 	if old != nil && old.TrustPolicyState != new.TrustPolicyState {
 		switch new.TrustPolicyState {
 		case edgeproto.TrackedState_UPDATE_REQUESTED:
-			log.SpanLog(ctx, log.DebugLevelInfra, "Updating Trust Policy")
+			log.SpanLog(ctx, log.DebugLevelInfra, "Updating Trust Policy", "new state", new.TrustPolicyState)
 			if new.State != edgeproto.TrackedState_READY {
 				log.SpanLog(ctx, log.DebugLevelInfra, "Update policy cannot be done until cloudlet is ready")
 				cloudletInfo.TrustPolicyState = edgeproto.TrackedState_UPDATE_ERROR
@@ -1295,6 +1295,7 @@ func (cd *ControllerData) cloudletChanged(ctx context.Context, old *edgeproto.Cl
 			} else {
 				cloudletInfo.TrustPolicyState = edgeproto.TrackedState_UPDATING
 				cd.UpdateCloudletInfo(ctx, &cloudletInfo)
+				cd.updateTrustPolicyKeyworkers.NeedsWork(ctx, new.Key)
 			}
 		}
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5989 updating trustpolicy gives time out error

### Description

Add back the call to updateTrustPolicyKeyworkers.NeedsWork which was inadvertently removed, causing trust policy update to time out