### PR TITLE
EDGECLOUD-6011 trustpolicyexception not creating rules in openstack

### DIFF
--- a/cloud-resource-manager/crmutil/controller-data.go
+++ b/cloud-resource-manager/crmutil/controller-data.go
@@ -1751,7 +1751,11 @@ func (cd *ControllerData) GetTrustPolicyExceptionsFromKey(ctx context.Context, t
 
 	cd.TrustPolicyExceptionCache.Show(&filter, func(tpe *edgeproto.TrustPolicyException) error {
 		log.SpanLog(ctx, log.DebugLevelInfra, "In GetTrustPolicyExceptionsFromKey()", "adding tpe:", tpe)
-		tpeArray = append(tpeArray, tpe)
+		// The tpe passed in from Show is what's in memory in the cache.
+		// To access it outside the cache lock,  need to make a copy.
+		tpeCopy := edgeproto.TrustPolicyException{}
+		tpeCopy.DeepCopyIn(tpe)
+		tpeArray = append(tpeArray, &tpeCopy)
 		return nil
 	})
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6011 trustpolicyexception not creating rules in openstack

fixed TrustPolicyExceptionCache lookup in HandleTrustPolicyException() to skip tpe policy Name

### Description

I broke this code when I moved from
	err := cd.TrustPolicyExceptionCache.Show(&edgeproto.TrustPolicyException{Key: tpeKey}, func(tpe *edgeproto.TrustPolicyException) error {
[...]
	})
to

	found, TrustPolicyException := cd.GetTrustPolicyExceptionFromKey(&tpeKey)

in 

https://github.com/mobiledgex/edge-cloud/pull/1555/files

### Unit test

Ran the fix on real cloudlet and verified the logs as well as security rules getting pushed to openstack.


devdatta@Dajgaonkar-MAC:~$ openstack security group show TDGPoolTPE-server_ping_threaded2-user3org-9.0-TDGPoolAAABBB-TDG
+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field           | Value                                                                                                                                                                                                                                                  |
+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| created_at      | 2022-01-12T15:46:59Z                                                                                                                                                                                                                                   |
| description     |                                                                                                                                                                                                                                                        |
| id              | d6f9a0a4-ebe7-4f1b-b42b-6f764210b9d8                                                                                                                                                                                                                   |
| location        | Munch({'cloud': '', 'region_name': 'RegionOne', 'zone': None, 'project': Munch({'id': 'b6b6b3a1e35b449383be5e35a1913ccf', 'name': 'mex', 'domain_id': 'default', 'domain_name': None})})                                                               |
| name            | TDGPoolTPE-server_ping_threaded2-user3org-9.0-TDGPoolAAABBB-TDG                                                                                                                                                                                        |
| project_id      | b6b6b3a1e35b449383be5e35a1913ccf                                                                                                                                                                                                                       |
| revision_number | 5                                                                                                                                                                                                                                                      |
| rules           | created_at='2022-01-12T15:47:00Z', direction='egress', ethertype='IPv4', id='d418ee3e-ec5c-4213-b4eb-e5da038fa341', port_range_max='2222', port_range_min='2222', protocol='udp', remote_ip_prefix='22.22.22.22/24', updated_at='2022-01-12T15:47:00Z' |
|                 | created_at='2022-01-12T15:47:00Z', direction='ingress', ethertype='IPv4', id='d7e22345-17a8-4a5e-981d-f9e57a6b7f40', port_range_max='22', port_range_min='22', protocol='tcp', remote_ip_prefix='0.0.0.0/0', updated_at='2022-01-12T15:47:00Z'         |
| stateful        | None                                                                                                                                                                                                                                                   |
| tags            | []                                                                                                                                                                                                                                                     |
| updated_at      | 2022-01-12T15:47:00Z                                                                                                                                                                                                                                   |
+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
devdatta@Dajgaonkar-MAC:~$



