### PR TITLE
change nodetype to enum

### DIFF
--- a/cloud-resource-manager/platform/fake/fake.go
+++ b/cloud-resource-manager/platform/fake/fake.go
@@ -231,14 +231,14 @@ func (s *Platform) UpdateClusterInst(ctx context.Context, clusterInst *edgeproto
 	}
 	newcVMs := []edgeproto.VmInfo{}
 	for _, vmInfo := range cVMs {
-		if vmInfo.Type == cloudcommon.NodeTypeClusterK8sNode {
+		if vmInfo.Type == cloudcommon.NodeTypeK8sClusterNode.String() {
 			if _, ok := fakeNodes[vmInfo.Name]; ok {
 				delete(fakeNodes, vmInfo.Name)
 				newcVMs = append(newcVMs, vmInfo)
 			} else {
 				UpdateCommonResourcesUsed(clusterInst.NodeFlavor, ResourceRemove)
 			}
-		} else if vmInfo.Type == cloudcommon.NodeTypeClusterMaster {
+		} else if vmInfo.Type == cloudcommon.NodeTypeK8sClusterMaster.String() {
 			if _, ok := fakeMasters[vmInfo.Name]; ok {
 				delete(fakeMasters, vmInfo.Name)
 				newcVMs = append(newcVMs, vmInfo)
@@ -254,7 +254,7 @@ func (s *Platform) UpdateClusterInst(ctx context.Context, clusterInst *edgeproto
 	for vmName, _ := range fakeNodes {
 		FakeClusterVMs[clusterInst.Key] = append(FakeClusterVMs[clusterInst.Key], edgeproto.VmInfo{
 			Name:        vmName,
-			Type:        cloudcommon.NodeTypeClusterK8sNode,
+			Type:        cloudcommon.NodeTypeK8sClusterNode.String(),
 			InfraFlavor: clusterInst.NodeFlavor,
 			Status:      "ACTIVE",
 		})
@@ -263,7 +263,7 @@ func (s *Platform) UpdateClusterInst(ctx context.Context, clusterInst *edgeproto
 	for vmName, _ := range fakeMasters {
 		FakeClusterVMs[clusterInst.Key] = append(FakeClusterVMs[clusterInst.Key], edgeproto.VmInfo{
 			Name:        vmName,
-			Type:        cloudcommon.NodeTypeClusterMaster,
+			Type:        cloudcommon.NodeTypeK8sClusterMaster.String(),
 			InfraFlavor: clusterInst.MasterNodeFlavor,
 			Status:      "ACTIVE",
 		})
@@ -283,7 +283,7 @@ func updateClusterResCount(clusterInst *edgeproto.ClusterInst) {
 	for ii := uint32(0); ii < clusterInst.NumMasters; ii++ {
 		FakeClusterVMs[clusterInst.Key] = append(FakeClusterVMs[clusterInst.Key], edgeproto.VmInfo{
 			Name:        fmt.Sprintf("fake-master-%d-%s", ii+1, vmNameSuffix),
-			Type:        cloudcommon.NodeTypeClusterMaster,
+			Type:        cloudcommon.NodeTypeK8sClusterMaster.String(),
 			InfraFlavor: clusterInst.MasterNodeFlavor,
 			Status:      "ACTIVE",
 		})
@@ -292,7 +292,7 @@ func updateClusterResCount(clusterInst *edgeproto.ClusterInst) {
 	for ii := uint32(0); ii < clusterInst.NumNodes; ii++ {
 		FakeClusterVMs[clusterInst.Key] = append(FakeClusterVMs[clusterInst.Key], edgeproto.VmInfo{
 			Name:        fmt.Sprintf("fake-node-%d-%s", ii+1, vmNameSuffix),
-			Type:        cloudcommon.NodeTypeClusterK8sNode,
+			Type:        cloudcommon.NodeTypeK8sClusterNode.String(),
 			InfraFlavor: clusterInst.NodeFlavor,
 			Status:      "ACTIVE",
 		})
@@ -301,7 +301,7 @@ func updateClusterResCount(clusterInst *edgeproto.ClusterInst) {
 	if clusterInst.IpAccess == edgeproto.IpAccess_IP_ACCESS_DEDICATED {
 		FakeClusterVMs[clusterInst.Key] = append(FakeClusterVMs[clusterInst.Key], edgeproto.VmInfo{
 			Name:        clusterInst.Fqdn,
-			Type:        cloudcommon.NodeTypeDedicatedRootLB,
+			Type:        cloudcommon.NodeTypeDedicatedRootLB.String(),
 			InfraFlavor: "x1.small",
 			Status:      "ACTIVE",
 		})
@@ -322,7 +322,7 @@ func updateVmAppResCount(ctx context.Context, clusterInst *edgeproto.ClusterInst
 		}
 		FakeClusterVMs[clusterInst.Key] = append(FakeClusterVMs[clusterInst.Key], edgeproto.VmInfo{
 			Name:        appFQN,
-			Type:        cloudcommon.NodeTypeAppVM,
+			Type:        cloudcommon.NodeTypeAppVM.String(),
 			InfraFlavor: appInst.VmFlavor,
 			Status:      "ACTIVE",
 		})
@@ -385,7 +385,7 @@ func (s *Platform) GetCloudletInfraResources(ctx context.Context) (*edgeproto.In
 	var resources edgeproto.InfraResourcesSnapshot
 	platvm := edgeproto.VmInfo{
 		Name:        "fake-platform-vm",
-		Type:        cloudcommon.NodeTypePlatformVM,
+		Type:        cloudcommon.NodeTypePlatformVM.String(),
 		InfraFlavor: "x1.small",
 		Status:      "ACTIVE",
 		Ipaddresses: []edgeproto.IpAddr{
@@ -395,7 +395,7 @@ func (s *Platform) GetCloudletInfraResources(ctx context.Context) (*edgeproto.In
 	resources.PlatformVms = append(resources.PlatformVms, platvm)
 	rlbvm := edgeproto.VmInfo{
 		Name:        "fake-rootlb-vm",
-		Type:        cloudcommon.NodeTypeDedicatedRootLB,
+		Type:        cloudcommon.NodeTypeDedicatedRootLB.String(),
 		InfraFlavor: "x1.small",
 		Status:      "ACTIVE",
 		Ipaddresses: []edgeproto.IpAddr{
@@ -536,7 +536,7 @@ func (s *Platform) GetNodePlatformClient(ctx context.Context, node *edgeproto.Cl
 func (s *Platform) ListCloudletMgmtNodes(ctx context.Context, clusterInsts []edgeproto.ClusterInst, vmAppInsts []edgeproto.AppInst) ([]edgeproto.CloudletMgmtNode, error) {
 	return []edgeproto.CloudletMgmtNode{
 		edgeproto.CloudletMgmtNode{
-			Type: cloudcommon.NodeTypePlatformVM,
+			Type: cloudcommon.NodeTypePlatformVM.String(),
 			Name: "platformvmname",
 		},
 	}, nil

--- a/cloud-resource-manager/proxy/certs/certifications.go
+++ b/cloud-resource-manager/proxy/certs/certifications.go
@@ -150,7 +150,7 @@ func getRootLbCertsHelper(ctx context.Context, key *edgeproto.CloudletKey, commo
 		return lastCertsUsed
 	}
 	// apply new cert
-	client, err := platform.GetNodePlatformClient(ctx, &edgeproto.CloudletMgmtNode{Type: cloudcommon.NodeTypeSharedRootLB})
+	client, err := platform.GetNodePlatformClient(ctx, &edgeproto.CloudletMgmtNode{Type: cloudcommon.NodeTypeSharedRootLB.String()})
 	if err == nil {
 		err = writeCertToRootLb(ctx, &tls, client, certsDir, certFile, keyFile)
 		if err != nil {

--- a/cloudcommon/infraresources.go
+++ b/cloudcommon/infraresources.go
@@ -94,7 +94,7 @@ func GetClusterInstVMRequirements(ctx context.Context, clusterInst *edgeproto.Cl
 		vmResources = append(vmResources, edgeproto.VMResource{
 			Key:      clusterInst.Key,
 			VmFlavor: nodeFlavor,
-			Type:     NodeTypeClusterDockerNode,
+			Type:     NodeTypeDockerClusterNode.String(),
 		})
 	} else {
 		// For managed-k8s platforms, ignore master node for resource calculation
@@ -104,13 +104,13 @@ func GetClusterInstVMRequirements(ctx context.Context, clusterInst *edgeproto.Cl
 					vmResources = append(vmResources, edgeproto.VMResource{
 						Key:      clusterInst.Key,
 						VmFlavor: nodeFlavor,
-						Type:     NodeTypeClusterMaster,
+						Type:     NodeTypeK8sClusterMaster.String(),
 					})
 				} else {
 					vmResources = append(vmResources, edgeproto.VMResource{
 						Key:      clusterInst.Key,
 						VmFlavor: masterNodeFlavor,
-						Type:     NodeTypeClusterMaster,
+						Type:     NodeTypeK8sClusterMaster.String(),
 					})
 				}
 			}
@@ -119,7 +119,7 @@ func GetClusterInstVMRequirements(ctx context.Context, clusterInst *edgeproto.Cl
 			vmResources = append(vmResources, edgeproto.VMResource{
 				Key:      clusterInst.Key,
 				VmFlavor: nodeFlavor,
-				Type:     NodeTypeClusterK8sNode,
+				Type:     NodeTypeK8sClusterNode.String(),
 			})
 		}
 	}
@@ -133,7 +133,7 @@ func GetClusterInstVMRequirements(ctx context.Context, clusterInst *edgeproto.Cl
 			vmResources = append(vmResources, edgeproto.VMResource{
 				Key:      clusterInst.Key,
 				VmFlavor: rootLBFlavor,
-				Type:     NodeTypeDedicatedRootLB,
+				Type:     NodeTypeDedicatedRootLB.String(),
 			})
 		}
 	}
@@ -159,13 +159,13 @@ func GetVMAppRequirements(ctx context.Context, app *edgeproto.App, appInst *edge
 		vmResources = append(vmResources, edgeproto.VMResource{
 			Key:      *appInst.ClusterInstKey(),
 			VmFlavor: rootLBFlavor,
-			Type:     NodeTypeDedicatedRootLB,
+			Type:     NodeTypeDedicatedRootLB.String(),
 		})
 	}
 	vmResources = append(vmResources, edgeproto.VMResource{
 		Key:           *appInst.ClusterInstKey(),
 		VmFlavor:      vmFlavor,
-		Type:          NodeTypeAppVM,
+		Type:          NodeTypeAppVM.String(),
 		AppAccessType: app.AccessType,
 	})
 	return vmResources, nil

--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -39,19 +39,51 @@ var OperatingSystemMac = "mac"
 var OperatingSystemLinux = "linux"
 
 // Cloudlet Platform nodes -- update IsPlatformNode if adding to this list
-var NodeTypeAppVM = "appvm"
-var NodeTypeSharedRootLB = "sharedrootlb"
-var NodeTypeDedicatedRootLB = "dedicatedrootlb"
-var NodeTypePlatformVM = "platformvm"
-var NodeTypePlatformHost = "platformhost"
-var NodeTypePlatformClusterMaster = "platform-cluster-master"
-var NodeTypePlatformClusterPrimaryNode = "platform-cluster-primary-node"
-var NodeTypePlatformClusterSecondaryNode = "platform-cluster-secondary-node"
 
-// Cloudlet Compute nodes
-var NodeTypeClusterMaster = "cluster-master"
-var NodeTypeClusterK8sNode = "cluster-k8s-node"
-var NodeTypeClusterDockerNode = "cluster-docker-node"
+type NodeType int
+
+const (
+	NodeTypeAppVM NodeType = iota
+	NodeTypeSharedRootLB
+	NodeTypeDedicatedRootLB
+	NodeTypePlatformVM
+	NodeTypePlatformHost
+	NodeTypePlatformK8sClusterMaster
+	NodeTypePlatformK8sClusterPrimaryNode
+	NodeTypePlatformK8sClusterSecondaryNode
+	// Cloudlet Compute nodes
+	NodeTypeK8sClusterMaster
+	NodeTypeK8sClusterNode
+	NodeTypeDockerClusterNode
+)
+
+func (n NodeType) String() string {
+	switch n {
+	case NodeTypeAppVM:
+		return "appvm"
+	case NodeTypeSharedRootLB:
+		return "sharedrootlb"
+	case NodeTypeDedicatedRootLB:
+		return "dedicatedrootlb"
+	case NodeTypePlatformVM:
+		return "platformvm"
+	case NodeTypePlatformHost:
+		return "platformhost"
+	case NodeTypePlatformK8sClusterMaster:
+		return "platform-k8s-cluster-master"
+	case NodeTypePlatformK8sClusterPrimaryNode:
+		return "platform-k8s-cluster-primary-node"
+	case NodeTypePlatformK8sClusterSecondaryNode:
+		return "platform-k8s-cluster-secondary-node"
+	case NodeTypeK8sClusterMaster:
+		return "k8s-cluster-master"
+	case NodeTypeK8sClusterNode:
+		return "k8s-cluster-node"
+	case NodeTypeDockerClusterNode:
+		return "docker-cluster-node"
+	}
+	return "unknown node type"
+}
 
 // resource types
 var ResourceTypeK8sLBSvc = "k8s-lb-svc"
@@ -377,22 +409,22 @@ func GetGPUDriverBuildPathFromURL(driverURL, deploymentTag string) string {
 	return strings.TrimPrefix(driverURL, fmt.Sprintf("https://storage.cloud.google.com/%s/", GetGPUDriverBucketName(deploymentTag)))
 }
 
-func IsPlatformNode(nodeType string) bool {
-	switch nodeType {
-	case NodeTypePlatformVM:
+func IsPlatformNode(nodeTypeStr string) bool {
+	switch nodeTypeStr {
+	case NodeTypePlatformVM.String():
 		fallthrough
-	case NodeTypePlatformHost:
+	case NodeTypePlatformHost.String():
 		fallthrough
-	case NodeTypePlatformClusterMaster:
+	case NodeTypePlatformK8sClusterMaster.String():
 		fallthrough
-	case NodeTypePlatformClusterPrimaryNode:
+	case NodeTypePlatformK8sClusterPrimaryNode.String():
 		fallthrough
-	case NodeTypePlatformClusterSecondaryNode:
+	case NodeTypePlatformK8sClusterSecondaryNode.String():
 		return true
 	}
 	return false
 }
 
-func IsLBNode(nodeType string) bool {
-	return nodeType == NodeTypeDedicatedRootLB || nodeType == NodeTypeSharedRootLB
+func IsLBNode(nodeTypeStr string) bool {
+	return nodeTypeStr == NodeTypeDedicatedRootLB.String() || nodeTypeStr == NodeTypeSharedRootLB.String()
 }

--- a/controller/clusterinst_api_test.go
+++ b/controller/clusterinst_api_test.go
@@ -765,11 +765,11 @@ func testClusterInstResourceUsage(t *testing.T, ctx context.Context, apis *AllAp
 		numMasters := 0
 		numRootLB := 0
 		for _, res := range ciResources {
-			if res.Type == cloudcommon.NodeTypeClusterMaster {
+			if res.Type == cloudcommon.NodeTypeK8sClusterMaster.String() {
 				numMasters++
-			} else if res.Type == cloudcommon.NodeTypeClusterK8sNode {
+			} else if res.Type == cloudcommon.NodeTypeK8sClusterNode.String() {
 				numNodes++
-			} else if res.Type == cloudcommon.NodeTypeDedicatedRootLB {
+			} else if res.Type == cloudcommon.NodeTypeDedicatedRootLB.String() {
 				numRootLB++
 			} else {
 				require.Fail(t, "invalid resource type", "type", res.Type)
@@ -818,9 +818,9 @@ func testClusterInstResourceUsage(t *testing.T, ctx context.Context, apis *AllAp
 		foundVMRes := false
 		foundVMRootLBRes := false
 		for _, vmRes := range vmAppResources {
-			if vmRes.Type == cloudcommon.NodeTypeAppVM {
+			if vmRes.Type == cloudcommon.NodeTypeAppVM.String() {
 				foundVMRes = true
-			} else if vmRes.Type == cloudcommon.NodeTypeDedicatedRootLB {
+			} else if vmRes.Type == cloudcommon.NodeTypeDedicatedRootLB.String() {
 				foundVMRootLBRes = true
 			}
 			require.Equal(t, vmAppResources[0].Key, *appInst.ClusterInstKey(), "resource key matches appinst's clusterinst key")

--- a/setup-env/e2e-tests/data/appdata-ratelimit_show.yml
+++ b/setup-env/e2e-tests/data/appdata-ratelimit_show.yml
@@ -428,15 +428,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: smallcluster-acmeappco
@@ -461,15 +461,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-2-tmus.local.localtest.net

--- a/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
+++ b/setup-env/e2e-tests/data/appdata_cloudlet1_moved_show.yml
@@ -452,15 +452,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   networks:
@@ -487,15 +487,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-2-tmus.local.localtest.net

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst0.yml
@@ -151,11 +151,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: smallcluster-acmeappco

--- a/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
+++ b/setup-env/e2e-tests/data/appdata_clusterInst1_cloudlet1_appInst1_show.yml
@@ -151,11 +151,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: smallcluster-acmeappco

--- a/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_autoprov_show.yml
@@ -448,11 +448,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-reservablecluster-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-reservablecluster-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: reservablecluster-mobiledgex.tmus-cloud-1-tmus.local.localtest.net
@@ -483,11 +483,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-reservablecluster2-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-reservablecluster2-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: reservablecluster2-mobiledgex.tmus-cloud-2-tmus.local.localtest.net
@@ -516,11 +516,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-1-tmus.local.localtest.net
@@ -549,11 +549,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: smallcluster-acmeappco

--- a/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
+++ b/setup-env/e2e-tests/data/appdata_no_appinst_show.yml
@@ -448,11 +448,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-reservablecluster-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-reservablecluster-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: reservablecluster-mobiledgex.tmus-cloud-1-tmus.local.localtest.net
@@ -482,11 +482,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-reservablecluster2-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-reservablecluster2-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: reservablecluster2-mobiledgex.tmus-cloud-2-tmus.local.localtest.net
@@ -515,11 +515,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-1-tmus.local.localtest.net
@@ -548,11 +548,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: smallcluster-acmeappco

--- a/setup-env/e2e-tests/data/appdata_show.yml
+++ b/setup-env/e2e-tests/data/appdata_show.yml
@@ -452,15 +452,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   networks:
@@ -487,15 +487,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-2-tmus.local.localtest.net

--- a/setup-env/e2e-tests/data/appdata_show_after_cluster_update.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_cluster_update.yml
@@ -452,19 +452,19 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-3-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   networks:
@@ -491,15 +491,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-2-tmus.local.localtest.net

--- a/setup-env/e2e-tests/data/appdata_show_after_refresh.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_refresh.yml
@@ -452,15 +452,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   networks:
@@ -487,15 +487,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-2-tmus.local.localtest.net

--- a/setup-env/e2e-tests/data/appdata_show_after_refresh_all.yml
+++ b/setup-env/e2e-tests/data/appdata_show_after_refresh_all.yml
@@ -452,15 +452,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   networks:
@@ -487,15 +487,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-2-tmus.local.localtest.net

--- a/setup-env/e2e-tests/data/appdata_show_prometheus_30s_interval.yml
+++ b/setup-env/e2e-tests/data/appdata_show_prometheus_30s_interval.yml
@@ -452,15 +452,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   networks:
@@ -487,15 +487,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-2-tmus.local.localtest.net

--- a/setup-env/e2e-tests/data/appdata_show_standby_crm.yml
+++ b/setup-env/e2e-tests/data/appdata_show_standby_crm.yml
@@ -452,15 +452,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   networks:
@@ -487,15 +487,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-2-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: smallcluster-acmeappco.tmus-cloud-2-tmus.local.localtest.net

--- a/setup-env/e2e-tests/data/appdata_trusted_show.yml
+++ b/setup-env/e2e-tests/data/appdata_trusted_show.yml
@@ -235,15 +235,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-cloudlet1-cluster1-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-cloudlet1-cluster1-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-cloudlet1-cluster1-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: cluster1-acmeappco
@@ -272,15 +272,15 @@ clusterinsts:
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-master-1-cloudlet2-cluster2-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-cloudlet2-cluster2-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-cloudlet2-cluster2-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: cluster2-acmeappco

--- a/setup-env/e2e-tests/data/appdata_trustpol_incompat_rules_show.yml
+++ b/setup-env/e2e-tests/data/appdata_trustpol_incompat_rules_show.yml
@@ -231,15 +231,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-cloudlet1-cluster1-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-cloudlet1-cluster1-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-cloudlet1-cluster1-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: cluster1-acmeappco

--- a/setup-env/e2e-tests/data/crm_info.yml
+++ b/setup-env/e2e-tests/data/crm_info.yml
@@ -233,11 +233,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -265,11 +265,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -297,11 +297,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable1-mobiledgex

--- a/setup-env/e2e-tests/data/influx_appdata_show.yml
+++ b/setup-env/e2e-tests/data/influx_appdata_show.yml
@@ -150,15 +150,15 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: smallcluster-acmeappco

--- a/setup-env/e2e-tests/data/show10.yml
+++ b/setup-env/e2e-tests/data/show10.yml
@@ -794,11 +794,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-azure-cloud-9-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-azure-cloud-9-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: reservable0-mobiledgex.azure-cloud-9-azure.local.localtest.net
@@ -830,11 +830,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-gcp-cloud-10-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-gcp-cloud-10-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: reservable0-mobiledgex.gcp-cloud-10-gcp.local.localtest.net
@@ -866,11 +866,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -898,11 +898,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -930,11 +930,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-3-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-3-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -962,11 +962,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-4-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-4-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -994,11 +994,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-5-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-5-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -1026,11 +1026,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-6-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-6-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -1058,11 +1058,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-7-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-7-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -1090,11 +1090,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-8-reservable0-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-8-reservable0-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable0-mobiledgex
@@ -1122,11 +1122,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-azure-cloud-9-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-azure-cloud-9-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: reservable1-mobiledgex.azure-cloud-9-azure.local.localtest.net
@@ -1158,11 +1158,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-gcp-cloud-10-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-gcp-cloud-10-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
     - name: reservable1-mobiledgex.gcp-cloud-10-gcp.local.localtest.net
@@ -1194,11 +1194,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable1-mobiledgex
@@ -1226,11 +1226,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable1-mobiledgex
@@ -1258,11 +1258,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-3-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-3-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable1-mobiledgex
@@ -1290,11 +1290,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-4-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-4-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable1-mobiledgex
@@ -1322,11 +1322,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-5-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-5-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable1-mobiledgex
@@ -1354,11 +1354,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-6-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-6-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable1-mobiledgex
@@ -1386,11 +1386,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-7-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-7-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable1-mobiledgex
@@ -1418,11 +1418,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-8-reservable1-mobiledgex
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-8-reservable1-mobiledgex
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: reservable1-mobiledgex

--- a/setup-env/e2e-tests/data/show2.yml
+++ b/setup-env/e2e-tests/data/show2.yml
@@ -222,11 +222,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-1-someapplication1-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-1-someapplication1-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: someapplication1-acmeappco
@@ -251,11 +251,11 @@ clusterinsts:
   resources:
     vms:
     - name: fake-master-1-tmus-cloud-2-someapplication1-acmeappco
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-tmus-cloud-2-someapplication1-acmeappco
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: someapplication1-acmeappco

--- a/setup-env/e2e-tests/data/trustpolicyexception_create_show.yml
+++ b/setup-env/e2e-tests/data/trustpolicyexception_create_show.yml
@@ -158,11 +158,11 @@ clusterinsts:
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-master-1-cloudlet2-1000realities-cluster-22-1000realities
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-cloudlet2-1000realities-cluster-22-1000realities
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: 1000realities-cluster-22-1000realities

--- a/setup-env/e2e-tests/data/trustpolicyexception_update_tpe1_active_show.yml
+++ b/setup-env/e2e-tests/data/trustpolicyexception_update_tpe1_active_show.yml
@@ -158,11 +158,11 @@ clusterinsts:
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-master-1-cloudlet2-1000realities-cluster-22-1000realities
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-cloudlet2-1000realities-cluster-22-1000realities
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: 1000realities-cluster-22-1000realities

--- a/setup-env/e2e-tests/data/trustpolicyexception_update_tpe1_portrange_show.yml
+++ b/setup-env/e2e-tests/data/trustpolicyexception_update_tpe1_portrange_show.yml
@@ -158,11 +158,11 @@ clusterinsts:
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-master-1-cloudlet2-1000realities-cluster-22-1000realities
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-cloudlet2-1000realities-cluster-22-1000realities
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: 1000realities-cluster-22-1000realities

--- a/setup-env/e2e-tests/data/trustpolicyexception_update_tpe1_rejected_show.yml
+++ b/setup-env/e2e-tests/data/trustpolicyexception_update_tpe1_rejected_show.yml
@@ -158,11 +158,11 @@ clusterinsts:
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-master-1-cloudlet2-1000realities-cluster-22-1000realities
-      type: cluster-master
+      type: k8s-cluster-master
       status: ACTIVE
       infraflavor: x1.small
     - name: fake-node-1-cloudlet2-1000realities-cluster-22-1000realities
-      type: cluster-k8s-node
+      type: k8s-cluster-node
       status: ACTIVE
       infraflavor: x1.small
   dnslabel: 1000realities-cluster-22-1000realities


### PR DESCRIPTION
Changes for some review comments from previous PR:

Change NodeType to enum and change some of the names per previous PR review.  

Note I did not change edgeproto.VmInfo and edgeproto.VMResource to use these enums directly as that would cause a controller/CRM incompatibility -- these passed back and forth for resource usage. So we use the String() function on the new enum