### PR TITLE
fix references to cloudcommon names

### DIFF
--- a/cloudcommon/deployment_test.go
+++ b/cloudcommon/deployment_test.go
@@ -12,11 +12,31 @@ import (
 	"github.com/mobiledgex/edge-cloud/deploygen"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
-	"github.com/mobiledgex/edge-cloud/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 var deploymentMF = "some deployment manifest"
+
+var testFlavor = edgeproto.Flavor{
+	Key: edgeproto.FlavorKey{
+		Name: "x1.tiny",
+	},
+	Ram:   1024,
+	Vcpus: 1,
+	Disk:  1,
+}
+
+var testFlavor2 = edgeproto.Flavor{
+	Key: edgeproto.FlavorKey{
+		Name: "x1.tiny.gpu",
+	},
+	Ram:   1024,
+	Vcpus: 1,
+	Disk:  1,
+	OptResMap: map[string]string{
+		"gpu": "pci:1",
+	},
+}
 
 func TestDeployment(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd | log.DebugLevelApi | log.DebugLevelNotify)
@@ -24,7 +44,17 @@ func TestDeployment(t *testing.T) {
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
-	app := &testutil.AppData[0]
+	app := &edgeproto.App{
+		Key: edgeproto.AppKey{
+			Organization: "NianticInc",
+			Name:         "Pokemon Go!",
+			Version:      "1.0.0",
+		},
+		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
+		AccessPorts:   "tcp:443,tcp:10002,udp:10002",
+		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
+		DefaultFlavor: testFlavor.Key,
+	}
 
 	// start up http server to serve deployment manifest
 	tsManifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -210,7 +240,7 @@ func TestDeploymentManifest(t *testing.T) {
 			InternalPort: int32(3333),
 		},
 	}
-	err = IsValidDeploymentManifest(DeploymentTypeKubernetes, "", svcManifest, ports, &testutil.FlavorData[0])
+	err = IsValidDeploymentManifest(DeploymentTypeKubernetes, "", svcManifest, ports, &testFlavor)
 	require.Nil(t, err, "valid k8s svc manifest")
 
 	// clusterIP should not be considered while validating access ports
@@ -218,12 +248,12 @@ func TestDeploymentManifest(t *testing.T) {
 		Proto:        dme.LProto_L_PROTO_TCP,
 		InternalPort: int32(1111),
 	})
-	err = IsValidDeploymentManifest(DeploymentTypeKubernetes, "", svcManifest, ports, &testutil.FlavorData[0])
+	err = IsValidDeploymentManifest(DeploymentTypeKubernetes, "", svcManifest, ports, &testFlavor)
 	require.NotNil(t, err, "invalid k8s svc manifest")
 	require.Contains(t, err.Error(), "tcp:1111 defined in AccessPorts but missing from kubernetes manifest")
 
 	// gpu flavor with rescount as 1
-	flavor := &testutil.FlavorData[4]
+	flavor := &testFlavor2
 
 	manifestResCnt1 := gpuBaseDeploymentManifest + gpuSubManifest
 	err = IsValidDeploymentManifestForFlavor(DeploymentTypeKubernetes, manifestResCnt1, flavor)

