### PR TITLE
EDGECLOUD-6076: Use redis for storing alerts 

### DIFF
--- a/controller/alert_api.go
+++ b/controller/alert_api.go
@@ -145,7 +145,7 @@ func (s *AlertApi) Update(ctx context.Context, in *edgeproto.Alert, rev int64) {
 	// This is because if the keep-alive is lost and we resync, then
 	// these additional actions should be performed again as part of StoreUpdate.
 
-	// Wait for alerts to synced with controller cache
+	// Wait for alerts to be synced with controller cache
 	recvdCache := make(chan bool, 1)
 	watchCancel := s.cache.WatchKey(in.GetKey(), func(ctx context.Context) {
 		recvdCache <- true
@@ -221,7 +221,7 @@ func (s *AlertApi) Delete(ctx context.Context, in *edgeproto.Alert, rev int64) {
 		})
 	}
 
-	// Wait for alerts to synced with controller cache
+	// Wait for alerts to be synced with controller cache
 	syncedCache := make(chan bool, 1)
 	watchCancel := s.cache.WatchKey(in.GetKey(), func(ctx context.Context) {
 		if !s.cache.Get(in.GetKey(), &edgeproto.Alert{}) {
@@ -327,7 +327,6 @@ func (s *AlertApi) CleanupCloudletAlerts(ctx context.Context, key *edgeproto.Clo
 	}
 	s.cache.Mux.Unlock()
 	for _, val := range matches {
-		// s.sourceCache.Delete(ctx, val, 0)
 		s.Delete(ctx, val, 0)
 	}
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6076: Use redis for storing alerts 

### Description
* This is a rework of PR I sent earlier: https://github.com/mobiledgex/edge-cloud/pull/1625. It addresses the concerns raised as part of that PR
* Alerts are now stored in redis with TTL set. TTL is refreshed by the controller as part of the `refreshAlertKeepAliveThread` (this is similar to maintaining leaseID in etcd). This is required to handle stale alerts
* As part of `alertApi.Update`, Alerts are stored in sourceCache, which then triggers storing the alert in redis
* Redis keyspace notification is used to sync alert data from redis with controller cache (look at `redis_sync.go/syncWithNotifyCache`). And hence as part of `alertApi.Update` we wait for data to be synced from redis with controller cache. Note: If pubsub connection to redis fails, it automatically handles reconnecting to the server and hence manually resetting the pubsub connection is not required)
* Redis Tx (transactional function) is used to call bulk redis commands atomically (just like STM)
* In case `refreshAlertKeepAliveThread`  fails for some reason, then `syncAllAlerts` is used to perform a full refresh of alerts from source cache
* Controller created alerts were only stored in etcd and not in source cache, which doesn’t make sense. Updated the code to use `alertApi.Update` to store all alerts, this way alerts from say `handleResourceUsageAlerts` is stored in src cache. Updated tests in main_test.go  to reflect this