### PR TITLE
EDGECLOUD-6068: Retry auto deletion of appinst if an action is in progress

### DIFF
--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -213,7 +213,8 @@ func (s *AppInstApi) AutoDeleteAppInsts(ctx context.Context, dynInsts map[edgepr
 				err = nil
 				break
 			}
-			if err != nil && strings.Contains(err.Error(), ObjBusyDeletionMsg) {
+			if err != nil && (strings.Contains(err.Error(), ObjBusyDeletionMsg) ||
+				strings.Contains(err.Error(), ActionInProgressMsg)) {
 				spinTime = time.Since(start)
 				if spinTime > s.all.settingsApi.Get().DeleteAppInstTimeout.TimeDuration() {
 					log.SpanLog(ctx, log.DebugLevelApi, "Timeout while waiting for App", "appName", val.Key.AppKey.Name)

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -34,6 +34,7 @@ type ClusterInstApi struct {
 var AutoClusterPrefixErr = fmt.Sprintf("Cluster name prefix \"%s\" is reserved",
 	cloudcommon.AutoClusterPrefix)
 var ObjBusyDeletionMsg = "busy, cannot be deleted"
+var ActionInProgressMsg = "action is already in progress"
 
 // Transition states indicate states in which the CRM is still busy.
 var CreateClusterInstTransitions = map[edgeproto.TrackedState]struct{}{


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6068: Deletion of k8s cluster instance fails when MexPrometheus App Inst is being deployed on the cluster

### Description

* If appInst creation of internal apps is in-progress, then retry auto-deletion of such appinsts on in-progress error