### PR TITLE
perform sanitization of appinstid in controller

### DIFF
--- a/cloud-resource-manager/platform/common/xind/xind.go
+++ b/cloud-resource-manager/platform/common/xind/xind.go
@@ -118,3 +118,7 @@ func (s *Xind) GetRootLBFlavor(ctx context.Context) (*edgeproto.Flavor, error) {
 		Disk:  uint64(0),
 	}, nil
 }
+
+func (s *Xind) NameSanitize(name string) string {
+	return name
+}

--- a/cloud-resource-manager/platform/dind/dind.go
+++ b/cloud-resource-manager/platform/dind/dind.go
@@ -28,3 +28,7 @@ func (s *Platform) GetInitHAConditionalCompatibilityVersion(ctx context.Context)
 func (s *Platform) ActiveChanged(ctx context.Context, platformActive bool) error {
 	return nil
 }
+
+func (s *Platform) NameSanitize(name string) string {
+	return name
+}

--- a/cloud-resource-manager/platform/fake/fake.go
+++ b/cloud-resource-manager/platform/fake/fake.go
@@ -797,3 +797,7 @@ func (s *Platform) ActiveChanged(ctx context.Context, platformActive bool) error
 	log.SpanLog(ctx, log.DebugLevelInfra, "ActiveChanged", "platformActive", platformActive)
 	return nil
 }
+
+func (s *Platform) NameSanitize(name string) string {
+	return name
+}

