### PR TITLE
allow internal and external apps to coexist on same port

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -200,6 +200,11 @@ func UpdateLoadBalancerPortMap(ctx context.Context, client ssh.Client, names *Ku
 
 	for _, s := range services {
 		lbip := ""
+		// It is possible to have ports for internal services that may overlap but not exposed externally. Skip services not part of this app.
+		if !names.ContainsService(s.Name) {
+			continue
+		}
+		log.SpanLog(ctx, log.DebugLevelInfra, "service name match found in kubenames", "svc name", s.Name)
 		if names.MultitenantNamespace != "" {
 			svcNamespace := s.ObjectMeta.Namespace
 			if svcNamespace != names.MultitenantNamespace {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5735 App with port 9090 in its manifest exposes internal prometheus service

### Description

Prometheus uses port 9090 although it is not exposed externally. So this port is available for use by developer apps. We don't typically expect a port conflict within a given LB/Namespace but this is an exception. With metalLB now in use, it is possible for 2 apps to use the same port so long as one of them is internal, such as Prometheus.

Fix is to check that the service name matches in UpdateLoadBalancerPortMap and only update the port map for the service we are looking for.