### PR TITLE
EDGECLOUD-6290 fix mcctl crash, remove deprecated alldata api

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -198,6 +198,9 @@ func (c *Command) runE(cmd *cobra.Command, args []string) error {
 func (c *Command) ParseInput(args []string) (*MapData, error) {
 	var in *MapData
 	if Datafile != "" {
+		if c.ReqData == nil {
+			return in, fmt.Errorf("command does not accept input")
+		}
 		byt, err := ioutil.ReadFile(Datafile)
 		if err != nil {
 			return nil, err
@@ -205,6 +208,9 @@ func (c *Command) ParseInput(args []string) (*MapData, error) {
 		Data = string(byt)
 	}
 	if Data != "" {
+		if c.ReqData == nil {
+			return in, fmt.Errorf("command does not accept input")
+		}
 		indata := make(map[string]interface{})
 		err := json.Unmarshal([]byte(Data), &indata)
 		if err == nil && c.ReqData != nil {

--- a/cli/input.go
+++ b/cli/input.go
@@ -53,6 +53,16 @@ type Input struct {
 // NOTE: arrays and maps not supported yet.
 func (s *Input) ParseArgs(args []string, obj interface{}) (*MapData, error) {
 	dat := map[string]interface{}{}
+	data := MapData{
+		Namespace: ArgsNamespace,
+		Data:      dat,
+	}
+	if len(args) == 0 {
+		return &data, nil
+	}
+	if obj == nil {
+		return &data, fmt.Errorf("no arguments accepted")
+	}
 
 	// resolve aliases first
 	aliases := make(map[string]string)
@@ -144,10 +154,6 @@ func (s *Input) ParseArgs(args []string, obj interface{}) (*MapData, error) {
 			return nil, fmt.Errorf("invalid args: %s",
 				strings.Join(unused, " "))
 		}
-	}
-	data := MapData{
-		Namespace: ArgsNamespace,
-		Data:      dat,
 	}
 	return &data, nil
 }
@@ -257,6 +263,9 @@ func JsonMap(mdat *MapData, obj interface{}) (*MapData, error) {
 		// already json
 		return mdat, nil
 	}
+	if obj == nil {
+		return mdat, fmt.Errorf("Invalid nil object")
+	}
 
 	js := map[string]interface{}{}
 	err := MapJsonNamesT(mdat.Data, js, reflect.TypeOf(obj), mdat.Namespace)
@@ -271,6 +280,9 @@ func JsonMap(mdat *MapData, obj interface{}) (*MapData, error) {
 }
 
 func MapJsonNamesT(dat, js map[string]interface{}, t reflect.Type, inputNS FieldNamespace) error {
+	if t == nil {
+		return fmt.Errorf("Invalid nil type")
+	}
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}

--- a/cli/input_test.go
+++ b/cli/input_test.go
@@ -208,6 +208,33 @@ func TestParseArgs(t *testing.T) {
 	_, err = input.ParseArgs(args, &buf)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), `parsing arg "arr:empty=ttrue" failed: unable to parse "ttrue" as bool, valid values are true, false`)
+
+	// no args is ok with nil object
+	noArgsMap, err := input.ParseArgs([]string{}, nil)
+	require.Nil(t, err)
+	require.Equal(t, 0, len(noArgsMap.Data))
+
+	// make sure code does not crash for nil input object
+	_, err = input.ParseArgs([]string{"foo"}, nil)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "no arguments accepted")
+	_, err = cli.JsonMap(&cli.MapData{}, nil)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Invalid nil object")
+	err = cli.MapJsonNamesT(map[string]interface{}{}, map[string]interface{}{}, nil, cli.JsonNamespace)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Invalid nil type")
+	cmd := cli.Command{}
+	cli.Datafile = "foo"
+	_, err = cmd.ParseInput([]string{})
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "command does not accept input")
+	cli.Datafile = ""
+	cli.Data = "{}"
+	_, err = cmd.ParseInput([]string{})
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "command does not accept input")
+	cli.Data = ""
 }
 
 func testConversionEmptyFields(t *testing.T, input *cli.Input, obj, buf interface{}, args []string, expectedFields []string) {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6290 mcctl alldata command causes crash and should be removed

### Description

Crash was caused by a nil object. Add in checks to the public functions in the cli package to check for invalid nil object.