### PR TITLE
EDGECLOUD-5834: GPU drivers uploaded to GCS are not associated with a region

### DIFF
--- a/controller/gpudriver_api.go
+++ b/controller/gpudriver_api.go
@@ -71,6 +71,16 @@ func setupGPUDriver(ctx context.Context, storageClient *gcs.GCSClient, driverKey
 	}
 	cb.Send(&edgeproto.Result{Message: "Downloading GPU driver build " + build.Name})
 	fileName := cloudcommon.GetGPUDriverBuildStoragePath(driverKey, build.Name, ext)
+
+	// Check if object already exists in GCS
+	exists, err := storageClient.ObjectExists(ctx, fileName)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		return "", fmt.Errorf("GPU driver with same build name already exists (in any region)")
+	}
+
 	localFilePath := "/tmp/" + strings.ReplaceAll(fileName, "/", "_")
 	err = cloudcommon.DownloadFile(ctx, authApi, build.DriverPath, build.DriverPathCreds, localFilePath, nil)
 	if err != nil {

--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -97,6 +97,27 @@ func (gc *GCSClient) ListObjects(ctx context.Context) ([]string, error) {
 	return objs, nil
 }
 
+// Check if object exists
+func (gc *GCSClient) ObjectExists(ctx context.Context, objName string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, gc.Timeout)
+	defer cancel()
+
+	it := gc.Client.Bucket(gc.BucketName).Objects(ctx, nil)
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return false, fmt.Errorf("Failed to get bucket(%q) objects: %v", gc.BucketName, err)
+		}
+		if objName == attrs.Name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Overwrites object if already exists
 func (gc *GCSClient) UploadObject(ctx context.Context, objectName, uploadFilePath string, buf *bytes.Buffer) error {
 	ctx, cancel := context.WithTimeout(ctx, gc.Timeout)


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5834: GPU drivers uploaded to GCS are not associated with a region

### Description
* GPU drivers uploaded to GCS are not associated with a region and hence add validation so that they don't overwrite existing build