### PR TITLE
fix regex to not truncate last word in message

### DIFF
--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -36,7 +36,7 @@ var createWaitNoResources = 10 * time.Second
 var applyManifest = "apply"
 var createManifest = "create"
 
-var podStateRegString = "(\\S+)\\s+(\\S+)\\s+(\\S+)\\s+(.*)\\s+"
+var podStateRegString = "(\\S+)\\s+(\\S+)\\s+(\\S+)\\s+(.*)\\s*"
 var podStateReg = regexp.MustCompile(podStateRegString)
 
 func LbServicePortToString(p *v1.ServicePort) string {


### PR DESCRIPTION
Small tweak to EDGECLOUD-6111 fix: in the error message returned we are truncating the last word because of the regex used. Tweak the regex.