### PR TITLE
EDGECLOUD-5918 ensure idempotent upgrade functions

### DIFF
--- a/controller/upgrade_funcs.go
+++ b/controller/upgrade_funcs.go
@@ -297,7 +297,7 @@ func TrustPolicyExceptionUpgradeFunc(ctx context.Context, objStore objstore.KVSt
 			return err2
 		}
 		log.SpanLog(ctx, log.DebugLevelUpgrade, "TrustPolicyExceptionUpgradeFunc found app", "required_outbound", appV0.RequiredOutboundConnections)
-		if len(appV0.RequiredOutboundConnections) > 0 {
+		if len(appV0.RequiredOutboundConnections) > 0 && appV0.RequiredOutboundConnections[0].Port != 0 {
 			newReqdConns := []edgeproto.SecurityRule{}
 			for _, conn := range appV0.RequiredOutboundConnections {
 				secRule := edgeproto.SecurityRule{

--- a/controller/upgrade_test.go
+++ b/controller/upgrade_test.go
@@ -185,6 +185,11 @@ func TestAllUpgradeFuncs(t *testing.T) {
 		require.Nil(t, err, "Upgrade failed")
 		err = compareDbToExpected(&objStore, VersionHash_UpgradeFuncNames[ii])
 		require.Nil(t, err, "Unexpected result from upgrade function(%s)", VersionHash_UpgradeFuncNames[ii])
+		// Run the upgrade again to make sure it's idempotent
+		err = RunSingleUpgrade(ctx, &objStore, apis, fn)
+		require.Nil(t, err, "Upgrade second run failed")
+		err = compareDbToExpected(&objStore, VersionHash_UpgradeFuncNames[ii])
+		require.Nil(t, err, "Unexpected result from upgrade function second run (idempotency check) (%s)", VersionHash_UpgradeFuncNames[ii])
 		// Stop it, so it's re-created again
 		objStore.Stop()
 	}

--- a/gencmd/debug.cmd.go
+++ b/gencmd/debug.cmd.go
@@ -4,9 +4,19 @@
 package gencmd
 
 import (
+	"context"
 	fmt "fmt"
+	_ "github.com/gogo/googleapis/google/api"
+	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
+	"github.com/mobiledgex/edge-cloud/cli"
+	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
+	_ "github.com/mobiledgex/edge-cloud/protogen"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/status"
+	"io"
 	math "math"
+	"strings"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -15,3 +25,511 @@ var _ = fmt.Errorf
 var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
+func DebugRequestHideTags(in *edgeproto.DebugRequest) {
+	if cli.HideTags == "" {
+		return
+	}
+	tags := make(map[string]struct{})
+	for _, tag := range strings.Split(cli.HideTags, ",") {
+		tags[tag] = struct{}{}
+	}
+	if _, found := tags["nocmp"]; found {
+		in.Node.Name = ""
+	}
+}
+
+func DebugReplyHideTags(in *edgeproto.DebugReply) {
+	if cli.HideTags == "" {
+		return
+	}
+	tags := make(map[string]struct{})
+	for _, tag := range strings.Split(cli.HideTags, ",") {
+		tags[tag] = struct{}{}
+	}
+	if _, found := tags["nocmp"]; found {
+		in.Node.Name = ""
+	}
+}
+
+func DebugDataHideTags(in *edgeproto.DebugData) {
+	if cli.HideTags == "" {
+		return
+	}
+	tags := make(map[string]struct{})
+	for _, tag := range strings.Split(cli.HideTags, ",") {
+		tags[tag] = struct{}{}
+	}
+	for i0 := 0; i0 < len(in.Requests); i0++ {
+		if _, found := tags["nocmp"]; found {
+			in.Requests[i0].Node.Name = ""
+		}
+	}
+}
+
+var DebugApiCmd edgeproto.DebugApiClient
+
+var EnableDebugLevelsCmd = &cli.Command{
+	Use:          "EnableDebugLevels",
+	RequiredArgs: strings.Join(EnableDebugLevelsRequiredArgs, " "),
+	OptionalArgs: strings.Join(EnableDebugLevelsOptionalArgs, " "),
+	AliasArgs:    strings.Join(DebugRequestAliasArgs, " "),
+	SpecialArgs:  &DebugRequestSpecialArgs,
+	Comments:     DebugRequestComments,
+	ReqData:      &edgeproto.DebugRequest{},
+	ReplyData:    &edgeproto.DebugReply{},
+	Run:          runEnableDebugLevels,
+}
+
+func runEnableDebugLevels(c *cli.Command, args []string) error {
+	if cli.SilenceUsage {
+		c.CobraCmd.SilenceUsage = true
+	}
+	obj := c.ReqData.(*edgeproto.DebugRequest)
+	_, err := c.ParseInput(args)
+	if err != nil {
+		return err
+	}
+	return EnableDebugLevels(c, obj)
+}
+
+func EnableDebugLevels(c *cli.Command, in *edgeproto.DebugRequest) error {
+	if DebugApiCmd == nil {
+		return fmt.Errorf("DebugApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := DebugApiCmd.EnableDebugLevels(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("EnableDebugLevels failed: %s", errstr)
+	}
+
+	objs := make([]*edgeproto.DebugReply, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("EnableDebugLevels recv failed: %s", errstr)
+		}
+		DebugReplyHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	c.WriteOutput(c.CobraCmd.OutOrStdout(), objs, cli.OutputFormat)
+	return nil
+}
+
+// this supports "Create" and "Delete" commands on ApplicationData
+func EnableDebugLevelss(c *cli.Command, data []edgeproto.DebugRequest, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("EnableDebugLevels %v\n", data[ii])
+		myerr := EnableDebugLevels(c, &data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
+}
+
+var DisableDebugLevelsCmd = &cli.Command{
+	Use:          "DisableDebugLevels",
+	RequiredArgs: strings.Join(DisableDebugLevelsRequiredArgs, " "),
+	OptionalArgs: strings.Join(DisableDebugLevelsOptionalArgs, " "),
+	AliasArgs:    strings.Join(DebugRequestAliasArgs, " "),
+	SpecialArgs:  &DebugRequestSpecialArgs,
+	Comments:     DebugRequestComments,
+	ReqData:      &edgeproto.DebugRequest{},
+	ReplyData:    &edgeproto.DebugReply{},
+	Run:          runDisableDebugLevels,
+}
+
+func runDisableDebugLevels(c *cli.Command, args []string) error {
+	if cli.SilenceUsage {
+		c.CobraCmd.SilenceUsage = true
+	}
+	obj := c.ReqData.(*edgeproto.DebugRequest)
+	_, err := c.ParseInput(args)
+	if err != nil {
+		return err
+	}
+	return DisableDebugLevels(c, obj)
+}
+
+func DisableDebugLevels(c *cli.Command, in *edgeproto.DebugRequest) error {
+	if DebugApiCmd == nil {
+		return fmt.Errorf("DebugApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := DebugApiCmd.DisableDebugLevels(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("DisableDebugLevels failed: %s", errstr)
+	}
+
+	objs := make([]*edgeproto.DebugReply, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("DisableDebugLevels recv failed: %s", errstr)
+		}
+		DebugReplyHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	c.WriteOutput(c.CobraCmd.OutOrStdout(), objs, cli.OutputFormat)
+	return nil
+}
+
+// this supports "Create" and "Delete" commands on ApplicationData
+func DisableDebugLevelss(c *cli.Command, data []edgeproto.DebugRequest, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("DisableDebugLevels %v\n", data[ii])
+		myerr := DisableDebugLevels(c, &data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
+}
+
+var ShowDebugLevelsCmd = &cli.Command{
+	Use:          "ShowDebugLevels",
+	RequiredArgs: strings.Join(ShowDebugLevelsRequiredArgs, " "),
+	OptionalArgs: strings.Join(ShowDebugLevelsOptionalArgs, " "),
+	AliasArgs:    strings.Join(DebugRequestAliasArgs, " "),
+	SpecialArgs:  &DebugRequestSpecialArgs,
+	Comments:     DebugRequestComments,
+	ReqData:      &edgeproto.DebugRequest{},
+	ReplyData:    &edgeproto.DebugReply{},
+	Run:          runShowDebugLevels,
+}
+
+func runShowDebugLevels(c *cli.Command, args []string) error {
+	if cli.SilenceUsage {
+		c.CobraCmd.SilenceUsage = true
+	}
+	obj := c.ReqData.(*edgeproto.DebugRequest)
+	_, err := c.ParseInput(args)
+	if err != nil {
+		return err
+	}
+	return ShowDebugLevels(c, obj)
+}
+
+func ShowDebugLevels(c *cli.Command, in *edgeproto.DebugRequest) error {
+	if DebugApiCmd == nil {
+		return fmt.Errorf("DebugApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := DebugApiCmd.ShowDebugLevels(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("ShowDebugLevels failed: %s", errstr)
+	}
+
+	objs := make([]*edgeproto.DebugReply, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("ShowDebugLevels recv failed: %s", errstr)
+		}
+		DebugReplyHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	c.WriteOutput(c.CobraCmd.OutOrStdout(), objs, cli.OutputFormat)
+	return nil
+}
+
+// this supports "Create" and "Delete" commands on ApplicationData
+func ShowDebugLevelss(c *cli.Command, data []edgeproto.DebugRequest, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("ShowDebugLevels %v\n", data[ii])
+		myerr := ShowDebugLevels(c, &data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
+}
+
+var RunDebugCmd = &cli.Command{
+	Use:          "RunDebug",
+	RequiredArgs: strings.Join(RunDebugRequiredArgs, " "),
+	OptionalArgs: strings.Join(RunDebugOptionalArgs, " "),
+	AliasArgs:    strings.Join(DebugRequestAliasArgs, " "),
+	SpecialArgs:  &DebugRequestSpecialArgs,
+	Comments:     DebugRequestComments,
+	ReqData:      &edgeproto.DebugRequest{},
+	ReplyData:    &edgeproto.DebugReply{},
+	Run:          runRunDebug,
+}
+
+func runRunDebug(c *cli.Command, args []string) error {
+	if cli.SilenceUsage {
+		c.CobraCmd.SilenceUsage = true
+	}
+	obj := c.ReqData.(*edgeproto.DebugRequest)
+	_, err := c.ParseInput(args)
+	if err != nil {
+		return err
+	}
+	return RunDebug(c, obj)
+}
+
+func RunDebug(c *cli.Command, in *edgeproto.DebugRequest) error {
+	if DebugApiCmd == nil {
+		return fmt.Errorf("DebugApi client not initialized")
+	}
+	ctx := context.Background()
+	stream, err := DebugApiCmd.RunDebug(ctx, in)
+	if err != nil {
+		errstr := err.Error()
+		st, ok := status.FromError(err)
+		if ok {
+			errstr = st.Message()
+		}
+		return fmt.Errorf("RunDebug failed: %s", errstr)
+	}
+
+	objs := make([]*edgeproto.DebugReply, 0)
+	for {
+		obj, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			errstr := err.Error()
+			st, ok := status.FromError(err)
+			if ok {
+				errstr = st.Message()
+			}
+			return fmt.Errorf("RunDebug recv failed: %s", errstr)
+		}
+		DebugReplyHideTags(obj)
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return nil
+	}
+	c.WriteOutput(c.CobraCmd.OutOrStdout(), objs, cli.OutputFormat)
+	return nil
+}
+
+// this supports "Create" and "Delete" commands on ApplicationData
+func RunDebugs(c *cli.Command, data []edgeproto.DebugRequest, err *error) {
+	if *err != nil {
+		return
+	}
+	for ii, _ := range data {
+		fmt.Printf("RunDebug %v\n", data[ii])
+		myerr := RunDebug(c, &data[ii])
+		if myerr != nil {
+			*err = myerr
+			break
+		}
+	}
+}
+
+var DebugApiCmds = []*cobra.Command{
+	EnableDebugLevelsCmd.GenCmd(),
+	DisableDebugLevelsCmd.GenCmd(),
+	ShowDebugLevelsCmd.GenCmd(),
+	RunDebugCmd.GenCmd(),
+}
+
+var DebugRequestRequiredArgs = []string{}
+var DebugRequestOptionalArgs = []string{
+	"name",
+	"type",
+	"organization",
+	"cloudlet",
+	"node.cloudletkey.federatedorganization",
+	"region",
+	"levels",
+	"cmd",
+	"pretty",
+	"id",
+	"args",
+	"timeout",
+}
+var DebugRequestAliasArgs = []string{
+	"name=node.name",
+	"type=node.type",
+	"organization=node.cloudletkey.organization",
+	"cloudlet=node.cloudletkey.name",
+	"region=node.region",
+	"cmd=cmd",
+}
+var DebugRequestComments = map[string]string{
+	"name":                                   "Name or hostname of node",
+	"type":                                   "Node type",
+	"organization":                           "Organization of the cloudlet site",
+	"cloudlet":                               "Name of the cloudlet",
+	"node.cloudletkey.federatedorganization": "Federated operator organization who shared this cloudlet",
+	"region":                                 "Region the node is in",
+	"levels":                                 "Comma separated list of debug level names: etcd,api,notify,dmereq,locapi,infra,metrics,upgrade,info,sampled",
+	"cmd":                                    "Debug command (use help to see available commands)",
+	"pretty":                                 "if possible, make output pretty",
+	"id":                                     "Id used internally",
+	"args":                                   "Additional arguments for cmd",
+	"timeout":                                "custom timeout (duration, defaults to 10s)",
+}
+var DebugRequestSpecialArgs = map[string]string{}
+var DebugReplyRequiredArgs = []string{}
+var DebugReplyOptionalArgs = []string{
+	"node.name",
+	"node.type",
+	"node.cloudletkey.organization",
+	"node.cloudletkey.name",
+	"node.cloudletkey.federatedorganization",
+	"node.region",
+	"output",
+	"id",
+}
+var DebugReplyAliasArgs = []string{}
+var DebugReplyComments = map[string]string{
+	"node.name":                              "Name or hostname of node",
+	"node.type":                              "Node type",
+	"node.cloudletkey.organization":          "Organization of the cloudlet site",
+	"node.cloudletkey.name":                  "Name of the cloudlet",
+	"node.cloudletkey.federatedorganization": "Federated operator organization who shared this cloudlet",
+	"node.region":                            "Region the node is in",
+	"output":                                 "Debug output, if any",
+	"id":                                     "Id used internally",
+}
+var DebugReplySpecialArgs = map[string]string{}
+var DebugDataRequiredArgs = []string{}
+var DebugDataOptionalArgs = []string{
+	"requests:#.node.name",
+	"requests:#.node.type",
+	"requests:#.node.cloudletkey.organization",
+	"requests:#.node.cloudletkey.name",
+	"requests:#.node.cloudletkey.federatedorganization",
+	"requests:#.node.region",
+	"requests:#.levels",
+	"requests:#.cmd",
+	"requests:#.pretty",
+	"requests:#.id",
+	"requests:#.args",
+	"requests:#.timeout",
+}
+var DebugDataAliasArgs = []string{}
+var DebugDataComments = map[string]string{
+	"requests:#.node.name":                              "Name or hostname of node",
+	"requests:#.node.type":                              "Node type",
+	"requests:#.node.cloudletkey.organization":          "Organization of the cloudlet site",
+	"requests:#.node.cloudletkey.name":                  "Name of the cloudlet",
+	"requests:#.node.cloudletkey.federatedorganization": "Federated operator organization who shared this cloudlet",
+	"requests:#.node.region":                            "Region the node is in",
+	"requests:#.levels":                                 "Comma separated list of debug level names: etcd,api,notify,dmereq,locapi,infra,metrics,upgrade,info,sampled",
+	"requests:#.cmd":                                    "Debug command (use help to see available commands)",
+	"requests:#.pretty":                                 "if possible, make output pretty",
+	"requests:#.id":                                     "Id used internally",
+	"requests:#.args":                                   "Additional arguments for cmd",
+	"requests:#.timeout":                                "custom timeout (duration, defaults to 10s)",
+}
+var DebugDataSpecialArgs = map[string]string{}
+var EnableDebugLevelsRequiredArgs = []string{
+	"levels",
+}
+var EnableDebugLevelsOptionalArgs = []string{
+	"name",
+	"type",
+	"organization",
+	"cloudlet",
+	"node.cloudletkey.federatedorganization",
+	"region",
+	"pretty",
+	"args",
+	"timeout",
+}
+var DisableDebugLevelsRequiredArgs = []string{
+	"levels",
+}
+var DisableDebugLevelsOptionalArgs = []string{
+	"name",
+	"type",
+	"organization",
+	"cloudlet",
+	"node.cloudletkey.federatedorganization",
+	"region",
+	"pretty",
+	"args",
+	"timeout",
+}
+var ShowDebugLevelsRequiredArgs = []string{}
+var ShowDebugLevelsOptionalArgs = []string{
+	"name",
+	"type",
+	"organization",
+	"cloudlet",
+	"node.cloudletkey.federatedorganization",
+	"region",
+	"pretty",
+	"args",
+	"timeout",
+}
+var RunDebugRequiredArgs = []string{
+	"cmd",
+}
+var RunDebugOptionalArgs = []string{
+	"name",
+	"type",
+	"organization",
+	"cloudlet",
+	"node.cloudletkey.federatedorganization",
+	"region",
+	"pretty",
+	"args",
+	"timeout",
+}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5918 Controller crash when trying to delete an appinst

### Description

As part of the changes for 5918, we need to ensure that upgrade functions are idempotent, so that they can be run again after a downgrade. This adds an extra run of each upgrade function to the upgrade unit test to ensure that they are idempotent. It also makes a small fix for the TrustPolicyException upgrade function to make it idempotent.