### PR TITLE
wrap kubectl and docker exec into docker wrappers

### DIFF
--- a/cloud-resource-manager/dockermgmt/dockerapp.go
+++ b/cloud-resource-manager/dockermgmt/dockerapp.go
@@ -26,6 +26,8 @@ type DockerNetworkingMode string
 var DockerHostMode DockerNetworkingMode = "hostMode"
 var DockerBridgeMode DockerNetworkingMode = "bridgeMode"
 
+const dockerCliImage string = "docker.mobiledgex.net/mobiledgex/mobiledgex_public/docker-cli@sha256:97911992833b8ca49ade2d6c712a5447ccbf6f3f237330ed80d0996b025ae997"
+
 type DockerOptions struct {
 	ForceImagePull bool
 }
@@ -496,7 +498,7 @@ func GetContainerCommand(clusterInst *edgeproto.ClusterInst, app *edgeproto.App,
 		if err != nil {
 			return "", fmt.Errorf("bad command: %s", err)
 		}
-		cmdStr := fmt.Sprintf("docker exec -it %s %s", req.ContainerId, userCmd)
+		cmdStr := fmt.Sprintf("docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -it %s docker exec -it %s %s", dockerCliImage, req.ContainerId, userCmd)
 		return cmdStr, nil
 	}
 	if req.Log != nil {

--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -24,6 +24,8 @@ const WaitRunning string = "WaitRunning"
 
 const DefaultNamespace string = "default"
 
+const kubectlImage string = "docker.mobiledgex.net/mobiledgex/mobiledgex_public/kubectl@sha256:e72b73d5b030faade325c9f9f8b55508a302492f7c75d5131b0641ea3ece8513"
+
 // This is half of the default controller AppInst timeout
 var maxWait = 15 * time.Minute
 
@@ -565,8 +567,7 @@ func GetContainerCommand(ctx context.Context, clusterInst *edgeproto.ClusterInst
 		if err != nil {
 			return "", fmt.Errorf("bad command: %s", err)
 		}
-		cmdStr := fmt.Sprintf("%s kubectl exec -n %s -it %s%s -- %s",
-			names.KconfEnv, namespace, containerCmd, podName, userCmd)
+		cmdStr := fmt.Sprintf("docker run --rm -it -v /home/ubuntu/%s:/.kube/config %s exec -n %s -it %s%s -- %s", names.KconfName, kubectlImage, namespace, containerCmd, podName, userCmd)
 		return cmdStr, nil
 	}
 	if req.Log != nil {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6340 kubectl exec and docker exec need to be sandboxed

### Description

To improve security, our docker exec and kubectl exec commands which are exposed via developer APIs are wrapped within kubectl and docker-cli containers. 

A second PR will be made soon to cache these images