### PR TITLE
EDGECLOUD-6257: Password update does not require re-entering password

### DIFF
--- a/cli/input.go
+++ b/cli/input.go
@@ -59,9 +59,6 @@ func (s *Input) ParseArgs(args []string, obj interface{}) (*MapData, error) {
 		Namespace: ArgsNamespace,
 		Data:      dat,
 	}
-	if len(args) == 0 {
-		return &data, nil
-	}
 	if obj == nil {
 		return &data, fmt.Errorf("no arguments accepted")
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6257: Password update does not require re-entering password

### Description
* Empty args check is not required, it should proceed and take input from terminal for password