### PR TITLE
EDGECLOUD-6076: Use redis for storing alerts

### DIFF
--- a/controller/cloudletinfo_api.go
+++ b/controller/cloudletinfo_api.go
@@ -222,8 +222,6 @@ func (s *CloudletInfoApi) FireCloudletAndAppInstDownAlerts(ctx context.Context, 
 }
 
 func (s *CloudletInfoApi) ClearCloudletAndAppInstDownAlerts(ctx context.Context, in *edgeproto.CloudletInfo) {
-	// We ignore the controller and notifyId check when cleaning up the alerts here
-	ctx = context.WithValue(ctx, ControllerCreatedAlerts, &ControllerCreatedAlerts)
 	s.clearCloudletDownAlert(ctx, in)
 	s.clearCloudletDownAppInstAlerts(ctx, in)
 }

--- a/controller/clusterinst_api.go
+++ b/controller/clusterinst_api.go
@@ -564,7 +564,7 @@ func (s *ClusterInstApi) getAllCloudletResources(ctx context.Context, stm concur
 	return allVmResources, diffVmResources, skipInfraCheck, nil
 }
 
-func (s *ClusterInstApi) handleResourceUsageAlerts(ctx context.Context, stm concurrency.STM, key *edgeproto.CloudletKey, warnings []string) {
+func (s *ClusterInstApi) handleResourceUsageAlerts(ctx context.Context, key *edgeproto.CloudletKey, warnings []string) {
 	alerts := cloudcommon.CloudletResourceUsageAlerts(ctx, key, warnings)
 	staleAlerts := make(map[edgeproto.AlertKey]struct{})
 	s.all.alertApi.cache.GetAllKeys(ctx, func(k *edgeproto.AlertKey, modRev int64) {
@@ -572,7 +572,7 @@ func (s *ClusterInstApi) handleResourceUsageAlerts(ctx context.Context, stm conc
 	})
 	for _, alert := range alerts {
 		s.all.alertApi.setAlertMetadata(&alert)
-		s.all.alertApi.store.STMPut(stm, &alert)
+		s.all.alertApi.Update(ctx, &alert, 0)
 		delete(staleAlerts, alert.GetKeyVal())
 	}
 	delAlert := edgeproto.Alert{}
@@ -590,7 +590,9 @@ func (s *ClusterInstApi) handleResourceUsageAlerts(ctx context.Context, stm conc
 			cloudletOrg != key.Organization {
 			continue
 		}
-		s.all.alertApi.store.STMDel(stm, &alertKey)
+		alertObj := edgeproto.Alert{}
+		edgeproto.AlertKeyStringParse(string(alertKey), &alertObj)
+		s.all.alertApi.Delete(ctx, &alertObj, 0)
 	}
 }
 
@@ -638,7 +640,7 @@ func (s *ClusterInstApi) validateResources(ctx context.Context, stm concurrency.
 	if genAlerts == GenResourceAlerts {
 		// generate alerts for these warnings
 		// clear off those alerts which are no longer firing
-		s.handleResourceUsageAlerts(ctx, stm, &cloudlet.Key, warnings)
+		s.handleResourceUsageAlerts(ctx, &cloudlet.Key, warnings)
 	}
 	return nil
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -262,6 +262,9 @@ func startServices() error {
 
 	allApis.Start(ctx)
 
+	// Sync data from redis with controller cache
+	syncRedisData(ctx, allApis)
+
 	initDebug(ctx, &nodeMgr, allApis)
 
 	err = allApis.settingsApi.initDefaults(ctx)

--- a/controller/redis_sync.go
+++ b/controller/redis_sync.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
+)
+
+// Sync data from redis with controller cache
+func syncRedisData(ctx context.Context, allApis *AllApis) {
+	log.SpanLog(ctx, log.DebugLevelInfo, "Start sync of redis data")
+
+	// fetch alert data from redis and sync it with controller cache
+	syncAlertCache(ctx, &allApis.alertApi.cache)
+
+	log.SpanLog(ctx, log.DebugLevelInfo, "Done sync of redis data")
+}
+
+func syncAlertCache(ctx context.Context, cache *edgeproto.AlertCache) {
+	log.SpanLog(ctx, log.DebugLevelInfo, "Start sync of redis alert data")
+	pattern := getAllAlertsKeyPattern()
+	alertKeys, err := redisClient.Keys(pattern).Result()
+	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelInfo, "Failed to sync alerts from redis", "err", err)
+		return
+	}
+	syncCount := 0
+	for _, alertKey := range alertKeys {
+		alertVal, err := redisClient.Get(alertKey).Result()
+		if err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfo, "Failed to sync alerts from redis", "alert", alertVal, "err", err)
+			continue
+		}
+		var obj edgeproto.Alert
+		err = json.Unmarshal([]byte(alertVal), &obj)
+		if err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfo, "Failed to sync alerts from redis", "alert", alertVal, "err", err)
+			continue
+		}
+		cache.Update(ctx, &obj, 0)
+		syncCount++
+	}
+	log.SpanLog(ctx, log.DebugLevelInfo, "Done sync of redis alert data", "sync-count", syncCount)
+}

--- a/controller/sync_lease_data.go
+++ b/controller/sync_lease_data.go
@@ -121,11 +121,6 @@ func (s *SyncLeaseData) syncData() error {
 
 		err = s.allApis.controllerApi.registerController(ctx, leaseID)
 		log.SpanLog(ctx, log.DebugLevelInfo, "registered controller", "hostname", cloudcommon.Hostname(), "err", err)
-
-		// Sync alerts inside goroutine because if there are lots of alerts then it
-		// might hold up keepalive and the controller lease might expire
-		err = s.allApis.alertApi.syncSourceData(ctx)
-		log.SpanLog(ctx, log.DebugLevelInfo, "synced alerts", "err", err)
 		span.Finish()
 	}()
 	return nil


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6076: Use redis for storing alerts

### Description

* Alerts are transient data and hence they should be stored in redis. Alerts will be stored with no expiry set. This assumes that the code which added the alert cleans it up appropriately
* Added code to sync data from redis with controller cache on controller bring up
* An issue with this approach is what if redis goes down? We would need some way to re-trigger those alerts from CRM and also any controller-generated alerts. This shouldn’t be an issue as alerts will still be cached as part of the AlertCache (for notify framework). And also if needed we can take persistent backup of redis data. But then it’s an unlikely scenario as we do support redis HA. And if redis still goes down then something is seriously wrong and it will cause a complete breakdown
