### PR TITLE
Trustpolicyexception

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/crm_server_test.go
+++ b/cloud-resource-manager/cmd/crmserver/crm_server_test.go
@@ -812,8 +812,8 @@ func testTrustPolicyExceptionUpdates1(t *testing.T, ctx context.Context, tpe *ed
 	// delete an appInst, should reduce the count by 1
 	log.SpanLog(ctx, log.DebugLevelApi, "############ UT1.5")
 	ii := 2 // index of trusted appInst on a clusterInst
-	data.AppInstances[ii].State = edgeproto.TrackedState_DELETE_REQUESTED
-	ctrlHandler.AppInstCache.Update(ctx, &data.AppInstances[ii], 0)
+	data.AppInstances[ii].State = edgeproto.TrackedState_DELETE_DONE
+	ctrlHandler.AppInstCache.Delete(ctx, &data.AppInstances[ii], 0)
 	require.Nil(t, notify.WaitFor(&controllerData.AppInstCache, 3))
 	require.Equal(t, 3, len(controllerData.AppInstCache.Objs))
 	time.Sleep(5 * time.Millisecond)
@@ -826,7 +826,8 @@ func testTrustPolicyExceptionUpdates1(t *testing.T, ctx context.Context, tpe *ed
 	ctrlHandler.AppInstCache.Update(ctx, &data.AppInstances[ii], 0)
 	require.Nil(t, notify.WaitFor(&controllerData.AppInstCache, 3))
 	require.Equal(t, 3, len(controllerData.AppInstCache.Objs))
-
+	count = fakePlatform.TrustPolicyExceptionCount(ctx)
+	require.Equal(t, 2, count)
 	log.SpanLog(ctx, log.DebugLevelApi, "############# end testTrustPolicyExceptionUpdates1 #############")
 }
 
@@ -851,7 +852,7 @@ func testTrustPolicyExceptionUpdates2(t *testing.T, ctx context.Context, tpe *ed
 
 	// test that the new Approved TPE is not programmed on any clusters, count should still be the old count
 	count := fakePlatform.TrustPolicyExceptionCount(ctx)
-	require.Equal(t, 1, count)
+	require.Equal(t, 2, count)
 
 	// test that a TPE with State ACTIVE, for an existing AppInst, adds that TPEs to that ClusterInst
 	log.SpanLog(ctx, log.DebugLevelApi, "############ UT2.2")
@@ -866,7 +867,7 @@ func testTrustPolicyExceptionUpdates2(t *testing.T, ctx context.Context, tpe *ed
 
 	// test that Multiple TPEs are configured per app, on multiple clusters. Total count increases by 2
 	count = fakePlatform.TrustPolicyExceptionCount(ctx)
-	require.Equal(t, 3, count)
+	require.Equal(t, 4, count)
 
 	log.SpanLog(ctx, log.DebugLevelApi, "############# end testTrustPolicyExceptionUpdates2 #############")
 }
@@ -876,7 +877,7 @@ func testTrustPolicyExceptionUpdates3(t *testing.T, ctx context.Context, ctrlHan
 
 	log.SpanLog(ctx, log.DebugLevelApi, "############ begin CloudletPoolCache.Update")
 	count := fakePlatform.TrustPolicyExceptionCount(ctx)
-	require.Equal(t, 3, count)
+	require.Equal(t, 4, count)
 
 	var CloudletsSaved [][]string
 

--- a/controller/trustpolicyexception_api.go
+++ b/controller/trustpolicyexception_api.go
@@ -115,10 +115,6 @@ func (s *TrustPolicyExceptionApi) UpdateTrustPolicyException(ctx context.Context
 				in.State != edgeproto.TrustPolicyExceptionState_TRUST_POLICY_EXCEPTION_STATE_REJECTED {
 				return fmt.Errorf("New state must be either Active or Rejected")
 			}
-		} else if !rulesSpecified {
-			// For an update, a developer can only specify security rules
-			// caller (developer) must provide at least one security rule
-			return fmt.Errorf("Security rules must be specified")
 		}
 		if rulesSpecified && cur.State != edgeproto.TrustPolicyExceptionState_TRUST_POLICY_EXCEPTION_STATE_APPROVAL_REQUESTED {
 			return fmt.Errorf("Can update security rules only when trust policy exception is still in approval requested state")


### PR DESCRIPTION
### Issues Fixed

appInstChanged() was handling tpe add/delete when TrackedState_CREATE_REQUESTED/TrackedState_DELETE_REQUESTED

This cause problem because when a CREATE can fail.
Instead of create, adding tpe when READY state comes in.
And instead of deleting tpe from TrackedState_DELETE_REQUESTED, doing so from appInstDeleted callback.

### Description

Changed appInstExistsForTpe() to check only for appInst.State == edgeproto.TrackedState_READY rather than all other creating and ready states.

Delete
- handleTrustPolicyExceptionForAppInst() from appInstDeleted()



### Unit test 1
devdatta@Dajgaonkar-MAC ~/g/s/g/m/edge-cloud (trustpolicyexception)> make unit-test
go test ./... > /tmp/edge-cloud-unit-test.log || \
                ((grep -A6 "\--- FAIL:" /tmp/edge-cloud-unit-test.log || \
                grep -A20 "panic: " /tmp/edge-cloud-unit-test.log || \
                grep -A2 "FATAL" /tmp/edge-cloud-unit-test.log) && \
                grep "FAIL\tgithub.com" /tmp/edge-cloud-unit-test.log)
devdatta@Dajgaonkar-MAC ~/g/s/g/m/edge-cloud (trustpolicyexception)>

### Unit test 2

devdatta@Dajgaonkar-MAC ~/g/s/g/m/edge-cloud (trustpolicyexception) [2]> make test-debug
e2e-tests -testfile ./setup-env/e2e-tests/testfiles/regression_group.yml -setupfile ./setup-env/e2e-tests/setups/local_multi.yml -stop -notimestamp
Creating output dir: /tmp/e2e_test_out

Testfile                       Test                                                         Result
-----------------------------------------------------------------------------------------------------
regression_group.yml           include: stop_cleanup.yml
 - stop_cleanup.yml            stop services and cleanup                                    PASS
regression_group.yml           include: deploy_start.yml
 - deploy_start.yml            start services                                               PASS
 - deploy_start.yml            verify services are running                                  PASS
regression_group.yml           include: check_dme_nodes.yml
 - check_dme_nodes.yml         check DME node-show                                          PASS
regression_group.yml           include: trustpolexception_add_update.yml
 - trustpolexception_add_up... create a trust policy exception                              PASS
 - trustpolexception_add_up... update a trust policy exception portrange                    PASS
 - trustpolexception_add_up... approve a trust policy exception                             PASS
 - trustpolexception_add_up... update remotecidr in an active trust policy exception, should fail PASS
 - trustpolexception_add_up... update Active state to ApprovalRequested, should fail        PASS
 - trustpolexception_add_up... reject a trust policy exception                              PASS
 - trustpolexception_add_up... delete trust policy exception, verify it is empty            PASS
regression_group.yml           include: stop_cleanup.yml
 - stop_cleanup.yml            stop services and cleanup                                    PASS

Total Run: 12, passed: 12, failed: 0, took: 1m5.798203917s
devdatta@Dajgaonkar-MAC ~/g/s/g/m/edge-cloud (trustpolicyexception)>

### Unit test 3

Manually Tested Create/Delete AppInst on Frankfurt cloudlet, went through the logs and openstack commands.

### Unit test 4

Ran my own shell scripts for add tpe/delete tpe.

