### PR TITLE
[Anthos] Need to clean up config yaml files after deleting cluster instance on Anthos

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -621,11 +621,23 @@ func DeleteNamespace(ctx context.Context, client ssh.Client, names *KubeNames) e
 			return fmt.Errorf("Error in deleting namespace: %s - %v", out, err)
 		}
 	}
+	log.SpanLog(ctx, log.DebugLevelInfra, "deleting namespaced kconf", "name", names.KconfName)
+
 	// delete namespaced kconf
 	err = pc.DeleteFile(client, names.KconfName, pc.NoSudo)
 	if err != nil {
 		// just log the error
 		log.SpanLog(ctx, log.DebugLevelInfra, "failed to clean up namespaced kconf", "err", err)
+	}
+
+	configYamlFile := names.MultitenantNamespace + ".yaml"
+
+	log.SpanLog(ctx, log.DebugLevelInfra, "deleting namespaced configYamlFile", "name", configYamlFile)
+
+	err = pc.DeleteFile(client, configYamlFile, pc.NoSudo)
+	if err != nil {
+		// just log the error
+		log.SpanLog(ctx, log.DebugLevelInfra, "failed to clean up namespace configYamlFile", "err", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6080 [Anthos] Need to clean up config yaml files after deleting cluster instance on Anthos

### Description

Added code to cleanup config yaml files in DeleteNamespace() 

### Unit test



devdatta@Dajgaonkar-MAC:~/go/src/github.com/mobiledgex/edge-cloud-infra (master)$ ec controller CreateApp apporg=mex appname=sdkdemo appvers=k8s imagetype=docker imagepath=“docker.mobiledgex.net/mobiledgex/images/mobiledgexsdkdemo” deployment=kubernetes defaultflavor=x1.small allowserverless=true


[…]

devdatta@Dajgaonkar-MAC:~/go/src/github.com/mobiledgex/edge-cloud-infra/mgmt/vault (master)$ ./vssh 145.40.77.115

Last login: Tue Feb 15 15:41:24 2022 from 223.229.223.149
ubuntu@stage-anthos-1:~ ls -lrt
total 76
drwxrwxr-x 4 ubuntu ubuntu 4096 Feb  9 19:52 baremetal
-rw-rw-r-- 1 ubuntu ubuntu 5582 Feb  9 20:02 stage-anthos-cloudlet-kubeconfig
-rw-r--r-- 1 root   root   5582 Feb  9 22:10 defaultclust.packet.kubeconfig
-rw-rw-r-- 1 ubuntu ubuntu  179 Feb 10 13:08 mobiledgex-computervision-22-autoclustercomputervision.yaml
-rw-rw-r-- 1 ubuntu ubuntu  147 Feb 11 17:37 edge-dev-nginx-latest-autoclusternginx.yaml
-rw-rw-r-- 1 ubuntu ubuntu  143 Feb 13 03:21 edge-dev-smsc-latest-autoclustersmsc.yaml
-rw-rw-r-- 1 ubuntu ubuntu  139 Feb 13 04:02 edge-dev-upf-latest-autoclusterupf.yaml
-rw-rw-r-- 1 ubuntu ubuntu  151 Feb 13 04:05 edge-dev-chrome-latest-autoclusterchrome.yaml
-rw-rw-r-- 1 ubuntu ubuntu  155 Feb 13 04:09 edge-dev-grafana-latest-autoclustergrafana.yaml
-rw-r--r-- 1 ubuntu ubuntu 5640 Feb 13 04:09 defaultclust.packet.edge-dev-grafana-latest-autoclustergrafana.kubeconfig
drwxrwxr-x 2 ubuntu ubuntu 4096 Feb 13 04:09 defaultclustmobiledgex.edge-dev-grafana-latest-autoclustergrafana
drwxrwxr-x 4 ubuntu ubuntu 4096 Feb 13 04:09 envoy
-rw-rw-r-- 1 ubuntu ubuntu  125 Feb 16 03:57 mex-sdkdemo-k8s-testcluster.yaml
-rw-r--r-- 1 ubuntu ubuntu 5625 Feb 16 03:57 defaultclust.packet.mex-sdkdemo-k8s-testcluster.kubeconfig
drwxrwxr-x 2 ubuntu ubuntu 4096 Feb 16 03:57 defaultclustmobiledgex.mex-sdkdemo-k8s-testcluster
ubuntu@stage-anthos-1:~ date
Wed Feb 16 03:58:07 UTC 2022
ubuntu@stage-anthos-1:~ ls mex-sdkdemo-k8s-testcluster.yaml
ls: cannot access 'mex-sdkdemo-k8s-testcluster.yaml': No such file or directory
ubuntu@stage-anthos-1:~


2022-02-16T09:28:33.101+0530	INFO	6d2e9e27cbe2d056	infracommon/dns.go:121	URI not specified, no DNS entry to delete
2022-02-16T09:28:33.101+0530	INFO	6d2e9e27cbe2d056	k8smgmt/appinst.go:391	deleting app	{"name": "sdkdemo", "cmd": "KUBECONFIG=defaultclust.packet.mex-sdkdemo-k8s-testcluster.kubeconfig kubectl delete -f defaultclustmobiledgex.mex-sdkdemo-k8s-testcluster/sdkdemomexk8s.yaml"}
2022-02-16T09:28:36.598+0530	INFO	6d2e9e27cbe2d056	k8smgmt/appinst.go:400	deleted deployment	{"name": "sdkdemo"}
2022-02-16T09:28:36.598+0530	INFO	6d2e9e27cbe2d056	k8smgmt/appinst.go:403	remove app manifest	{"name": "sdkdemo", "file": "defaultclustmobiledgex.mex-sdkdemo-k8s-testcluster/sdkdemomexk8s.yaml"}
2022-02-16T09:28:39.818+0530	INFO	6d2e9e27cbe2d056	k8smgmt/appinst.go:133	waiting for appinst pods	{"appName": "sdkdemo", "maxWait": "15m0s", "waitFor": "WaitDeleted"}
2022-02-16T09:28:39.818+0530	INFO	6d2e9e27cbe2d056	k8smgmt/appinst.go:49	check pods status	{"namespace": "mex-sdkdemo-k8s-testcluster", "selector": "mex-app=sdkdemok8s-deployment”}
2022-02-16T09:28:43.218+0530	INFO	6d2e9e27cbe2d056	k8smgmt/appinst.go:117	all pods gone	{"selector": "mex-app=sdkdemok8s-deployment"}
2022-02-16T09:28:43.218+0530	INFO	6d2e9e27cbe2d056	k8smgmt/appinst.go:616	deleting namespace	{"name": "mex-sdkdemo-k8s-testcluster"}
2022-02-16T09:28:51.849+0530	INFO	6d2e9e27cbe2d056	k8smgmt/appinst.go:624	deleting namespaced kconf	{"name": "defaultclust.packet.mex-sdkdemo-k8s-testcluster.kubeconfig"}
2022-02-16T09:28:51.849+0530	INFO	pc/pc.go:154	delete file
2022-02-16T09:28:55.388+0530	INFO	pc/pc.go:163	deleted file	{"file": "defaultclust.packet.mex-sdkdemo-k8s-testcluster.kubeconfig"}
2022-02-16T09:28:55.388+0530	INFO	6d2e9e27cbe2d056	k8smgmt/appinst.go:635	deleting namespaced configYamlFile	{"name": "mex-sdkdemo-k8s-testcluster.yaml"}
2022-02-16T09:28:55.389+0530	INFO	pc/pc.go:154	delete file
2022-02-16T09:28:58.550+0530	INFO	pc/pc.go:163	deleted file	{"file": "mex-sdkdemo-k8s-testcluster.yaml"}
2022-02-16T09:28:58.551+0530	INFO	6d2e9e27cbe2d056	pc/pc.go:141	deleting directory	{"dir": "defaultclustmobiledgex.mex-sdkdemo-k8s-testcluster"}
2022-02-16T09:29:01.838+0530	INFO	6d2e9e27cbe2d056	crmutil/controller-data.go:274	update cloudlet resources snapshot	{"key": "organization:\"packet\" name:\"stage-anthos\" "}