--- a/testutil/test_data.go
+++ b/testutil/test_data.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/util"
@@ -80,7 +81,7 @@ var ClusterKeys = []edgeproto.ClusterKey{
 		Name: "Reservable",
 	},
 	edgeproto.ClusterKey{
-		Name: "defaultmtclust", // cloudcommon.DefaultMultiTenantCluster
+		Name: cloudcommon.DefaultMultiTenantCluster,
 	},
 	edgeproto.ClusterKey{
 		Name: "dockerCluster",
@@ -197,7 +198,7 @@ var AppData = []edgeproto.App{
 	},
 	edgeproto.App{ // 9
 		Key: edgeproto.AppKey{
-			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+			Organization: cloudcommon.OrganizationMobiledgeX,
 			Name:         "AutoDeleteApp",
 			Version:      "1.0.0",
 		},
@@ -253,7 +254,7 @@ var AppData = []edgeproto.App{
 	},
 	edgeproto.App{ // 13 - MobiledgeX app
 		Key: edgeproto.AppKey{
-			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+			Organization: cloudcommon.OrganizationMobiledgeX,
 			Name:         "SampleApp",
 			Version:      "1.0.0",
 		},
@@ -289,7 +290,7 @@ var AppData = []edgeproto.App{
 			Name:         "Pokemon Docker!",
 			Version:      "1.0.1",
 		},
-		Deployment:    "docker", // cloudcommon.DeploymentTypeDocker
+		Deployment:    cloudcommon.DeploymentTypeDocker,
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:   "tcp:80,tcp:443,tcp:81:tls",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
@@ -514,7 +515,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey:   ClusterKeys[4],
 			CloudletKey:  cloudletData[0].Key,
-			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+			Organization: cloudcommon.OrganizationMobiledgeX,
 		},
 		Flavor:     FlavorData[0].Key,
 		IpAccess:   edgeproto.IpAccess_IP_ACCESS_SHARED,
@@ -526,7 +527,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey:   ClusterKeys[5], // multi-tenant cluster
 			CloudletKey:  cloudletData[0].Key,
-			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+			Organization: cloudcommon.OrganizationMobiledgeX,
 		},
 		Flavor:           FlavorData[0].Key,
 		IpAccess:         edgeproto.IpAccess_IP_ACCESS_SHARED,
@@ -541,7 +542,7 @@ var ClusterInstData = []edgeproto.ClusterInst{
 			CloudletKey:  cloudletData[1].Key,
 			Organization: DevData[0],
 		},
-		Deployment: "docker", // cloudcommon.DeploymentTypeDocker
+		Deployment: cloudcommon.DeploymentTypeDocker,
 		Flavor:     FlavorData[0].Key,
 		IpAccess:   edgeproto.IpAccess_IP_ACCESS_DEDICATED,
 	},
@@ -557,7 +558,7 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 				Name: "reservable0",
 			},
 			CloudletKey:  cloudletData[1].Key,
-			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+			Organization: cloudcommon.OrganizationMobiledgeX,
 		},
 		Flavor:     FlavorData[0].Key,
 		NumMasters: 1,
@@ -574,7 +575,7 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 				Name: "reservable0",
 			},
 			CloudletKey:  cloudletData[2].Key,
-			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+			Organization: cloudcommon.OrganizationMobiledgeX,
 		},
 		Flavor:     FlavorData[1].Key,
 		NumMasters: 1,
@@ -591,7 +592,7 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 				Name: "reservable1",
 			},
 			CloudletKey:  cloudletData[2].Key,
-			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+			Organization: cloudcommon.OrganizationMobiledgeX,
 		},
 		Flavor:     FlavorData[1].Key,
 		NumMasters: 1,
@@ -608,7 +609,7 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 				Name: "reservable0",
 			},
 			CloudletKey:  cloudletData[3].Key,
-			Organization: "MobiledgeX", // cloudcommon.OrganizationMobiledgeX
+			Organization: cloudcommon.OrganizationMobiledgeX,
 		},
 		Flavor:     FlavorData[0].Key,
 		NumMasters: 1,
@@ -1001,7 +1002,7 @@ var CloudletInfoData = []edgeproto.CloudletInfo{
 				},
 			},
 		},
-		CompatibilityVersion: 1, // cloudcommon.GetCRMCompatibilityVersion()
+		CompatibilityVersion: cloudcommon.GetCRMCompatibilityVersion(),
 		Properties: map[string]string{
 			"supports-mt": "true", // cloudcommon.CloudletSupportsMT
 		},
@@ -1056,7 +1057,7 @@ var CloudletInfoData = []edgeproto.CloudletInfo{
 				},
 			},
 		},
-		CompatibilityVersion: 1, // cloudcommon.GetCRMCompatibilityVersion()
+		CompatibilityVersion: cloudcommon.GetCRMCompatibilityVersion(),
 	},
 	edgeproto.CloudletInfo{
 		Key:         cloudletData[2].Key,
@@ -1108,7 +1109,7 @@ var CloudletInfoData = []edgeproto.CloudletInfo{
 				},
 			},
 		},
-		CompatibilityVersion: 1, // cloudcommon.GetCRMCompatibilityVersion()
+		CompatibilityVersion: cloudcommon.GetCRMCompatibilityVersion(),
 	},
 	edgeproto.CloudletInfo{
 		Key:         cloudletData[3].Key,
@@ -1154,7 +1155,7 @@ var CloudletInfoData = []edgeproto.CloudletInfo{
 				},
 			},
 		},
-		CompatibilityVersion: 1, // cloudcommon.GetCRMCompatibilityVersion()
+		CompatibilityVersion: cloudcommon.GetCRMCompatibilityVersion(),
 	},
 }
 


### PR DESCRIPTION
Remove dependency on testutil package from cloudcommon, that way test_data.go which refers to cloudcommon globals can use them directly instead of a copy, which is hard to maintain if the values ever change.