### PR TITLE
e2e-test pgrep tweaks for getting stuck

### DIFF
--- a/setup-env/e2e-tests/e2e-tests.go
+++ b/setup-env/e2e-tests/e2e-tests.go
@@ -243,12 +243,15 @@ func runTests(dirName, fileName, progName string, depth int, mods []string) (int
 				}
 				continue
 			}
-			sof := ""
-			if *stopOnFail {
-				sof = "-stop"
+			args := []string{
+				"-testConfig", configStr,
+				"-testSpec", string(testSpec),
+				"-mods", string(modsSpec),
 			}
-			cmdstr := fmt.Sprintf("%s -testConfig '%s' -testSpec '%s' -mods '%s' %s", progName, configStr, string(testSpec), string(modsSpec), sof)
-			cmd := exec.Command("sh", "-c", cmdstr)
+			if *stopOnFail {
+				args = append(args, "-stop")
+			}
+			cmd := exec.Command(progName, args...)
 			var out bytes.Buffer
 			var stderr bytes.Buffer
 			cmd.Stdout = &out


### PR DESCRIPTION
I've been having problems on my laptop with e2e-test stop-processes hanging. It appears pgrep hangs, but I've been unable to figure out why. This cleans up some of the exec to make it easier to debug pgrep (it's not wrapped in a shell for exec), and adds a timeout in case it does get stuck.