### PR TITLE
EDGECLOUD-6273: Updated replicas is not reflected as part of appinst upgrade

### DIFF
--- a/cloud-resource-manager/k8smgmt/manifest.go
+++ b/cloud-resource-manager/k8smgmt/manifest.go
@@ -199,14 +199,14 @@ func MergeEnvVars(ctx context.Context, authApi cloudcommon.RegistryAuthApi, app 
 		case *appsv1.Deployment:
 			template = &obj.Spec.Template
 			name = obj.ObjectMeta.Name
-			obj.Spec.Replicas = getDefaultReplicas(app, names)
+			obj.Spec.Replicas = getDefaultReplicas(app, names, *obj.Spec.Replicas)
 		case *appsv1.DaemonSet:
 			template = &obj.Spec.Template
 			name = obj.ObjectMeta.Name
 		case *appsv1.StatefulSet:
 			template = &obj.Spec.Template
 			name = obj.ObjectMeta.Name
-			obj.Spec.Replicas = getDefaultReplicas(app, names)
+			obj.Spec.Replicas = getDefaultReplicas(app, names, *obj.Spec.Replicas)
 		}
 		if template == nil {
 			continue
@@ -270,8 +270,11 @@ func AddManifest(mf, addmf string) string {
 	return mf + "---\n" + addmf
 }
 
-func getDefaultReplicas(app *edgeproto.App, names *KubeNames) *int32 {
+func getDefaultReplicas(app *edgeproto.App, names *KubeNames, curReplica int32) *int32 {
 	val := int32(1)
+	if curReplica != 0 {
+		val = curReplica
+	}
 	if names.MultitenantNamespace != "" && app.ServerlessConfig != nil {
 		val = int32(app.ServerlessConfig.MinReplicas)
 	}

--- a/cloud-resource-manager/k8smgmt/manifest_test.go
+++ b/cloud-resource-manager/k8smgmt/manifest_test.go
@@ -50,7 +50,7 @@ func TestEnvVars(t *testing.T) {
 	defaultFlavor := testutil.FlavorData[0]
 
 	authApi := &cloudcommon.DummyRegistryAuthApi{}
-	// Test Deploymeent manifest with inline EnvVars
+	// Test Deployment manifest with inline EnvVars
 	baseMf, err := cloudcommon.GetAppDeploymentManifest(ctx, nil, app)
 	require.Nil(t, err)
 	envVarsMf, err := MergeEnvVars(ctx, authApi, app, baseMf, nil, names, &defaultFlavor)
@@ -190,7 +190,7 @@ kind: Deployment
 metadata:
   name: pokemongo-deployment
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: pokemongo
@@ -296,7 +296,7 @@ metadata:
     config: ""
   name: pokemongo-deployment
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: pokemongo


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-6273: Updated replicas is not reflected as part of appinst upgrade

### Description
* `getDefaultReplicas` was not taking the value of replicas set in app's deployment manifest