### PR TITLE
EDGECLOUD-6150 fail CreateCloudlet if SingleKubernetesClusterOwner set on non-single cluster cloudlet

### DIFF
--- a/controller/cloudlet_api.go
+++ b/controller/cloudlet_api.go
@@ -625,6 +625,10 @@ func (s *CloudletApi) createCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 			if err != nil {
 				return err
 			}
+		} else {
+			if in.SingleKubernetesClusterOwner != "" {
+				return fmt.Errorf("Single kubernetes cluster owner can only be set on a single cluster platform")
+			}
 		}
 
 		in.CreatedAt = dme.TimeToTimestamp(time.Now())


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-6150 "cloudlet create" should give error when using singlekubernetesclusterowner option for non k8s-bare-metal cloudlets

### Description

CreateCloudlet should fail if SingleKubernetesClusterOwner was specified and the target platform is not a SingleKubernetesCluster platform.