### PR TITLE
EDGECLOUD-5982 New e2e-tests for QOS Sessions

### DIFF
--- a/setup-env/apis/dmeapi.go
+++ b/setup-env/apis/dmeapi.go
@@ -544,8 +544,8 @@ func runDmeAPIiter(ctx context.Context, api, apiFile, outputDir string, apiReque
 			}
 			// Whether first or subsequent run, save unfiltered output to be checked against on next run.
 			util.PrintToYamlFile(api+"unfiltered.yml", outputDir, reply, true)
+			util.FilterQosPrioritySessionReply(reply)
 		}
-		util.FilterQosPrioritySessionReply(reply)
 		dmereply = reply
 		dmeerror = err
 

--- a/setup-env/util/util.go
+++ b/setup-env/util/util.go
@@ -651,6 +651,15 @@ func FilterFindCloudletReply(reply *dmeproto.FindCloudletReply) {
 	delete(reply.Tags, cloudcommon.TagPrioritySessionId)
 }
 
+func FilterQosPrioritySessionReply(reply *dmeproto.QosPrioritySessionReply) {
+	// Session ID and timestamps change each request.
+	if reply.SessionId != "" {
+		reply.SessionId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+	}
+	reply.StartedAt = 0
+	reply.ExpiresAt = 0
+}
+
 func FilterAppInstEdgeEventsCookies(appInstReply *dmeproto.AppInstListReply) {
 	for _, cloudlet := range appInstReply.Cloudlets {
 		for _, appinst := range cloudlet.Appinstances {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5982 Create QosPrioritySession API for DME

### Description
e2e code to support new tests. Supports saving reply, so that it can be used on a subsequent test to verify against, or in the case of delete, use as a parameter.