### PR TITLE
EDGECLOUD-5839  Vault GetKV: Expose warning as error instead

### DIFF
--- a/vault/kv.go
+++ b/vault/kv.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"
@@ -48,7 +49,11 @@ func GetKV(client *api.Client, path string, version int) (map[string]interface{}
 		return nil, fmt.Errorf("no secrets at path %s", path)
 	}
 	if secret.Data == nil {
-		return nil, fmt.Errorf("no valid secrets at path %s", path)
+		if len(secret.Warnings) > 0 {
+			errStr := strings.Join(secret.Warnings, ";")
+			return nil, fmt.Errorf("No data: %s", errStr)
+		}
+		return nil, fmt.Errorf("No data at path %s", path)
 	}
 	return secret.Data, nil
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5839  Vault GetKV: Expose warning as error instead

### Description

Add a check that the data in the secret is not null. This could be the case that the read/write were done using a mismatched api versions.