### PR TITLE
EDGECLOUD-6226 fix runcommand exploit allowing access to parent VM

### DIFF
--- a/cloud-resource-manager/dockermgmt/dockerapp.go
+++ b/cloud-resource-manager/dockermgmt/dockerapp.go
@@ -492,7 +492,11 @@ func GetContainerCommand(clusterInst *edgeproto.ClusterInst, app *edgeproto.App,
 		}
 	}
 	if req.Cmd != nil {
-		cmdStr := fmt.Sprintf("docker exec -it %s %s", req.ContainerId, util.QuoteArgs(req.Cmd.Command))
+		userCmd, err := util.QuoteArgs(req.Cmd.Command)
+		if err != nil {
+			return "", fmt.Errorf("bad command: %s", err)
+		}
+		cmdStr := fmt.Sprintf("docker exec -it %s %s", req.ContainerId, userCmd)
 		return cmdStr, nil
 	}
 	if req.Log != nil {

--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -549,8 +549,12 @@ func GetContainerCommand(ctx context.Context, clusterInst *edgeproto.ClusterInst
 		if containerName != "" {
 			containerCmd = fmt.Sprintf("-c %s ", containerName)
 		}
+		userCmd, err := util.QuoteArgs(req.Cmd.Command)
+		if err != nil {
+			return "", fmt.Errorf("bad command: %s", err)
+		}
 		cmdStr := fmt.Sprintf("%s kubectl exec -n %s -it %s%s -- %s",
-			names.KconfEnv, namespace, containerCmd, podName, util.QuoteArgs(req.Cmd.Command))
+			names.KconfEnv, namespace, containerCmd, podName, userCmd)
 		return cmdStr, nil
 	}
 	if req.Log != nil {

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25 // indirect
 	github.com/jefferai/jsonx v1.0.0 // indirect
 	github.com/jonboulle/clockwork v0.1.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/keybase/go-crypto v0.0.0-20190403132359-d65b6b94177f // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -676,6 +676,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keybase/go-crypto v0.0.0-20190403132359-d65b6b94177f/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/keybase/go-ps v0.0.0-20161005175911-668c8856d999/go.mod h1:hY+WOq6m2FpbvyrI93sMaypsttvaIL5nhVR92dTMUcQ=

--- a/util/strings.go
+++ b/util/strings.go
@@ -1,9 +1,10 @@
 package util
 
 import (
-	"encoding/csv"
 	"strconv"
 	"strings"
+
+	"github.com/kballard/go-shellquote"
 )
 
 func isASCIILower(c byte) bool {
@@ -110,14 +111,14 @@ func UnCamelCase(name string) string {
 	return strings.Join(parts, "_")
 }
 
-func QuoteArgs(cmd string) string {
+func QuoteArgs(cmd string) (string, error) {
 	cmd = strings.TrimSpace(cmd)
-	r := csv.NewReader(strings.NewReader(cmd))
-	r.Comma = ' '
-	r.TrimLeadingSpace = true
-	args, _ := r.Read()
+	args, err := shellquote.Split(cmd)
+	if err != nil {
+		return "", err
+	}
 	for i := range args {
 		args[i] = strconv.Quote(args[i])
 	}
-	return strings.Join(args, " ")
+	return strings.Join(args, " "), nil
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6226 Runcommand allows running commands in parent VM

### Description

The command string passed to "docker exec" or "kubectl exec" via runcommand was directly appended. This allowed a command like "ls; ls" to run the first "ls" as part of the docker exec, but the second in the parent VM. The full command issued look like `docker exec -it container ls; ls`, which is run in the parent VM, so it's easy to see how to execute arbitrary commands in the parent VM.

A typical fix of programmatically issuing "docker exec" via a library API (i.e. exec.Command()) instead of via a shell can't be done in this case, because we are tunneling this command as a string through an ssh session.

The other typical fix of escaping and wrapping the whole command with quotes also doesn't work, because kubectl exec and docker exec treat the first argument as the binary to run. So for example, if you run `docker exec -it container "ls -l"`, it's going to try to run the binary "ls -l", not the command "ls" with argument "-l". Of course there is no binary named "ls -l", so it's going to fail.

Another potential fix is wrap the command with `bash -c "user-input"`, so the whole thing ends up as `docker exec -it container bash -c "user-input"`. This works to ensure all user input is executed in the container, but the problem there is containers don't necessarily have bash or sh shells in them to do this. If they don't, then the user will not be able to run any commands at all.

So what I've done here is to split the user-input command by whitespace (honoring quotes), and then quote every arg, and pass that to docker exec. What this ends up doing is having no effect on commands that do not use special shell characters (like semicolon or pipe or redirects or &), but commands with special characters end up treating those special characters like string arguments, rather than having the shell that runs the docker command interpret them. For example:

```
cmd="ls -ltrh" -->
   docker exec -it cont "ls" "-ltrh"  -> executes as expected
cmd="ls; ls" -->
   docker exec -it cont "ls;" "ls" -> fails, no such binary "ls;"
cmd="ls  ;ls" -->
   docker exec -it cont "ls" ";ls" -> fails, ls reports that file ";ls" is not found
cmd=`echo "newpass" > /var/etc/passwd` -->
   docker exec -it cont "echo" "newpass" ">" "/var/etc/password --> succeeds, just prints to stdout the string "newpass > /var/etc/password"
cmd=`bash -c "ls -ltrh"` -->
   docker exec -it cont "bash" "-c" "ls -ltrh" --> succeeds, executes ls -ltrh as expected (assuming container has the bash binary)
```

Using the above test cases, I tested this locally for kubectl exec using a KIND cluster, via `make kind-test-start`. I also tested docker exec manually on a random container.