### PR TITLE
EDGECLOUD-5617: CreateCloudlet fails while writing crm access key for VMPool

### DIFF
--- a/cloud-resource-manager/dockermgmt/dockerapp.go
+++ b/cloud-resource-manager/dockermgmt/dockerapp.go
@@ -118,7 +118,7 @@ func handleDockerZipfile(ctx context.Context, authApi cloudcommon.RegistryAuthAp
 		dockerComposeCommand = "up -d"
 
 		// create a directory for the app and its files
-		err := pc.CreateDir(ctx, client, dir, pc.Overwrite)
+		err := pc.CreateDir(ctx, client, dir, pc.Overwrite, pc.NoSudo)
 		if err != nil {
 			return err
 		}

--- a/cloud-resource-manager/k8smgmt/appinst.go
+++ b/cloud-resource-manager/k8smgmt/appinst.go
@@ -350,7 +350,7 @@ func createOrUpdateAppInst(ctx context.Context, authApi cloudcommon.RegistryAuth
 		return fmt.Errorf("error merging environment variables config file: %s", err)
 	}
 	configDir, configName := getConfigDirName(names)
-	err = pc.CreateDir(ctx, client, configDir, pc.NoOverwrite)
+	err = pc.CreateDir(ctx, client, configDir, pc.NoOverwrite, pc.NoSudo)
 	if err != nil {
 		return err
 	}

--- a/cloud-resource-manager/k8smgmt/upgrade.go
+++ b/cloud-resource-manager/k8smgmt/upgrade.go
@@ -93,7 +93,7 @@ func upgradeVersionSingleClusterConfigDir(ctx context.Context, caches *platform.
 		// make new config dir if necessary (may already have been created
 		// if multiple AppInsts in ClusterInst)
 		configDir, configName := getConfigDirName(names)
-		err = pc.CreateDir(ctx, client, configDir, pc.NoOverwrite)
+		err = pc.CreateDir(ctx, client, configDir, pc.NoOverwrite, pc.NoSudo)
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelInfra, "upgrade version single cluster config dir, create dir failed", "AppInst", appInst.Key, "err", err)
 			continue


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5617: CreateCloudlet fails while writing crm access key for VMPool

### Description
* For VMPool, we need sudo permissions to create /root/accesskeys directory
* Refer PR: https://github.com/mobiledgex/edge-cloud-infra/pull/2094