### PR TITLE
EDGECLOUD-5318 add tty and stdin options to mcctl exec commands

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -23,6 +23,8 @@ var Debug bool
 var OutputStream bool
 var SilenceUsage bool
 var OutputFormat = OutputFormatYaml
+var Interactive bool
+var Tty bool
 
 func AddInputFlags(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&Data, "data", "", "json formatted input data, alternative to name=val args list")
@@ -39,6 +41,13 @@ func AddDebugFlag(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&Debug, "debug", false, "debug")
 	flagSet.BoolVar(&SilenceUsage, "silence-usage", false, "silence-usage")
 }
+
+func AddTtyFlags(flagSet *pflag.FlagSet) {
+	flagSet.BoolVarP(&Interactive, "interactive", "i", false, "send stdin")
+	flagSet.BoolVarP(&Tty, "tty", "t", false, "treat stdin and stout as a tty")
+}
+
+var NoFlags func(flagSet *pflag.FlagSet) = nil
 
 // HideTags is a comma separated list of tag names that are matched
 // against the protocmd.hidetag field option. Fields that match will
@@ -70,6 +79,7 @@ type Command struct {
 	Run                  func(c *Command, args []string) error
 	UsageIsHelp          bool
 	Annotations          map[string]string
+	AddFlagsFunc         func(*pflag.FlagSet)
 }
 
 func (c *Command) GenCmd() *cobra.Command {
@@ -85,6 +95,9 @@ func (c *Command) GenCmd() *cobra.Command {
 
 	if c.Run != nil {
 		cmd.RunE = c.runE
+	}
+	if c.AddFlagsFunc != nil {
+		c.AddFlagsFunc(cmd.Flags())
 	}
 	return cmd
 }

--- a/edgectl/exec.go
+++ b/edgectl/exec.go
@@ -51,5 +51,9 @@ func runExecRequest(c *cli.Command, args []string, apiFunc execFunc) error {
 		}
 		return reply, nil
 	}
-	return edgecli.RunEdgeTurn(req, exchangeFunc)
+	options := &edgecli.ExecOptions{
+		Stdin: cli.Interactive,
+		Tty:   cli.Tty,
+	}
+	return edgecli.RunEdgeTurn(req, options, exchangeFunc)
 }

--- a/edgectl/main.go
+++ b/edgectl/main.go
@@ -159,9 +159,11 @@ func main() {
 	controllerCmd.AddCommand(createCmd.GenCmd())
 	controllerCmd.AddCommand(deleteCmd.GenCmd())
 	gencmd.RunCommandCmd.Run = runRunCommand
+	gencmd.RunCommandCmd.AddFlagsFunc = cli.AddTtyFlags
 	gencmd.ShowLogsCmd.Run = runShowLogs
 	gencmd.RunConsoleCmd.Run = runRunConsole
 	gencmd.AccessCloudletCmd.Run = runAccessCloudlet
+	gencmd.AccessCloudletCmd.AddFlagsFunc = cli.AddTtyFlags
 	controllerCmd.AddCommand(gencmd.RunCommandCmd.GenCmd(), gencmd.RunConsoleCmd.GenCmd(), gencmd.ShowLogsCmd.GenCmd(), gencmd.AccessCloudletCmd.GenCmd())
 
 	dmeCmd.AddCommand(gencmd.MatchEngineApiCmds...)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5318 mcctl error when redirecting runcommand/showlogs output

### Description

This adds "interactive" and "tty" options for mcctl commands that open a shell in a remote container/VM. Previously, the code always assumed you wanted a local tty. However, doing so makes it impossible to redirect output from non-interactive commands.

So now, the cli commands for RunCommand and AccessCloudlet have the same options as "docker exec" and "kubectl exec" to indicate whether or not to reidrect stdin and create a tty so that text from the remote shell gets formatted correctly.

So from now, running an interactive shell must include the "-it" option. Running a non-interactive command like "ls -l" can now be redirected to a file if those options are left off.