### PR TITLE
update container version

### DIFF
--- a/cloud-resource-manager/cmd/crmserver/main.go
+++ b/cloud-resource-manager/cmd/crmserver/main.go
@@ -297,6 +297,8 @@ func main() {
 						cspan.Finish()
 						log.FatalLog("unexpected error getting cloudlet info from HA cache", "err", err)
 					}
+					// update the container version as this may not match what is in the cache
+					myCloudletInfo.ContainerVersion = cloudletContainerVersion
 					if myCloudletInfo.State == dme.CloudletState_CLOUDLET_STATE_READY {
 						log.SpanLog(ctx, log.DebugLevelInfo, "conditional init not required as cloudlet was previously ready and versions match")
 						conditionalInitRequired = false


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6219 CRM HA : "container version" does not get updated after CRM upgrade 

### Description

On CRM switchover, the container version in the cloudlet info gets copied from the redis cache. It needs to be updated for the newly active instance.