### PR TITLE
EDGECLOUD-6356 Cannot update app with qossessionprofile=NoPriority

### DIFF
--- a/controller/app_api.go
+++ b/controller/app_api.go
@@ -619,7 +619,8 @@ func (s *AppApi) UpdateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.R
 		}
 		// If NO_PRIORITY, set to duration to 0.
 		if in.QosSessionProfile == edgeproto.QosSessionProfile_QOS_NO_PRIORITY {
-			in.QosSessionDuration = 0
+			log.DebugLog(log.DebugLevelApi, "Automatically setting QosSessionDuration to 0")
+			cur.QosSessionDuration = 0
 		}
 
 		cur.CopyInFields(in)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6356 Cannot update app with qossessionprofile=NoPriority

### Description
Move the check for a duration without a profile to before the fields get copied in the case of updating an existing app.