--- a/cloud-resource-manager/platform/kind/kind-cluster.go
+++ b/cloud-resource-manager/platform/kind/kind-cluster.go
@@ -275,3 +275,7 @@ func GetClusterContainerNames(ctx context.Context, client ssh.Client, clusterNam
 func (s *Platform) ActiveChanged(ctx context.Context, platformActive bool) error {
 	return nil
 }
+
+func (s *Platform) NameSanitize(name string) string {
+	return name
+}

--- a/cloud-resource-manager/platform/platform.go
+++ b/cloud-resource-manager/platform/platform.go
@@ -172,6 +172,8 @@ type Platform interface {
 	GetRootLBFlavor(ctx context.Context) (*edgeproto.Flavor, error)
 	// Called when the platform instance switches activity. Currently only transition from Standby to Active is allowed.
 	ActiveChanged(ctx context.Context, platformActive bool) error
+	// Sanitizes the name to make it conform to platform requirements.
+	NameSanitize(name string) string
 }
 
 type ClusterSvc interface {

--- a/cloudcommon/names.go
+++ b/cloudcommon/names.go
@@ -231,40 +231,6 @@ func GetRootLBFQDNOld(key *edgeproto.CloudletKey, domain string) string {
 	return fmt.Sprintf("%s.%s.%s", loc, oper, domain)
 }
 
-// GetAppInstId returns a string for this AppInst that is likely to be
-// unique within the region. It does not guarantee uniqueness.
-// The delimiter '.' is removed from the AppInstId so that it can be used
-// to append further strings to this ID to build derived unique names.
-// Salt can be used by the caller to add an extra field if needed
-// to ensure uniqueness. In all cases, any requirements for uniqueness
-// must be guaranteed by the caller.
-func GetAppInstId(appInst *edgeproto.AppInst, app *edgeproto.App, salt string) string {
-	fields := []string{}
-
-	appName := util.DNSSanitize(appInst.Key.AppKey.Name)
-	dev := util.DNSSanitize(appInst.Key.AppKey.Organization)
-	ver := util.DNSSanitize(appInst.Key.AppKey.Version)
-	appId := fmt.Sprintf("%s%s%s", dev, appName, ver)
-	fields = append(fields, appId)
-
-	if IsClusterInstReqd(app) {
-		cluster := util.DNSSanitize(appInst.Key.ClusterInstKey.ClusterKey.Name)
-		fields = append(fields, cluster)
-	}
-
-	loc := util.DNSSanitize(appInst.Key.ClusterInstKey.CloudletKey.Name)
-	fields = append(fields, loc)
-
-	oper := util.DNSSanitize(appInst.Key.ClusterInstKey.CloudletKey.Organization)
-	fields = append(fields, oper)
-
-	if salt != "" {
-		salt = util.DNSSanitize(salt)
-		fields = append(fields, salt)
-	}
-	return strings.Join(fields, "-")
-}
-
 // FqdnPrefix is used only for IP-per-service platforms that allocate
 // an IP for each kubernetes service. Because it adds an extra level of
 // DNS label hierarchy and cannot match the wildcard cert, we do not

--- a/controller/appinst_api.go
+++ b/controller/appinst_api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/gogo/protobuf/types"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
+	pfutils "github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/utils"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/cloudcommon/node"
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
@@ -1004,7 +1005,10 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			if ii != 0 {
 				salt = strconv.Itoa(ii)
 			}
-			id := cloudcommon.GetAppInstId(in, &app, salt)
+			id, err := pfutils.GetAppInstId(ctx, in, &app, salt, cloudletPlatformType)
+			if err != nil {
+				return err
+			}
 			if s.idStore.STMHas(stm, id) {
 				continue
 			}

--- a/controller/appinst_api_test.go
+++ b/controller/appinst_api_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
+	pfutils "github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/utils"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -1245,6 +1247,11 @@ func testKVStoreHasKey(kvstore objstore.KVStore, keystr string) bool {
 }
 
 func TestAppInstIdDelimiter(t *testing.T) {
+	log.SetDebugLevel(log.DebugLevelApi)
+
+	log.InitTracer(nil)
+	defer log.FinishTracer()
+	ctx := log.StartTestSpan(context.Background())
 	// The generated AppInstId must not have any '.'
 	// in it. That will allow any platform-specific code
 	// to append further strings to it, delimited by '.',
@@ -1253,7 +1260,7 @@ func TestAppInstIdDelimiter(t *testing.T) {
 		// need the app definition as well
 		for _, app := range testutil.AppData {
 			if app.Key.Matches(&ai.Key.AppKey) {
-				id := cloudcommon.GetAppInstId(&ai, &app, "")
+				id, _ := pfutils.GetAppInstId(ctx, &ai, &app, "", edgeproto.PlatformType_PLATFORM_TYPE_FAKE)
 				require.NotContains(t, id, ".", "id must not contain '.'")
 			}
 		}
@@ -1268,8 +1275,38 @@ func TestAppInstIdDelimiter(t *testing.T) {
 	appInst.Key.ClusterInstKey.Organization += "."
 	appInst.Key.ClusterInstKey.CloudletKey.Name += "."
 	appInst.Key.ClusterInstKey.CloudletKey.Organization += "."
-	id := cloudcommon.GetAppInstId(&appInst, &app, ".")
+	id, _ := pfutils.GetAppInstId(ctx, &appInst, &app, ".", edgeproto.PlatformType_PLATFORM_TYPE_FAKE)
 	require.NotContains(t, id, ".", "id must not contain '.'")
+
+	// test name sanitization
+	startWithNumReg := regexp.MustCompile("^\\d")
+	appOrgStartWithNumber := edgeproto.App{
+		Key: edgeproto.AppKey{
+			Name:         "testapp",
+			Organization: "5GTestOrg",
+			Version:      "1.0",
+		},
+	}
+	appInstOrgStartWithNumber := edgeproto.AppInst{
+		Key: edgeproto.AppInstKey{
+			AppKey: appOrgStartWithNumber.Key,
+			ClusterInstKey: edgeproto.VirtualClusterInstKey{
+				ClusterKey: edgeproto.ClusterKey{
+					Name: "cluster1",
+				},
+				CloudletKey: edgeproto.CloudletKey{
+					Organization: "TDG",
+					Name:         "CloudletA",
+				},
+				Organization: appOrgStartWithNumber.Key.Organization,
+			},
+		},
+	}
+
+	id, _ = pfutils.GetAppInstId(ctx, &appInstOrgStartWithNumber, &appOrgStartWithNumber, ".", edgeproto.PlatformType_PLATFORM_TYPE_FAKE)
+	require.Regexp(t, startWithNumReg, id, "fake id not sanitized")
+	id, _ = pfutils.GetAppInstId(ctx, &appInstOrgStartWithNumber, &appOrgStartWithNumber, ".", edgeproto.PlatformType_PLATFORM_TYPE_OPENSTACK)
+	require.NotRegexp(t, startWithNumReg, id, "openstack id must not start with number")
 }
 
 func waitForAppInstState(t *testing.T, ctx context.Context, apis *AllApis, key *edgeproto.AppInstKey, ii int, state edgeproto.TrackedState) {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6351 long term fix for heat stack with leading number

### Description

Per review comment on github.com/mobiledgex/edge-cloud-infra/pull/2083, adding new NameSanitize platform function to do appinst unique id sanitization at the controller. GetAppInstId had to be relocated for dependency reasons