### PR TITLE
UpdateCloudlet() trustpolicy update time out error message fix 

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -1202,7 +1202,7 @@ func (s *CloudletApi) UpdateCloudlet(in *edgeproto.Cloudlet, inCb edgeproto.Clou
 		// Wait for policy to update
 		err = s.updateTrustPolicyInternal(ctx, &in.Key, in.TrustPolicy, cb)
 		if caseInsensitiveContainsTimedOut(err.Error()) {
-			cb.Send(&edgeproto.Result{Message: fmt.Sprintf("UpdateCloudlet() Update cloudlet is in progress: %s - %s Please use 'cloudlet show' to check current status", cloudletKey, err.Error())})
+			cb.Send(&edgeproto.Result{Message: fmt.Sprintf("Update cloudlet is in progress: %s - %s Please use 'cloudlet show' to check current status", cloudletKey, err.Error())})
 		}
 		return err
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5246 Timed out waiting for Trust Policy should not display if work is in progress and timeout is to short


### Description

TrustPolicy Update timeout message was already fixed.
Now fixing timeout message for Cloudlet Update

### Unit-test
test code to recreate timeout
@@ -615,6 +616,8 @@ func (s *Platform) UpdateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud

 func (s *Platform) UpdateTrustPolicy(ctx context.Context, TrustPolicy *edgeproto.TrustPolicy) error {
        log.DebugLog(log.DebugLevelInfra, "fake UpdateTrustPolicy begin", "policy", TrustPolicy)
+       r := rand.Intn(20)
+       time.Sleep(time.Duration(r) * time.Second)
        return nil
 }

devdatta@Dajgaonkar-MAC:~  lmc cloudlet update region=local cloudlet-org=tmus cloudlet=tmus-cloud-tp trustpolicy=tp1
message: 'Doing TrustPolicy: tp1 Update for Cloudlet: organization:"tmus" name:"tmus-cloud-tp" '
message: 'In progress TrustPolicy: tp1 Update for Cloudlet: organization:"tmus" name:"tmus-cloud-tp"  --
  Timed out waiting for Trust Policy'
message: 'UpdateCloudlet() Update cloudlet is in progress: {tmus tmus-cloud-tp } -
  Timed out waiting for Trust Policy Please use ''cloudlet show'' to check current
  status'
Error: OK (200), Timed out waiting for Trust Policy
devdatta@Dajgaonkar-MAC:~  lmc trustpolicy update region=local cloudlet-org=tmus name=tp1
message: 'Doing TrustPolicy: tp1 Update for Cloudlet: organization:"tmus" name:"tmus-cloud-tp" '
message: 'In progress TrustPolicy: tp1 Update for Cloudlet: organization:"tmus" name:"tmus-cloud-tp"  --
  Timed out waiting for Trust Policy'
message: 'Update cloudlet is in progress: {tmus tmus-cloud-tp } - Timed out waiting
  for Trust Policy Please use ''cloudlet show'' to check current status'
message: 'Processed: 1 Cloudlets.  Passed: 0 InProgress: 1 Failed: 0'
devdatta@Dajgaonkar-MAC:~$