### PR TITLE
Fix rootLB TLS certs refresh thread as it can end up using expired certs

### DIFF
--- a/cloud-resource-manager/proxy/certs/certifications.go
+++ b/cloud-resource-manager/proxy/certs/certifications.go
@@ -137,49 +137,50 @@ func getRootLbCertsHelper(ctx context.Context, key *edgeproto.CloudletKey, commo
 	} else {
 		err = getSelfSignedCerts(ctx, &tls, commonName)
 	}
-	if lastCertsUsed != nil {
-		if *lastCertsUsed == tls {
-			// certs did not change, perform no action
-			log.SpanLog(ctx, log.DebugLevelInfo, "Ignore rootlb certs update as certs have not changed since last update")
-			return lastCertsUsed
-		}
+	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelInfo, "Unable to get updated certs, will try again", "err", err)
+		nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), fmt.Errorf("Unable to get certs: %v", err))
+		// on error, return lastCertsUsed as it might just be a temporary glitch
+		// and certs might not have changed
+		return lastCertsUsed
 	}
+	if lastCertsUsed != nil && *lastCertsUsed == tls {
+		// certs did not change, perform no action
+		log.SpanLog(ctx, log.DebugLevelInfo, "Ignore rootlb certs update as certs have not changed since last update")
+		return lastCertsUsed
+	}
+	// apply new cert
+	client, err := platform.GetNodePlatformClient(ctx, &edgeproto.CloudletMgmtNode{Type: cloudcommon.CloudletNodeSharedRootLB})
 	if err == nil {
-		client, err := platform.GetNodePlatformClient(ctx, &edgeproto.CloudletMgmtNode{Type: cloudcommon.CloudletNodeSharedRootLB})
-		if err == nil {
-			err = writeCertToRootLb(ctx, &tls, client, certsDir, certFile, keyFile)
-			if err != nil {
-				err = fmt.Errorf("write cert to rootLB failed: %v", err)
-				nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), err, "rootlb", commonName)
-			}
-		} else {
-			err = fmt.Errorf("Failed to get shared RootLB ssh client: %v", err)
-			nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), err, "rootlb", commonName)
-		}
-		DedicatedMux.Lock()
-		DedicatedTls = tls
-		DedicatedMux.Unlock()
-		// dedicated LBs
-		dedicatedClients, err := platform.GetRootLBClients(ctx)
-		if err == nil {
-			for lbName, client := range dedicatedClients {
-				if client == nil {
-					nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), fmt.Errorf("missing client"), "rootlb", lbName)
-					continue
-				}
-				err = writeCertToRootLb(ctx, &tls, client, certsDir, certFile, keyFile)
-				if err != nil {
-					err = fmt.Errorf("write cert to rootLB failed: %v", err)
-					nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), err, "rootlb", lbName)
-				}
-			}
-		} else {
-			err = fmt.Errorf("Failed to get dedicated RootLB ssh clients: %v", err)
+		err = writeCertToRootLb(ctx, &tls, client, certsDir, certFile, keyFile)
+		if err != nil {
+			err = fmt.Errorf("write cert to rootLB failed: %v", err)
 			nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), err, "rootlb", commonName)
 		}
 	} else {
-		log.SpanLog(ctx, log.DebugLevelInfo, "Unable to get certs", "err", err)
-		nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), fmt.Errorf("Unable to get certs: %v", err))
+		err = fmt.Errorf("Failed to get shared RootLB ssh client: %v", err)
+		nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), err, "rootlb", commonName)
+	}
+	DedicatedMux.Lock()
+	DedicatedTls = tls
+	DedicatedMux.Unlock()
+	// dedicated LBs
+	dedicatedClients, err := platform.GetRootLBClients(ctx)
+	if err == nil {
+		for lbName, client := range dedicatedClients {
+			if client == nil {
+				nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), fmt.Errorf("missing client"), "rootlb", lbName)
+				continue
+			}
+			err = writeCertToRootLb(ctx, &tls, client, certsDir, certFile, keyFile)
+			if err != nil {
+				err = fmt.Errorf("write cert to rootLB failed: %v", err)
+				nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), err, "rootlb", lbName)
+			}
+		}
+	} else {
+		err = fmt.Errorf("Failed to get dedicated RootLB ssh clients: %v", err)
+		nodeMgr.Event(ctx, "TLS certs error", key.Organization, key.GetTags(), err, "rootlb", commonName)
 	}
 	return &tls
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6198: RootLB TLS certs refresh thread can end up using expired certs

### Description
* Fix `getRootLBCertsTrigger` chan initialization
* Cache last certs used to avoid rootLB cert refresh in case the certs didn't change
* Vault refreshes the certs 30 days before expiry. And crmserver reloads rootLB certs every 30 days. If time aligns, crmserver might end up reloading the certs on the day of expiry. Changed the code to refresh certs every day (This is what certbot itself does). Thanks @venkytv for the suggestion.  