### PR TITLE
Update open source software handling to include software mirroring

### DIFF
--- a/util/parsedeps/parsedeps.go
+++ b/util/parsedeps/parsedeps.go
@@ -198,7 +198,7 @@ func getSourceMirror(pkgDir string) (string, error) {
 	// make sure mirror exists
 	resp, err := http.Get(repo)
 	if err != nil {
-		err = fmt.Errorf("Failed to retreive mirrored code at %s: %s", repo, err)
+		err = fmt.Errorf("Failed to retrieve mirrored code at %s: %s", repo, err)
 	}
 	if err == nil && resp.StatusCode == http.StatusNotFound {
 		// create a tar file to upload
@@ -206,7 +206,7 @@ func getSourceMirror(pkgDir string) (string, error) {
 		tarCmd.Dir = os.Getenv("HOME") + "/go/pkg/mod"
 		out, cmdErr := tarCmd.CombinedOutput()
 		if cmdErr != nil {
-			log.Fatal(fmt.Sprintf(`tar command "(cd %s; tar -cvf %s %s)" failed: %s, %s`, tarCmd.Dir, tarFile, localDir, string(out), cmdErr))
+			log.Fatal(fmt.Sprintf(`tar command "(cd %s; %s)" failed: %s, %s`, tarCmd.Dir, tarCmd.String(), string(out), cmdErr))
 		}
 		err = fmt.Errorf("Please upload %s/%s to online storage at %s for mirroring", tarCmd.Dir, tarFile, repo)
 	}


### PR DESCRIPTION
This updates the parsedeps program that generates the THIRD-PARTY-NOTICES attribution file to include links to mirrored open source libraries. Under the requirements of the Mozilla license, we must provide a readily available copy of the libraries to be able to use them. We now have a public google cloud storage bucket where we are hosting tar files of the library's source code.

Parsedeps checks that the tar file is present in GCS. If not, it will create a tar file, and generate an error message asking you to upload it.