### PR TITLE
Enable origin check for websocket connections to EdgeTURN

### DIFF
--- a/edgeturn/server.go
+++ b/edgeturn/server.go
@@ -419,9 +419,6 @@ func setupProxyServer(started chan bool) error {
 	})
 
 	upgrader := websocket.Upgrader{}
-	// Disable origin check restriction.
-	// Should be safe as we do token validation
-	upgrader.CheckOrigin = func(r *http.Request) bool { return true }
 	http.HandleFunc("/edgeshell", func(w http.ResponseWriter, r *http.Request) {
 		queryArgs := r.URL.Query()
 		tokenVals, ok := queryArgs["edgetoken"]


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6233: Websocket inspect origin if present

### Description
* We initially disabled the same-origin check for websocket connection to `/edgeshell` (EdgeTURN), because we didn't think it was necessary as we performed token validation. But it is recommended as part of a security audit to enable this check.
* This won't affect the connection to edgeshell for the following cases:
   1. Edgectl/MCCTL: Origin header is not set when the connection is initiated from these binaries and hence same-origin check is ignored internally
   2. Web-Console: Browser will set origin header, but this will be same as MC hostname because console & MC are residing on the same server and hence same-origin check will succeed