### PR TITLE
EDGECLOUD-6015 capitalize mcctl arg help comments

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -10,6 +10,7 @@ import (
 
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/util"
 	yaml "github.com/mobiledgex/yaml/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -163,6 +164,7 @@ func (c *Command) argsHelp(pad int, args []string) string {
 		comment := ""
 		if c.Comments != nil {
 			comment = c.Comments[str]
+			comment = util.CapitalizeMessage(comment)
 		}
 		fmt.Fprintf(&buf, "  %-*s%s\n", pad, str, comment)
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6015 mcctl events should have the  arg descriptions capitalized

### Description

Capitalizes all mcctl argument help descriptions.
```
> mcctl events find -h
Find events and audit events, results sorted by relevance

Usage: mcctl events find [flags] [args]

Optional Args:
  name       Name of the event, may be specified multiple times
  org        Organization associated with the event, may be specified multiple times
  type       Type of event, either "event" or "audit", may be specified multiple times
  region     Region name
  error      Any words in an error message
  tags       Key=value tag, may be specified multiple times, key may include alert, alertorg, apiendpointtype, apiname, app, apporg, appver, cloudlet, cloudletorg, cloudletpool, cloudletpoolorg, cluster, clusterorg, clusterreforg, controlleraddr, deviceid, deviceidtype, federatedorg, flavor, flowsettingsname, gpudriver, gpudriverorg, maxreqssettingsname, name, network, node, noderegion, nodetype, policy, policyorg, ratelimittarget, restagtable, restagtableorg, uniqueid, uniqueidtype, vcluster, vmpool, vmpoolorg
  failed     Specify true to find events with an error
  notname    Name of the event to exclude, may be specified multiple times
  notorg     Organization associated with the event to exclude, may be specified multiple times
  nottype    Type of event, either "event" or "audit" to exclude, may be specified multiple times
  notregion  Region for the event to exclude, may be specified multiple times
  noterror   Any words in an error message to exclude
  nottags    Any tags to exclude, see tags option
  notfailed  Specify true to find events without any error
  starttime  Absolute time of search range start (RFC3339)
  endtime    Absolute time of search range end (RFC3339)
  startage   Relative age from now of search range start (default 48h)
  endage     Relative age from now of search range end (default 0)
  from       Start offset if paging through results
  limit      Number of results to return, either to limit or for paging results
```